### PR TITLE
Remove file names with "scalardl" from search results

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -276,7 +276,7 @@ defaults:
 
   # Hides ScalarDL-related pages (e.g., Helm Charts docs) from search results.
   - scope:
-      path: "docs/**/*scalardl*" # Specifies the folder where docs with `scalardl` in the file name live.
+      path: "docs/**/helm-charts/**/*scalardl*" # Specifies the folder where docs with `scalardl` in the file name live.
       # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
     values:
       layout: page # Specifies the type of template used from the "_layouts" folder.

--- a/_config.yml
+++ b/_config.yml
@@ -274,6 +274,16 @@ defaults:
       toc_sticky: true
       search: false # Excludes previous versions from search to reduce noise and search loading time. We should improve this function in the future to allow people to search for versioned docs.
 
+  # Hides ScalarDL-related pages (e.g., Helm Charts docs) from search results.
+  - scope:
+      path: "docs/**/*scalardl*" # Specifies the folder where docs with `scalardl` in the file name live.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      hidden: true 
+      search: false
+      sitemap: false
+
   # Remove irrelevant search results
   - scope:
       path: "assets"


### PR DESCRIPTION
## Related issue

**If applicable, please provide a link to the issue related to this change.**

- [ ] **Related issue:** [URL]
- [x] **No related issue**

## Description

**Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.**

This PR removes pages in the `helm-charts` folders that include `scalardl` in the file name from search results. These pages are removed from search to reduce irrelevant results. The pages should still be accessible when clicked on from pages that link to them though so that users are not shown a 404 error. 

### Type of change

- [ ] Documentation (new or updated documentation)
- [x] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

**Please describe the tests that you ran to verify your changes and provide instructions so that we can reproduce. Please also list any relevant details for your test configuration.**

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, searched for "ScalarDL", and confirmed that pages that included `scalardl` in the file name no longer appeared in search results. 
- [x] Confirmed that pages that include links to pages with `scalardl` in the file name were still accessible.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
