### PR TITLE
Fix broken links to samples in the side navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -93,23 +93,23 @@ versions:
   - title: "Samples" 
     children:
       - title: "ScalarDB Samples" 
-        url: /docs/3.9/scalardb-samples
+        url: /docs/3.9/scalardb-samples/README
       # - title: "ScalarDB Samples"
-      #   url: /docs/3.9/scalardb-samples/scalardb-sample
+      #   url: /docs/3.9/scalardb-samples/scalardb-sample/README
       # - title: "ScalarDB Server Sample"
-      #   url: /docs/3.9/scalardb-samples/scalardb-server-sample
+      #   url: /docs/3.9/scalardb-samples/scalardb-server-sample/README
       # - title: "Microservice Transaction Sample"
-      #   url: /docs/3.9/scalardb-samples/microservice-transaction-sample
+      #   url: /docs/3.9/scalardb-samples/microservice-transaction-sample/README
       # - title: "Multi-Storage Transaction Sample"
-      #   url: /docs/3.9/scalardb-samples/multi-storage-transaction-sample
+      #   url: /docs/3.9/scalardb-samples/multi-storage-transaction-sample/README
       # - title: "ScalarDB GraphQL Sample"
-      #   url: /docs/3.9/scalardb-samples/scalardb-graphql-sample
+      #   url: /docs/3.9/scalardb-samples/scalardb-graphql-sample/README
       - title: "Spring Data Multi-Storage Transaction Sample"
-        url: /docs/3.9/scalardb-samples/spring-data-multi-storage-transaction-sample
+        url: /docs/3.9/scalardb-samples/spring-data-multi-storage-transaction-sample/README
       - title: "Spring Data Sample"
-        url: /docs/3.9/scalardb-samples/spring-data-sample
+        url: /docs/3.9/scalardb-samples/spring-data-sample/README
       - title: "ScalarDB Deployment Sample on Kubernetes (Multi-Storage Transactions)"
-        url: /docs/3.9/helm-charts/samples/scalardb/scalardb-multi-storage-sample
+        url: /docs/3.9/helm-charts/samples/scalardb/scalardb-multi-storage-sample/README
   # Develop docs
   - title: "Develop"
     children:
@@ -232,23 +232,23 @@ versions:
   - title: "Samples" 
     children:
       - title: "ScalarDB Samples" 
-        url: /docs/3.8/scalardb-samples
+        url: /docs/3.8/scalardb-samples/README
       # - title: "ScalarDB Samples"
-      #   url: /docs/3.8/scalardb-samples/scalardb-sample
+      #   url: /docs/3.8/scalardb-samples/scalardb-sample/README
       # - title: "ScalarDB Server Sample"
-      #   url: /docs/3.8/scalardb-samples/scalardb-server-sample
+      #   url: /docs/3.8/scalardb-samples/scalardb-server-sample/README
       # - title: "Microservice Transaction Sample"
-      #   url: /docs/3.8/scalardb-samples/microservice-transaction-sample
+      #   url: /docs/3.8/scalardb-samples/microservice-transaction-sample/README
       # - title: "Multi-Storage Transaction Sample"
-      #   url: /docs/3.8/scalardb-samples/multi-storage-transaction-sample
+      #   url: /docs/3.8/scalardb-samples/multi-storage-transaction-sample/README
       # - title: "ScalarDB GraphQL Sample"
-      #   url: /docs/3.8/scalardb-samples/scalardb-graphql-sample
+      #   url: /docs/3.8/scalardb-samples/scalardb-graphql-sample/README
       - title: "Spring Data Multi-Storage Transaction Sample"
-        url: /docs/3.8/scalardb-samples/spring-data-multi-storage-transaction-sample
+        url: /docs/3.8/scalardb-samples/spring-data-multi-storage-transaction-sample/README
       - title: "Spring Data Sample"
