### PR TITLE
Add a "Configurations" page as an index in the "Develop" section of the sidebar navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -107,24 +107,14 @@ versions:
         url: /docs/latest/scalardb-sql/add-scalardb-sql-to-your-build/
       - title: "Developer Guides for ScalarDB"
         url: /docs/latest/guides/
-      - title: "ScalarDB Configurations"
-        url: /docs/latest/configurations/
-      - title: "ScalarDB SQL Configurations"
-        url: /docs/latest/scalardb-sql/configurations/
-      - title: "Configurations for Consensus Commit"
-        url: /docs/latest/configurations-for-consensus-commit/
+      - title: "Configuration Guides for ScalarDB"
+        url: /docs/latest/development-configurations/
       - title: "ScalarDB Schema Loader"
         url: /docs/latest/schema-loader/
       # - title: "Export Function for ScalarDB Data Loader" # May be added in the near future.
       #   url: /docs/latest/scalardb-data-loader/getting-started-export/
       # - title: "Import Function for ScalarDB Data Loader" # May be added in the near future.
       #   url: /docs/latest/scalardb-data-loader/getting-started-import/
-      - title: "Multi-storage Transactions"
-        url: /docs/latest/multi-storage-transactions/
-      - title: "Two-Phase Commit Transactions"
-        url: /docs/latest/two-phase-commit-transactions/
-      - title: "ScalarDB Cluster Configurations"
-        url: /docs/latest/scalardb-cluster/scalardb-cluster-configurations/
       - title: "How to Run ScalarDB GraphQL Server"
         url: /docs/latest/scalardb-graphql/how-to-run-server/
       - title: "How to Run Two-Phase Commit Transaction"
@@ -136,8 +126,6 @@ versions:
     children:
       - title: "Getting Started with Scalar Helm Charts"
         url: /docs/latest/helm-charts/getting-started-scalar-helm-charts/
-      - title: "ScalarDB Cluster"
-        url: /docs/latest/scalardb-cluster/
       - title: "Set Up ScalarDB Cluster on Kubernetes by Using a Helm Chart"
         url: /docs/latest/scalardb-cluster/setup-scalardb-cluster-on-kubernetes-by-using-helm-chart/
       - title: "Configure a custom values file for Scalar Helm Charts"
@@ -177,6 +165,8 @@ versions:
         url: /docs/latest/storage-abstraction/
       - title: "ScalarDB Benchmarks"
         url: /docs/latest/scalardb-benchmarks/README/
+      - title: "ScalarDB Cluster"
+        url: /docs/latest/scalardb-cluster/
       - title: "ScalarDB SQL Grammar"
         url: /docs/latest/scalardb-sql/grammar/
 
@@ -232,20 +222,14 @@ versions:
         url: /docs/3.8/add-scalardb-to-your-build/
       - title: "Developer Guides for ScalarDB"
         url: /docs/3.8/guides/
-      - title: "ScalarDB SQL Configurations"
-        url: /docs/3.8/scalardb-sql/configurations/
-      - title: "Configurations for Consensus Commit"
-        url: /docs/3.8/configurations-for-consensus-commit/
+      - title: "Configuration Guides for ScalarDB"
+        url: /docs/3.8/development-configurations/
       - title: "ScalarDB Schema Loader"
         url: /docs/3.8/schema-loader/
       - title: "Export Function for ScalarDB Data Loader"
         url: /docs/3.8/scalardb-data-loader/getting-started-export/
       - title: "Import Function for ScalarDB Data Loader"
         url: /docs/3.8/scalardb-data-loader/getting-started-import/
-      - title: "Multi-storage Transactions"
-        url: /docs/3.8/multi-storage-transactions/
-      - title: "Two-Phase Commit Transactions"
-        url: /docs/3.8/two-phase-commit-transactions/
       - title: "How to Run Two-Phase Commit Transaction"
         url: /docs/3.8/scalardb-graphql/how-to-run-two-phase-commit-transaction/
       - title: "How to Run ScalarDB GraphQL Server"
@@ -271,8 +255,6 @@ versions:
         url: /docs/3.8/helm-charts/mount-files-or-volumes-on-scalar-pods/
       - title: "How to use Secret resources to pass the credentials as the environment variables into the properties file"
         url: /docs/3.8/helm-charts/use-secret-for-credentials/
