### PR TITLE
Update article links on the home page and add "Enterprise" to the side navigation and home page title

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -60,9 +60,9 @@ versions:
 # After that, add a new scope in `_config.yml` to include an item that provides the proper versioned navigation to the site when someone visits the page (i.e., make sure people who visit a version 3.8 doc are shown a side navigation that includes only 3.8 docs.)
 
 "latest":
-  - title: "⬅ ScalarDB docs home" 
+  - title: "⬅ ScalarDB Enterprise docs home" 
     url: /docs # Don't change this URL. This links back to the parent product home page.
-  - title: "ScalarDB 3.10"
+  - title: "ScalarDB 3.10 Enterprise"
     children:
   # Get Started docs
   - title: "Get Started"
@@ -173,9 +173,9 @@ versions:
         url: /docs/latest/scalardb-sql/grammar/
 
 "3.9":
-  - title: "⬅ ScalarDB docs home" 
+  - title: "⬅ ScalarDB Enterprise docs home" 
     url: /docs # Don't change this URL. This links back to the parent product home page.
-  - title: "ScalarDB 3.9"
+  - title: "ScalarDB 3.9 Enterprise"
     children:
   # Get Started docs
   - title: "Get Started"
@@ -286,9 +286,9 @@ versions:
         url: /docs/3.9/scalardb-sql/grammar/
 
 "3.8":
-  - title: "⬅ ScalarDB docs home" 
+  - title: "⬅ ScalarDB Enterprise docs home" 
     url: /docs # Don't change this URL. This links back to the parent product home page.
-  - title: "ScalarDB 3.8"
+  - title: "ScalarDB 3.8 Enterprise"
     children:
   # Get Started docs
   - title: "Get Started"
@@ -403,9 +403,9 @@ versions:
         url: /docs/3.8/scalardb-sql/grammar/
 
 "3.7":
-  - title: "⬅ ScalarDB docs home" 
+  - title: "⬅ ScalarDB Enterprise docs home" 
     url: /docs # Don't change this URL. This links back to the parent product home page.
-  - title: "ScalarDB 3.7"
+  - title: "ScalarDB 3.7 Enterprise"
     children:
   # Get Started docs
   - title: "Get Started"
@@ -518,9 +518,9 @@ versions:
         url: /docs/3.7/scalardb-sql/grammar/
 
 "3.6":
-  - title: "⬅ ScalarDB docs home" 
+  - title: "⬅ ScalarDB Enterprise docs home" 
     url: /docs # Don't change this URL. This links back to the parent product home page.
-  - title: "ScalarDB 3.6"
+  - title: "ScalarDB 3.6 Enterprise"
     children:
   # Get Started docs
   - title: "Get Started"
@@ -633,9 +633,9 @@ versions:
         url: /docs/3.6/scalardb-sql/grammar/
 
 "3.5":
-  - title: "⬅ ScalarDB docs home" 
+  - title: "⬅ ScalarDB Enterprise docs home" 
     url: /docs # Don't change this URL. This links back to the parent product home page.
-  - title: "ScalarDB 3.5"
+  - title: "ScalarDB 3.5 Enterprise"
     children:
   # Get Started docs
   - title: "Get Started"
@@ -738,9 +738,9 @@ versions:
         url: /docs/3.5/scalardb-cluster/
 
 "3.4":
-  - title: "⬅ ScalarDB docs home" 
+  - title: "⬅ ScalarDB Enterprise docs home" 
     url: /docs # Don't change this URL. This links back to the parent product home page.
-  - title: "ScalarDB 3.4"
+  - title: "ScalarDB 3.4 Enterprise"
     children:
   # Get Started docs
   - title: "Get Started"

--- a/_home/home.md
+++ b/_home/home.md
@@ -7,15 +7,8 @@ product_row:
   - image_path: 
     alt: ""
     title: "ScalarDB" # This title will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