-        url: /docs/3.8/scalardb-samples/spring-data-sample
+        url: /docs/3.8/scalardb-samples/spring-data-sample/README
       - title: "ScalarDB Deployment Sample on Kubernetes (Multi-Storage Transactions)"
-        url: /docs/3.8/helm-charts/samples/scalardb/scalardb-multi-storage-sample
+        url: /docs/3.8/helm-charts/samples/scalardb/scalardb-multi-storage-sample/README
   # Develop docs
   - title: "Develop"
     children:
@@ -371,23 +371,23 @@ versions:
   - title: "Samples" 
     children:
       - title: "ScalarDB Samples" 
-        url: /docs/3.7/scalardb-samples
+        url: /docs/3.7/scalardb-samples/README
       # - title: "ScalarDB Samples"
-      #   url: /docs/3.7/scalardb-samples/scalardb-sample
+      #   url: /docs/3.7/scalardb-samples/scalardb-sample/README
       # - title: "ScalarDB Server Sample"
-      #   url: /docs/3.7/scalardb-samples/scalardb-server-sample
+      #   url: /docs/3.7/scalardb-samples/scalardb-server-sample/README
       # - title: "Microservice Transaction Sample"
-      #   url: /docs/3.7/scalardb-samples/microservice-transaction-sample
+      #   url: /docs/3.7/scalardb-samples/microservice-transaction-sample/README
       # - title: "Multi-Storage Transaction Sample"
-      #   url: /docs/3.7/scalardb-samples/multi-storage-transaction-sample
+      #   url: /docs/3.7/scalardb-samples/multi-storage-transaction-sample/README
       # - title: "ScalarDB GraphQL Sample"
-      #   url: /docs/3.7/scalardb-samples/scalardb-graphql-sample
+      #   url: /docs/3.7/scalardb-samples/scalardb-graphql-sample/README
       - title: "Spring Data Multi-Storage Transaction Sample"
-        url: /docs/3.7/scalardb-samples/spring-data-multi-storage-transaction-sample
+        url: /docs/3.7/scalardb-samples/spring-data-multi-storage-transaction-sample/README
       - title: "Spring Data Sample"
-        url: /docs/3.7/scalardb-samples/spring-data-sample
+        url: /docs/3.7/scalardb-samples/spring-data-sample/README
       - title: "ScalarDB Deployment Sample on Kubernetes (Multi-Storage Transactions)"
-        url: /docs/3.7/helm-charts/samples/scalardb/scalardb-multi-storage-sample
+        url: /docs/3.7/helm-charts/samples/scalardb/scalardb-multi-storage-sample/README
   # Develop docs
   - title: "Develop"
     children:
@@ -506,23 +506,23 @@ versions:
   - title: "Samples" 
     children:
       - title: "ScalarDB Samples" 
-        url: /docs/3.6/scalardb-samples
+        url: /docs/3.6/scalardb-samples/README
       # - title: "ScalarDB Samples"
-      #   url: /docs/3.6/scalardb-samples/scalardb-sample
+      #   url: /docs/3.6/scalardb-samples/scalardb-sample/README
       # - title: "ScalarDB Server Sample"
-      #   url: /docs/3.6/scalardb-samples/scalardb-server-sample
+      #   url: /docs/3.6/scalardb-samples/scalardb-server-sample/README
       # - title: "Microservice Transaction Sample"
-      #   url: /docs/3.6/scalardb-samples/microservice-transaction-sample
+      #   url: /docs/3.6/scalardb-samples/microservice-transaction-sample/README
       # - title: "Multi-Storage Transaction Sample"
-      #   url: /docs/3.6/scalardb-samples/multi-storage-transaction-sample
+      #   url: /docs/3.6/scalardb-samples/multi-storage-transaction-sample/README
       # - title: "ScalarDB GraphQL Sample"
-      #   url: /docs/3.6/scalardb-samples/scalardb-graphql-sample
+      #   url: /docs/3.6/scalardb-samples/scalardb-graphql-sample/README
       - title: "Spring Data Multi-Storage Transaction Sample"