-      - title: "ScalarDB Cluster"
-        url: /docs/3.8/scalardb-cluster
       - title: "ScalarDB GraphQL Deployment Guide on AWS"
         url: /docs/3.8/scalardb-graphql/aws-deployment-guide/
       - title: "ScalarDB SQL Server"
@@ -300,6 +282,8 @@ versions:
         url: /docs/3.8/storage-abstraction/
       - title: "ScalarDB Benchmarks"
         url: /docs/3.8/scalardb-benchmarks/README/
+      - title: "ScalarDB Cluster"
+        url: /docs/3.8/scalardb-cluster
       - title: "ScalarDB SQL Grammar"
         url: /docs/3.8/scalardb-sql/grammar/
 
@@ -355,18 +339,12 @@ versions:
         url: /docs/3.7/add-scalardb-to-your-build/
       - title: "Developer Guides for ScalarDB"
         url: /docs/3.7/guides/
-      - title: "ScalarDB SQL Configurations"
-        url: /docs/3.7/scalardb-sql/configurations/
-      - title: "Configurations for Consensus Commit"
-        url: /docs/3.7/configurations-for-consensus-commit/
+      - title: "Configuration Guides for ScalarDB"
+        url: /docs/3.7/development-configurations/
       - title: "Export Function for ScalarDB Data Loader"
         url: /docs/3.7/scalardb-data-loader/getting-started-export/
       - title: "Import Function for ScalarDB Data Loader"
         url: /docs/3.7/scalardb-data-loader/getting-started-import/
-      - title: "Multi-storage Transactions"
-        url: /docs/3.7/multi-storage-transactions/
-      - title: "Two-Phase Commit Transactions"
-        url: /docs/3.7/two-phase-commit-transactions/
       - title: "How to Run Two-Phase Commit Transaction"
         url: /docs/3.7/scalardb-graphql/how-to-run-two-phase-commit-transaction/
       - title: "How to Run ScalarDB GraphQL Server"
@@ -392,8 +370,6 @@ versions:
         url: /docs/3.7/helm-charts/mount-files-or-volumes-on-scalar-pods/
       - title: "How to use Secret resources to pass the credentials as the environment variables into the properties file"
         url: /docs/3.7/helm-charts/use-secret-for-credentials/
-      - title: "ScalarDB Cluster"
-        url: /docs/3.7/scalardb-cluster/
       - title: "ScalarDB GraphQL Deployment Guide on AWS"
         url: /docs/3.7/scalardb-graphql/aws-deployment-guide/
       - title: "ScalarDB SQL Server"
@@ -421,6 +397,8 @@ versions:
         url: /docs/3.7/storage-abstraction/
       - title: "ScalarDB Benchmarks"
         url: /docs/3.7/scalardb-benchmarks/README/
+      - title: "ScalarDB Cluster"
+        url: /docs/3.7/scalardb-cluster/
       - title: "ScalarDB SQL Grammar"
         url: /docs/3.7/scalardb-sql/grammar/
 
@@ -476,18 +454,12 @@ versions:
         url: /docs/3.6/add-scalardb-to-your-build/
       - title: "Developer Guides for ScalarDB"
         url: /docs/3.6/guides/
-      - title: "ScalarDB SQL Configurations"
-        url: /docs/3.6/scalardb-sql/configurations/
-      - title: "Configurations for Consensus Commit"
-        url: /docs/3.6/configurations-for-consensus-commit/
+      - title: "Configuration Guides for ScalarDB"
+        url: /docs/3.6/development-configurations/
       - title: "Export Function for ScalarDB Data Loader"
         url: /docs/3.6/scalardb-data-loader/getting-started-export/
       - title: "Import Function for ScalarDB Data Loader"
         url: /docs/3.6/scalardb-data-loader/getting-started-import/
-      - title: "Multi-storage Transactions"
-        url: /docs/3.6/multi-storage-transactions/
-      - title: "Two-Phase Commit Transactions"
-        url: /docs/3.6/two-phase-commit-transactions/
       - title: "How to Run Two-Phase Commit Transaction"
         url: /docs/3.6/scalardb-graphql/how-to-run-two-phase-commit-transaction/
       - title: "How to Run ScalarDB GraphQL Server"
