### PR TITLE
Disable configuration to remove file names with "scalardl" from search results

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -275,14 +275,14 @@ defaults:
       search: false # Excludes previous versions from search to reduce noise and search loading time. We should improve this function in the future to allow people to search for versioned docs.
 
   # Hides ScalarDL-related pages (e.g., Helm Charts docs) from search results.
-  - scope:
-      path: "docs/**/helm-charts/**/*scalardl*" # Specifies the folder where docs with `scalardl` in the file name live.
-      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
-    values:
-      layout: page # Specifies the type of template used from the "_layouts" folder.
-      hidden: true 
-      search: false
-      sitemap: false
+  # - scope:
+  #     path: "docs/**/helm-charts/**/*scalardl*" # Specifies the folder where docs with `scalardl` in the file name live.
+  #     # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+  #   values:
+  #     layout: page # Specifies the type of template used from the "_layouts" folder.
+  #     hidden: true 
+  #     search: false
+  #     sitemap: false
 
   # Remove irrelevant search results
   - scope:

--- a/_config.yml
+++ b/_config.yml
@@ -275,6 +275,7 @@ defaults:
       search: false # Excludes previous versions from search to reduce noise and search loading time. We should improve this function in the future to allow people to search for versioned docs.
 
   # Hides ScalarDL-related pages (e.g., Helm Charts docs) from search results.
+  # NOTE: The following method causes a lengthy build time, which occasionally causes the build to remain "In progress" indefinitely. Because of that, it is currently commented out until we find an alternative way to hide specific pages from search results.
   # - scope:
   #     path: "docs/**/helm-charts/**/*scalardl*" # Specifies the folder where docs with `scalardl` in the file name live.
   #     # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.


### PR DESCRIPTION
## Description

**Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.**

This PR removed the configuration for hiding files with `scalardl` in the file name within `helm-charts` folders from search results. 

People can now see docs with `scalardl` in the file name within the `helm-charts` folders discoverable in search. Although this is an undesirable result, making sure this docs site builds properly without issues is more important.

 ### Related issue or PR

**If applicable, please provide a link to the issue or PR related to this change.**

- [x] **Related issue or PR:** https://github.com/scalar-labs/docs-scalardb/pull/31
- [ ] **No related issue or PR**

### Type of change

- [ ] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [x] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

**Please describe the tests that you ran to verify your changes and provide instructions so that we can reproduce. Please also list any relevant details for your test configuration.**

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Confirmed that the build time did not lag for too long (took approximately 1 minute to build and deploy).

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