-        url: /docs/3.6/scalardb-samples/spring-data-multi-storage-transaction-sample
+        url: /docs/3.6/scalardb-samples/spring-data-multi-storage-transaction-sample/README
       - title: "Spring Data Sample"
-        url: /docs/3.6/scalardb-samples/spring-data-sample
+        url: /docs/3.6/scalardb-samples/spring-data-sample/README
       - title: "ScalarDB Deployment Sample on Kubernetes (Multi-Storage Transactions)"
-        url: /docs/3.6/helm-charts/samples/scalardb/scalardb-multi-storage-sample
+        url: /docs/3.6/helm-charts/samples/scalardb/scalardb-multi-storage-sample/README
   # Develop docs
   - title: "Develop"
     children:
@@ -635,23 +635,23 @@ versions:
   - title: "Samples" 
     children:
       - title: "ScalarDB Samples" 
-        url: /docs/3.5/scalardb-samples
+        url: /docs/3.5/scalardb-samples/README
       # - title: "ScalarDB Samples"
-      #   url: /docs/3.5/scalardb-samples/scalardb-sample
+      #   url: /docs/3.5/scalardb-samples/scalardb-sample/README
       # - title: "ScalarDB Server Sample"
-      #   url: /docs/3.5/scalardb-samples/scalardb-server-sample
+      #   url: /docs/3.5/scalardb-samples/scalardb-server-sample/README
       # - title: "Microservice Transaction Sample"
-      #   url: /docs/3.5/scalardb-samples/microservice-transaction-sample
+      #   url: /docs/3.5/scalardb-samples/microservice-transaction-sample/README
       # - title: "Multi-Storage Transaction Sample"
-      #   url: /docs/3.5/scalardb-samples/multi-storage-transaction-sample
+      #   url: /docs/3.5/scalardb-samples/multi-storage-transaction-sample/README
       # - title: "ScalarDB GraphQL Sample"
-      #   url: /docs/3.5/scalardb-samples/scalardb-graphql-sample
+      #   url: /docs/3.5/scalardb-samples/scalardb-graphql-sample/README
       - title: "Spring Data Multi-Storage Transaction Sample"
-        url: /docs/3.5/scalardb-samples/spring-data-multi-storage-transaction-sample
+        url: /docs/3.5/scalardb-samples/spring-data-multi-storage-transaction-sample/README
       - title: "Spring Data Sample"
-        url: /docs/3.5/scalardb-samples/spring-data-sample
+        url: /docs/3.5/scalardb-samples/spring-data-sample/README
       - title: "ScalarDB Deployment Sample on Kubernetes (Multi-Storage Transactions)"
-        url: /docs/3.5/helm-charts/samples/scalardb/scalardb-multi-storage-sample
+        url: /docs/3.5/helm-charts/samples/scalardb/scalardb-multi-storage-sample/README
   # Develop docs
   - title: "Develop"
     children:
@@ -746,23 +746,23 @@ versions:
   - title: "Samples" 
     children:
       - title: "ScalarDB Samples" 
-        url: /docs/3.4/scalardb-samples
+        url: /docs/3.4/scalardb-samples/README
       # - title: "ScalarDB Samples"
-      #   url: /docs/3.4/scalardb-samples/scalardb-sample
+      #   url: /docs/3.4/scalardb-samples/scalardb-sample/README
       # - title: "ScalarDB Server Sample"
-      #   url: /docs/3.4/scalardb-samples/scalardb-server-sample
+      #   url: /docs/3.4/scalardb-samples/scalardb-server-sample/README
       # - title: "Microservice Transaction Sample"
-      #   url: /docs/3.4/scalardb-samples/microservice-transaction-sample
+      #   url: /docs/3.4/scalardb-samples/microservice-transaction-sample/README
       # - title: "Multi-Storage Transaction Sample"