@@ -513,8 +485,6 @@ versions:
         url: /docs/3.6/helm-charts/mount-files-or-volumes-on-scalar-pods/
       - title: "How to use Secret resources to pass the credentials as the environment variables into the properties file"
         url: /docs/3.6/helm-charts/use-secret-for-credentials/
-      - title: "ScalarDB Cluster"
-        url: /docs/3.6/scalardb-cluster/
       - title: "ScalarDB GraphQL Deployment Guide on AWS"
         url: /docs/3.6/scalardb-graphql/aws-deployment-guide/
       - title: "ScalarDB SQL Server"
@@ -542,6 +512,8 @@ versions:
         url: /docs/3.6/storage-abstraction/
       - title: "ScalarDB Benchmarks"
         url: /docs/3.6/scalardb-benchmarks/README/
+      - title: "ScalarDB Cluster"
+        url: /docs/3.6/scalardb-cluster/
       - title: "ScalarDB SQL Grammar"
         url: /docs/3.6/scalardb-sql/grammar/
 
@@ -591,6 +563,8 @@ versions:
     children:
       - title: "Add ScalarDB to your build"
         url: /docs/3.5/add-scalardb-to-your-build/
+      - title: "Configuration Guides for ScalarDB"
+        url: /docs/3.5/development-configurations/
       - title: "Export Function for ScalarDB Data Loader"
         url: /docs/3.5/scalardb-data-loader/getting-started-export/
       - title: "Import Function for ScalarDB Data Loader"
@@ -622,8 +596,6 @@ versions:
         url: /docs/3.5/helm-charts/mount-files-or-volumes-on-scalar-pods/
       - title: "How to use Secret resources to pass the credentials as the environment variables into the properties file"
         url: /docs/3.5/helm-charts/use-secret-for-credentials/
-      - title: "ScalarDB Cluster"
-        url: /docs/3.5/scalardb-cluster/
       - title: "ScalarDB GraphQL Deployment Guide on AWS"
         url: /docs/3.5/scalardb-graphql/aws-deployment-guide/
   # Manage docs
@@ -647,6 +619,8 @@ versions:
         url: /docs/3.5/requirements/
       - title: "ScalarDB Benchmarks"
         url: /docs/3.5/scalardb-benchmarks/README/
+      - title: "ScalarDB Cluster"
+        url: /docs/3.5/scalardb-cluster/
 
 "3.4":
   - title: "⬅ ScalarDB docs home" 
@@ -690,14 +664,12 @@ versions:
     children:
       - title: "Add ScalarDB to your build"
         url: /docs/3.4/add-scalardb-to-your-build/
+      - title: "Configuration Guides for ScalarDB"
+        url: /docs/3.4/development-configurations/
       - title: "Export Function for ScalarDB Data Loader"
         url: /docs/3.4/scalardb-data-loader/getting-started-export/
       - title: "Import Function for ScalarDB Data Loader"
         url: /docs/3.4/scalardb-data-loader/getting-started-import/
-      - title: "Multi-storage Transactions"
-        url: /docs/3.4/multi-storage-transactions/
-      - title: "Two-Phase Commit Transactions"
-        url: /docs/3.4/two-phase-commit-transactions/
   # Deploy docs
   - title: "Deploy"
     children:
@@ -717,8 +689,6 @@ versions:
         url: /docs/3.4/helm-charts/mount-files-or-volumes-on-scalar-pods/
       - title: "How to use Secret resources to pass the credentials as the environment variables into the properties file"
         url: /docs/3.4/helm-charts/use-secret-for-credentials/
-      - title: "ScalarDB Cluster"
-        url: /docs/3.4/scalardb-cluster/
   # Manage docs
   - title: "Manage"
     children:
@@ -740,3 +710,5 @@ versions:
         url: /docs/3.4/requirements/
       - title: "ScalarDB Benchmarks"
         url: /docs/3.4/scalardb-benchmarks/README/
+      - title: "ScalarDB Cluster"
+        url: /docs/3.4/scalardb-cluster/

