### PR TITLE
Add updated samples docs for ScalarDB Analytics with PostgreSQL 

### DIFF
--- a/docs/3.4/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
+++ b/docs/3.4/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
@@ -7,23 +7,9 @@ This tutorial describes how to create a sample application for ScalarDB Analytic
 - Docker
 - psql
 
-## Clone the ScalarDB samples repository
-
-Open Terminal, then clone the ScalarDB samples repository by running the following command:
-
-```shell
-$ git clone https://github.com/scalar-labs/scalardb-samples
-```
-
-Then, go to the directory with this sample by running the following command:
-
-```shell
-$ cd scalardb-samples/scalardb-analytics-postgresql-sample
-```
-
 ## Set up the database
 
-First, you must set up the database to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have not set up the database yet, please follow the instructions in [Getting Started](https://scalardb.scalar-labs.com/docs/3.9/scalardb-analytics-postgresql/getting-started.md).
+First, you must set up the database to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have not set up the database yet, please follow the instructions in [Getting Started](https://scalardb.scalar-labs.com/docs/latest/scalardb-analytics-postgresql/getting-started).
 
 ## Schema in ScalarDB
 
@@ -161,7 +147,7 @@ Password for user postgres:
  c_comment    | text             |           |          |
 ```
 
-The column definitions are the same as the original table in the ScalarDB database. Type mapping between ScalarDB and PostgreSQL is explained in [Data type mapping between ScalarDB and the other databases](https://scalardb.scalar-labs.com/docs/3.9/schema-loader/#data-type-mapping-between-scalardb-and-the-other-databases). Internally, this view is based on the foreign table explained above and interprets the transaction metadata to expose only the valid data with the Read Committed isolation level.
+The column definitions are the same as the original table in the ScalarDB database. Type mapping between ScalarDB and PostgreSQL is explained in [Data type mapping between ScalarDB and the other databases](https://scalardb.scalar-labs.com/docs/latest/schema-loader/#data-type-mapping-between-scalardb-and-the-other-databases). Internally, this view is based on the foreign table explained above and interprets the transaction metadata to expose only the valid data with the Read Committed isolation level.
 
 Normally, you don't need to access the foreign tables directly. You can equate the views with the tables in the ScalarDB database.
 

--- a/docs/3.5/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
+++ b/docs/3.5/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
@@ -7,23 +7,9 @@ This tutorial describes how to create a sample application for ScalarDB Analytic
 - Docker
 - psql
 
-## Clone the ScalarDB samples repository
-
-Open Terminal, then clone the ScalarDB samples repository by running the following command:
-
-```shell
-$ git clone https://github.com/scalar-labs/scalardb-samples
-```
-
-Then, go to the directory with this sample by running the following command:
-
-```shell
-$ cd scalardb-samples/scalardb-analytics-postgresql-sample
-```
-
 ## Set up the database
 
-First, you must set up the database to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have not set up the database yet, please follow the instructions in [Getting Started](https://scalardb.scalar-labs.com/docs/3.9/scalardb-analytics-postgresql/getting-started.md).
+First, you must set up the database to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have not set up the database yet, please follow the instructions in [Getting Started](https://scalardb.scalar-labs.com/docs/latest/scalardb-analytics-postgresql/getting-started).
 
 ## Schema in ScalarDB
 
@@ -161,7 +147,7 @@ Password for user postgres:
  c_comment    | text             |           |          |
 ```
 
-The column definitions are the same as the original table in the ScalarDB database. Type mapping between ScalarDB and PostgreSQL is explained in [Data type mapping between ScalarDB and the other databases](https://scalardb.scalar-labs.com/docs/3.9/schema-loader/#data-type-mapping-between-scalardb-and-the-other-databases). Internally, this view is based on the foreign table explained above and interprets the transaction metadata to expose only the valid data with the Read Committed isolation level.
+The column definitions are the same as the original table in the ScalarDB database. Type mapping between ScalarDB and PostgreSQL is explained in [Data type mapping between ScalarDB and the other databases](https://scalardb.scalar-labs.com/docs/latest/schema-loader/#data-type-mapping-between-scalardb-and-the-other-databases). Internally, this view is based on the foreign table explained above and interprets the transaction metadata to expose only the valid data with the Read Committed isolation level.
 
 Normally, you don't need to access the foreign tables directly. You can equate the views with the tables in the ScalarDB database.
 

--- a/docs/3.6/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
+++ b/docs/3.6/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
@@ -7,23 +7,9 @@ This tutorial describes how to create a sample application for ScalarDB Analytic
 - Docker
 - psql
 
-## Clone the ScalarDB samples repository
-
-Open Terminal, then clone the ScalarDB samples repository by running the following command:
-
-```shell
-$ git clone https://github.com/scalar-labs/scalardb-samples
-```
-
-Then, go to the directory with this sample by running the following command:
-
-```shell
-$ cd scalardb-samples/scalardb-analytics-postgresql-sample
-```
-
 ## Set up the database
 
-First, you must set up the database to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have not set up the database yet, please follow the instructions in [Getting Started](https://scalardb.scalar-labs.com/docs/3.9/scalardb-analytics-postgresql/getting-started.md).
+First, you must set up the database to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have not set up the database yet, please follow the instructions in [Getting Started](https://scalardb.scalar-labs.com/docs/latest/scalardb-analytics-postgresql/getting-started).
 
 ## Schema in ScalarDB
 
@@ -161,7 +147,7 @@ Password for user postgres:
  c_comment    | text             |           |          |
 ```
 
-The column definitions are the same as the original table in the ScalarDB database. Type mapping between ScalarDB and PostgreSQL is explained in [Data type mapping between ScalarDB and the other databases](https://scalardb.scalar-labs.com/docs/3.9/schema-loader/#data-type-mapping-between-scalardb-and-the-other-databases). Internally, this view is based on the foreign table explained above and interprets the transaction metadata to expose only the valid data with the Read Committed isolation level.
+The column definitions are the same as the original table in the ScalarDB database. Type mapping between ScalarDB and PostgreSQL is explained in [Data type mapping between ScalarDB and the other databases](https://scalardb.scalar-labs.com/docs/latest/schema-loader/#data-type-mapping-between-scalardb-and-the-other-databases). Internally, this view is based on the foreign table explained above and interprets the transaction metadata to expose only the valid data with the Read Committed isolation level.
 
 Normally, you don't need to access the foreign tables directly. You can equate the views with the tables in the ScalarDB database.
 

--- a/docs/3.7/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
+++ b/docs/3.7/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
@@ -7,23 +7,9 @@ This tutorial describes how to create a sample application for ScalarDB Analytic
 - Docker
 - psql
 
-## Clone the ScalarDB samples repository
-
-Open Terminal, then clone the ScalarDB samples repository by running the following command:
-
-```shell
-$ git clone https://github.com/scalar-labs/scalardb-samples
-```
-
-Then, go to the directory with this sample by running the following command:
-
-```shell
-$ cd scalardb-samples/scalardb-analytics-postgresql-sample
-```
-
 ## Set up the database
 
-First, you must set up the database to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have not set up the database yet, please follow the instructions in [Getting Started](https://scalardb.scalar-labs.com/docs/3.9/scalardb-analytics-postgresql/getting-started.md).
+First, you must set up the database to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have not set up the database yet, please follow the instructions in [Getting Started](https://scalardb.scalar-labs.com/docs/latest/scalardb-analytics-postgresql/getting-started).
 
 ## Schema in ScalarDB
 
@@ -161,7 +147,7 @@ Password for user postgres:
  c_comment    | text             |           |          |
 ```
 
-The column definitions are the same as the original table in the ScalarDB database. Type mapping between ScalarDB and PostgreSQL is explained in [Data type mapping between ScalarDB and the other databases](https://scalardb.scalar-labs.com/docs/3.9/schema-loader/#data-type-mapping-between-scalardb-and-the-other-databases). Internally, this view is based on the foreign table explained above and interprets the transaction metadata to expose only the valid data with the Read Committed isolation level.
+The column definitions are the same as the original table in the ScalarDB database. Type mapping between ScalarDB and PostgreSQL is explained in [Data type mapping between ScalarDB and the other databases](https://scalardb.scalar-labs.com/docs/latest/schema-loader/#data-type-mapping-between-scalardb-and-the-other-databases). Internally, this view is based on the foreign table explained above and interprets the transaction metadata to expose only the valid data with the Read Committed isolation level.
 
 Normally, you don't need to access the foreign tables directly. You can equate the views with the tables in the ScalarDB database.
 

--- a/docs/3.8/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
+++ b/docs/3.8/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
@@ -7,23 +7,9 @@ This tutorial describes how to create a sample application for ScalarDB Analytic
 - Docker
 - psql
 
-## Clone the ScalarDB samples repository
-
-Open Terminal, then clone the ScalarDB samples repository by running the following command:
-
-```shell
-$ git clone https://github.com/scalar-labs/scalardb-samples
-```
-
-Then, go to the directory with this sample by running the following command:
-
-```shell
-$ cd scalardb-samples/scalardb-analytics-postgresql-sample
-```
-
 ## Set up the database
 
-First, you must set up the database to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have not set up the database yet, please follow the instructions in [Getting Started](https://scalardb.scalar-labs.com/docs/3.9/scalardb-analytics-postgresql/getting-started.md).
+First, you must set up the database to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have not set up the database yet, please follow the instructions in [Getting Started](https://scalardb.scalar-labs.com/docs/latest/scalardb-analytics-postgresql/getting-started).
 
 ## Schema in ScalarDB
 
@@ -161,7 +147,7 @@ Password for user postgres:
  c_comment    | text             |           |          |
 ```
 
-The column definitions are the same as the original table in the ScalarDB database. Type mapping between ScalarDB and PostgreSQL is explained in [Data type mapping between ScalarDB and the other databases](https://scalardb.scalar-labs.com/docs/3.9/schema-loader/#data-type-mapping-between-scalardb-and-the-other-databases). Internally, this view is based on the foreign table explained above and interprets the transaction metadata to expose only the valid data with the Read Committed isolation level.
+The column definitions are the same as the original table in the ScalarDB database. Type mapping between ScalarDB and PostgreSQL is explained in [Data type mapping between ScalarDB and the other databases](https://scalardb.scalar-labs.com/docs/latest/schema-loader/#data-type-mapping-between-scalardb-and-the-other-databases). Internally, this view is based on the foreign table explained above and interprets the transaction metadata to expose only the valid data with the Read Committed isolation level.
 
 Normally, you don't need to access the foreign tables directly. You can equate the views with the tables in the ScalarDB database.
 

--- a/docs/3.9/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
+++ b/docs/3.9/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
@@ -7,23 +7,9 @@ This tutorial describes how to create a sample application for ScalarDB Analytic
 - Docker
 - psql
 
-## Clone the ScalarDB samples repository
-
-Open Terminal, then clone the ScalarDB samples repository by running the following command:
-
-```shell
-$ git clone https://github.com/scalar-labs/scalardb-samples
-```
-
-Then, go to the directory with this sample by running the following command:
-
-```shell
-$ cd scalardb-samples/scalardb-analytics-postgresql-sample
-```
-
 ## Set up the database
 
-First, you must set up the database to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have not set up the database yet, please follow the instructions in [Getting Started](https://scalardb.scalar-labs.com/docs/3.9/scalardb-analytics-postgresql/getting-started.md).
+First, you must set up the database to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have not set up the database yet, please follow the instructions in [Getting Started](https://scalardb.scalar-labs.com/docs/latest/scalardb-analytics-postgresql/getting-started).
 
 ## Schema in ScalarDB
 
@@ -161,7 +147,7 @@ Password for user postgres:
  c_comment    | text             |           |          |
 ```
 
-The column definitions are the same as the original table in the ScalarDB database. Type mapping between ScalarDB and PostgreSQL is explained in [Data type mapping between ScalarDB and the other databases](https://scalardb.scalar-labs.com/docs/3.9/schema-loader/#data-type-mapping-between-scalardb-and-the-other-databases). Internally, this view is based on the foreign table explained above and interprets the transaction metadata to expose only the valid data with the Read Committed isolation level.
+The column definitions are the same as the original table in the ScalarDB database. Type mapping between ScalarDB and PostgreSQL is explained in [Data type mapping between ScalarDB and the other databases](https://scalardb.scalar-labs.com/docs/latest/schema-loader/#data-type-mapping-between-scalardb-and-the-other-databases). Internally, this view is based on the foreign table explained above and interprets the transaction metadata to expose only the valid data with the Read Committed isolation level.
 
 Normally, you don't need to access the foreign tables directly. You can equate the views with the tables in the ScalarDB database.
 

--- a/docs/latest/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
+++ b/docs/latest/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
@@ -7,23 +7,9 @@ This tutorial describes how to create a sample application for ScalarDB Analytic
 - Docker
 - psql
 
-## Clone the ScalarDB samples repository
-
-Open Terminal, then clone the ScalarDB samples repository by running the following command:
-
-```shell
-$ git clone https://github.com/scalar-labs/scalardb-samples
-```
-
-Then, go to the directory with this sample by running the following command:
-
-```shell
-$ cd scalardb-samples/scalardb-analytics-postgresql-sample
-```
-
 ## Set up the database
 
-First, you must set up the database to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have not set up the database yet, please follow the instructions in [Getting Started](https://scalardb.scalar-labs.com/docs/3.9/scalardb-analytics-postgresql/getting-started.md).
+First, you must set up the database to run analytical queries with ScalarDB Analytics with PostgreSQL. If you have not set up the database yet, please follow the instructions in [Getting Started](https://scalardb.scalar-labs.com/docs/latest/scalardb-analytics-postgresql/getting-started).
 
 ## Schema in ScalarDB
 
@@ -161,7 +147,7 @@ Password for user postgres:
  c_comment    | text             |           |          |
 ```
 
-The column definitions are the same as the original table in the ScalarDB database. Type mapping between ScalarDB and PostgreSQL is explained in [Data type mapping between ScalarDB and the other databases](https://scalardb.scalar-labs.com/docs/3.9/schema-loader/#data-type-mapping-between-scalardb-and-the-other-databases). Internally, this view is based on the foreign table explained above and interprets the transaction metadata to expose only the valid data with the Read Committed isolation level.
+The column definitions are the same as the original table in the ScalarDB database. Type mapping between ScalarDB and PostgreSQL is explained in [Data type mapping between ScalarDB and the other databases](https://scalardb.scalar-labs.com/docs/latest/schema-loader/#data-type-mapping-between-scalardb-and-the-other-databases). Internally, this view is based on the foreign table explained above and interprets the transaction metadata to expose only the valid data with the Read Committed isolation level.
 
 Normally, you don't need to access the foreign tables directly. You can equate the views with the tables in the ScalarDB database.
 


### PR DESCRIPTION
## Description

This PR adds updated docs for the ScalarDB Analytics with PostgreSQL sample doc.

### Related issue or PR

- https://github.com/scalar-labs/scalardb-samples/pull/45

### Type of change

- [x] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, visited the updated pages, and confirmed that the updated links worked as expected.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