-      #   url: /docs/3.4/scalardb-samples/multi-storage-transaction-sample
+      #   url: /docs/3.4/scalardb-samples/multi-storage-transaction-sample/README
       # - title: "ScalarDB GraphQL Sample"
-      #   url: /docs/3.4/scalardb-samples/scalardb-graphql-sample
+      #   url: /docs/3.4/scalardb-samples/scalardb-graphql-sample/README
       - title: "Spring Data Multi-Storage Transaction Sample"
-        url: /docs/3.4/scalardb-samples/spring-data-multi-storage-transaction-sample
+        url: /docs/3.4/scalardb-samples/spring-data-multi-storage-transaction-sample/README
       - title: "Spring Data Sample"
-        url: /docs/3.4/scalardb-samples/spring-data-sample
+        url: /docs/3.4/scalardb-samples/spring-data-sample/README
       - title: "ScalarDB Deployment Sample on Kubernetes (Multi-Storage Transactions)"
-        url: /docs/3.4/helm-charts/samples/scalardb/scalardb-multi-storage-sample
+        url: /docs/3.4/helm-charts/samples/scalardb/scalardb-multi-storage-sample/README
   # Develop docs
   - title: "Develop"
     children:

--- a/docs/3.4/scalardb-samples/README.md
+++ b/docs/3.4/scalardb-samples/README.md
@@ -1,8 +1,8 @@
 # ScalarDB Samples
-This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):
+This document lists sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):
 
-- [ScalarDB Sample](scalardb-sample/)
-- [ScalarDB Server Sample](scalardb-server-sample/)
-- [Multi-storage Transaction Sample](multi-storage-transaction-sample/)
-- [Microservice Transaction Sample](microservice-transaction-sample/)
-- [ScalarDB GraphQL Sample](scalardb-graphql-sample/)
+- [ScalarDB Sample](scalardb-sample/README.md)
+- [ScalarDB Server Sample](scalardb-server-sample/README.md)
+- [Multi-storage Transaction Sample](multi-storage-transaction-sample/README.md)
+- [Microservice Transaction Sample](microservice-transaction-sample/README.md)
+- [ScalarDB GraphQL Sample](scalardb-graphql-sample/README.md)

--- a/docs/3.5/scalardb-samples/README.md
+++ b/docs/3.5/scalardb-samples/README.md
@@ -1,8 +1,8 @@
 # ScalarDB Samples
-This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):
+This document lists sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):
 
-- [ScalarDB Sample](scalardb-sample/)
-- [ScalarDB Server Sample](scalardb-server-sample/)
-- [Multi-storage Transaction Sample](multi-storage-transaction-sample/)
-- [Microservice Transaction Sample](microservice-transaction-sample/)
-- [ScalarDB GraphQL Sample](scalardb-graphql-sample/)
+- [ScalarDB Sample](scalardb-sample/README.md)
+- [ScalarDB Server Sample](scalardb-server-sample/README.md)
+- [Multi-storage Transaction Sample](multi-storage-transaction-sample/README.md)
+- [Microservice Transaction Sample](microservice-transaction-sample/README.md)
+- [ScalarDB GraphQL Sample](scalardb-graphql-sample/README.md)

--- a/docs/3.6/scalardb-samples/README.md
+++ b/docs/3.6/scalardb-samples/README.md
@@ -1,8 +1,8 @@
 # ScalarDB Samples
-This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):
+This document lists sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):
 
-- [ScalarDB Sample](scalardb-sample/)
-- [ScalarDB Server Sample](scalardb-server-sample/)
-- [Multi-storage Transaction Sample](multi-storage-transaction-sample/)
-- [Microservice Transaction Sample](microservice-transaction-sample/)
-- [ScalarDB GraphQL Sample](scalardb-graphql-sample/)
+- [ScalarDB Sample](scalardb-sample/README.md)
+- [ScalarDB Server Sample](scalardb-server-sample/README.md)
+- [Multi-storage Transaction Sample](multi-storage-transaction-sample/README.md)
+- [Microservice Transaction Sample](microservice-transaction-sample/README.md)
+- [ScalarDB GraphQL Sample](scalardb-graphql-sample/README.md)