-    excerpt: "Cloud-native universal transaction manager" # Add a brief product description (approximately 8 words)
+    excerpt: "Universal transaction manager" # Add a brief product description (approximately 8 words)
     url: "docs/latest" # Add a relative URL to the product home page doc that is within this parent product docs site
-    btn_class: "btn--primary"
-    btn_label: "Get started" # This can be any other type of call to action
-  - image_path: 
-    alt: ""
-    title: "ScalarDB Server" # This title will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
-    excerpt: "gRPC server that implements ScalarDB interface" # Add a brief product description (approximately 8 words)
-    url: "docs/latest/scalardb-server" # Add a relative URL to the product home page doc that is within this parent product docs site
     btn_class: "btn--primary"
     btn_label: "Get started" # This can be any other type of call to action
   - image_path: 
@@ -25,18 +18,25 @@ product_row:
     url: "docs/latest/schema-loader" # Add a relative URL to the product home page doc that is within this parent product docs site
     btn_class: "btn--primary"
     btn_label: "Get started" # This can be any other type of call to action
+  - image_path: 
+    alt: ""
+    title: "ScalarDB Cluster" # This title will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
+    excerpt: "Clustering solution for ScalarDB" # Add a brief product description (approximately 8 words)
+    url: "docs/latest/scalardb-cluster/" # Add a relative URL to the product home page doc that is within this parent product docs site
+    btn_class: "btn--primary"
+    btn_label: "Get started" # This can be any other type of call to action
 recommended_row:
   - image_path: assets/images/book-green.svg # Choose the appropriate icon for the doc recommended here: (`book-green.svg`, `cloud-purple.svg`, `page-blue.svg`)
     alt: ""
     title: "Getting Started with ScalarDB" # The title for a recommended doc will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
-    excerpt: "Set up a simple electronic money application" # Add a brief description about the doc (approximately 8 words)
+    excerpt: "Set up a simple electronic money app" # Add a brief description about the doc (approximately 8 words)
     url: "docs/latest/getting-started" # Add a relative URL to the product home page doc that is within this parent product docs site
     btn_class: "btn--primary"
     btn_label: "Learn more" # This can be any other type of call to action
   - image_path: assets/images/book-green.svg # Choose the appropriate icon for the doc recommended here: (`book-green.svg`, `cloud-purple.svg`, `page-blue.svg`)
     alt: ""
     title: "ScalarDB Samples" # The title for a recommended doc will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
-    excerpt: "Try running sample applications for ScalarDB" # Add a brief description about the doc (approximately 8 words)
+    excerpt: "Set up sample applications" # Add a brief description about the doc (approximately 8 words)
     url: "docs/latest/scalardb-samples/README" # Add a relative URL to the product home page doc that is within this parent product docs site
     btn_class: "btn--primary"
     btn_label: "Learn more" # This can be any other type of call to action
@@ -50,12 +50,12 @@ recommended_row:
   
 ---
 
-# ScalarDB documentation
+# ScalarDB Enterprise Documentation
 
 ScalarDB is a universal transaction manager that achieves:
 
-* database/storage-agnostic ACID transactions in a scalable manner even if an underlying database or storage is not ACID-compliant.
-* multi-storage/database/service ACID transactions that can span multiple (possibly different) databases, storages, and services.
+* Database/storage-agnostic ACID transactions in a scalable manner even if an underlying database or storage is not ACID compliant.
+* Multi-storage/database/service ACID transactions that can span multiple (possibly different) databases, storages, and services.
 
 {% include product_row %}
 


### PR DESCRIPTION
## Description

This PR updates the links on the home page and adds "Enterprise" in the side navigation and on the home page title to help readers identify the site they are visiting (as opposed to the Community version). 

### Related issue or PR

N/A

### Type of change

- [ ] Documentation (new or updated documentation)
- [x] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, visited the updated home page, confirmed that "Enterprise" appeared as expected in the title, and checked that the updated links displayed and worked as expected. Also confirmed that "Enterprise" appeared as expected in the side navigation.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
