### PR TITLE
Fix broken links in the "Recommended" section on the home page

### DIFF
--- a/_home/home.md
+++ b/_home/home.md
@@ -37,14 +37,14 @@ recommended_row:
     alt: ""
     title: "ScalarDB Samples" # The title for a recommended doc will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
     excerpt: "Try running sample applications for ScalarDB" # Add a brief description about the doc (approximately 8 words)
-    url: "docs/3.9/scalardb-samples" # Add a relative URL to the product home page doc that is within this parent product docs site
+    url: "docs/3.9/scalardb-samples/README" # Add a relative URL to the product home page doc that is within this parent product docs site
     btn_class: "btn--primary"
     btn_label: "Learn more" # This can be any other type of call to action
   - image_path: assets/images/page-blue.svg # Choose the appropriate icon for the doc recommended here: (`book-green.svg`, `cloud-purple.svg`, `page-blue.svg`)
     alt: ""
     title: "ScalarDB Benchmarks" # The title for a recommended doc will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
     excerpt: "Run benchmark programs for ScalarDB" # Add a brief description about the doc (approximately 8 words)
-    url: "docs/3.9/scalardb-benchmarks" # Add a relative URL to the product home page doc that is within this parent product docs site
+    url: "docs/3.9/scalardb-benchmarks/README" # Add a relative URL to the product home page doc that is within this parent product docs site
     btn_class: "btn--primary"
     btn_label: "Learn more" # This can be any other type of call to action
   


### PR DESCRIPTION
## Related issue

**If applicable, please provide a link to the issue related to this change.**

- [ ] **Related issue:** [URL]
- [x] **No related issue**

## Description

**Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.**

This PR fixes broken links that are in the **Recommended** section of the ScalarDB docs home page. After enabling `permalink: pretty` in `_config.yml`, docs with file names `README.md` needed to be added in the URL. However, these links were not updated.

### Type of change

- [ ] Documentation (new or updated documentation)
- [x] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [x] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

**Please describe the tests that you ran to verify your changes and provide instructions so that we can reproduce. Please also list any relevant details for your test configuration.**

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, selected the links that were broken, and confirmed they directed me to the correct page as expected.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.