--- a/docs/3.7/scalardb-samples/README.md
+++ b/docs/3.7/scalardb-samples/README.md
@@ -1,8 +1,8 @@
 # ScalarDB Samples
-This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):
+This document lists sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):
 
-- [ScalarDB Sample](scalardb-sample/)
-- [ScalarDB Server Sample](scalardb-server-sample/)
-- [Multi-storage Transaction Sample](multi-storage-transaction-sample/)
-- [Microservice Transaction Sample](microservice-transaction-sample/)
-- [ScalarDB GraphQL Sample](scalardb-graphql-sample/)
+- [ScalarDB Sample](scalardb-sample/README.md)
+- [ScalarDB Server Sample](scalardb-server-sample/README.md)
+- [Multi-storage Transaction Sample](multi-storage-transaction-sample/README.md)
+- [Microservice Transaction Sample](microservice-transaction-sample/README.md)
+- [ScalarDB GraphQL Sample](scalardb-graphql-sample/README.md)

--- a/docs/3.8/scalardb-samples/README.md
+++ b/docs/3.8/scalardb-samples/README.md
@@ -1,8 +1,8 @@
 # ScalarDB Samples
-This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):
+This document lists sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):
 
-- [ScalarDB Sample](scalardb-sample/)
-- [ScalarDB Server Sample](scalardb-server-sample/)
-- [Multi-storage Transaction Sample](multi-storage-transaction-sample/)
-- [Microservice Transaction Sample](microservice-transaction-sample/)
-- [ScalarDB GraphQL Sample](scalardb-graphql-sample/)
+- [ScalarDB Sample](scalardb-sample/README.md)
+- [ScalarDB Server Sample](scalardb-server-sample/README.md)
+- [Multi-storage Transaction Sample](multi-storage-transaction-sample/README.md)
+- [Microservice Transaction Sample](microservice-transaction-sample/README.md)
+- [ScalarDB GraphQL Sample](scalardb-graphql-sample/README.md)

--- a/docs/3.9/scalardb-samples/README.md
+++ b/docs/3.9/scalardb-samples/README.md
@@ -1,8 +1,8 @@
 # ScalarDB Samples
-This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):
+This document lists sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):
 
-- [ScalarDB Sample](scalardb-sample/)
-- [ScalarDB Server Sample](scalardb-server-sample/)
-- [Multi-storage Transaction Sample](multi-storage-transaction-sample/)
-- [Microservice Transaction Sample](microservice-transaction-sample/)
-- [ScalarDB GraphQL Sample](scalardb-graphql-sample/)
+- [ScalarDB Sample](scalardb-sample/README.md)
+- [ScalarDB Server Sample](scalardb-server-sample/README.md)
+- [Multi-storage Transaction Sample](multi-storage-transaction-sample/README.md)
+- [Microservice Transaction Sample](microservice-transaction-sample/README.md)
+- [ScalarDB GraphQL Sample](scalardb-graphql-sample/README.md)


### PR DESCRIPTION
## Related issue

**If applicable, please provide a link to the issue related to this change.**

- [ ] **Related issue:** [URL]
- [x] **No related issue**

## Description

**Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.**

This PR fixes broken links for samples. In the side navigation and on the samples landing page, docs with the file name `README.md` are not navigable since they don't include the actual file name in the relative URL.

> **Note**
> 
> For reference on how files named `README.md` affect the docs site, see the following: https://github.com/scalar-labs/docs-scalardb/pull/14.

### Type of change

- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (an improvement to the existing state)
- [ ] This change requires a documentation update

## How has this been tested?

**Please describe the tests that you ran to verify your changes and provide instructions so that we can reproduce. Please also list any relevant details for your test configuration.**

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, and confirmed the docs are navigable from the side navigation and samples landing page.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