--- a/docs/3.4/development-configurations.md
+++ b/docs/3.4/development-configurations.md
@@ -1,0 +1,6 @@
+# Configuration Guides for ScalarDB
+
+The following is a list of configuration guides for ScalarDB:
+
+- [Configure Multi-Storage Transactions](multi-storage-transactions.md)
+- [Configure Two-Phase Commit Transactions](two-phase-commit-transactions.md)

--- a/docs/3.5/development-configurations.md
+++ b/docs/3.5/development-configurations.md
@@ -1,0 +1,6 @@
+# Configuration Guides for ScalarDB
+
+The following is a list of configuration guides for ScalarDB:
+
+- [Configure Multi-Storage Transactions](multi-storage-transactions.md)
+- [Configure Two-Phase Commit Transactions](two-phase-commit-transactions.md)

--- a/docs/3.6/development-configurations.md
+++ b/docs/3.6/development-configurations.md
@@ -1,0 +1,8 @@
+# Configuration Guides for ScalarDB
+
+The following is a list of configuration guides for ScalarDB:
+
+- [Configure ScalarDB SQL](scalardb-sql/configurations.md)
+- [Configure Consensus Commit](configurations-for-consensus-commit.md)
+- [Configure Multi-Storage Transactions](multi-storage-transactions.md)
+- [Configure Two-Phase Commit Transactions](two-phase-commit-transactions.md)

--- a/docs/3.7/development-configurations.md
+++ b/docs/3.7/development-configurations.md
@@ -1,0 +1,8 @@
+# Configuration Guides for ScalarDB
+
+The following is a list of configuration guides for ScalarDB:
+
+- [Configure ScalarDB SQL](scalardb-sql/configurations.md)
+- [Configure Consensus Commit](configurations-for-consensus-commit.md)
+- [Configure Multi-Storage Transactions](multi-storage-transactions.md)
+- [Configure Two-Phase Commit Transactions](two-phase-commit-transactions.md)

--- a/docs/3.8/development-configurations.md
+++ b/docs/3.8/development-configurations.md
@@ -1,0 +1,8 @@
+# Configuration Guides for ScalarDB
+
+The following is a list of configuration guides for ScalarDB:
+
+- [Configure ScalarDB SQL](scalardb-sql/configurations.md)
+- [Configure Consensus Commit](configurations-for-consensus-commit.md)
+- [Configure Multi-Storage Transactions](multi-storage-transactions.md)
+- [Configure Two-Phase Commit Transactions](two-phase-commit-transactions.md)

--- a/docs/3.9/development-configurations.md
+++ b/docs/3.9/development-configurations.md
@@ -1,0 +1,10 @@
+# Configuration Guides for ScalarDB
+
+The following is a list of configuration guides for ScalarDB:
+
+- [Configure ScalarDB](configurations.md)
+- [Configure ScalarDB Cluster](scalardb-cluster/scalardb-cluster-configurations.md)
+- [Configure ScalarDB SQL](scalardb-sql/configurations.md)
+- [Configure Consensus Commit](configurations-for-consensus-commit.md)
+- [Configure Multi-Storage Transactions](multi-storage-transactions.md)
+- [Configure Two-Phase Commit Transactions](two-phase-commit-transactions.md)

--- a/docs/latest/development-configurations.md
+++ b/docs/latest/development-configurations.md
@@ -1,0 +1,10 @@
+# Configuration Guides for ScalarDB
+
+The following is a list of configuration guides for ScalarDB:
+
+- [Configure ScalarDB](configurations.md)
+- [Configure ScalarDB Cluster](scalardb-cluster/scalardb-cluster-configurations.md)
+- [Configure ScalarDB SQL](scalardb-sql/configurations.md)
+- [Configure Consensus Commit](configurations-for-consensus-commit.md)
+- [Configure Multi-Storage Transactions](multi-storage-transactions.md)
+- [Configure Two-Phase Commit Transactions](two-phase-commit-transactions.md)


### PR DESCRIPTION
## Description

This PR adds a new "Configuration" page that acts as an index for configuration-related docs that live in the "Develop" section of the side navigation and updates the navigation to add the new page and remove the pages listed in that index.

### Related issue or PR

N/A

### Type of change

- [x] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, checked the side navigation for each version, and checked the new "configuration" pages that contain a list of configuration-related doc types displayed and were navigable as expected.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
