### PR TITLE
Add a Releases category to the side navigation and add individual release notes for ScalarDB 3.4 to 3.10

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -286,6 +286,21 @@ defaults:
       toc_sticky: true
       search: false # Excludes previous versions from search to reduce noise and search loading time. We should improve this function in the future to allow people to search for versioned docs.
 
+  # Release notes
+  - scope:
+      path: "docs/releases" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "latest" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: true
+
+
   # Hides ScalarDL-related pages (e.g., Helm Charts docs) from search results.
   # NOTE: The following method causes a lengthy build time, which occasionally causes the build to remain "In progress" indefinitely. Because of that, it is currently commented out until we find an alternative way to hide specific pages from search results.
   # - scope:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -175,6 +175,27 @@ versions:
         url: /docs/latest/scalardb-cluster/
       - title: "ScalarDB SQL Grammar"
         url: /docs/latest/scalardb-sql/grammar/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/releases/
+      # - title: "v3.10"
+      #   url: /docs/releases/release-3.10/
+      # - title: "v3.9"
+      #   url: /docs/releases/release-3.9/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy
 
 "3.9":
   - title: "⬅ ScalarDB Enterprise docs home" 
@@ -292,6 +313,27 @@ versions:
         url: /docs/3.9/scalardb-cluster/
       - title: "ScalarDB SQL Grammar"
         url: /docs/3.9/scalardb-sql/grammar/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/releases/
+      # - title: "v3.10"
+      #   url: /docs/releases/release-3.10/
+      # - title: "v3.9"
+      #   url: /docs/releases/release-3.9/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy
 
 "3.8":
   - title: "⬅ ScalarDB Enterprise docs home" 
@@ -413,6 +455,27 @@ versions:
         url: /docs/3.8/scalardb-cluster
       - title: "ScalarDB SQL Grammar"
         url: /docs/3.8/scalardb-sql/grammar/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/releases/
+      # - title: "v3.10"
+      #   url: /docs/releases/release-3.10/
+      # - title: "v3.9"
+      #   url: /docs/releases/release-3.9/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy
 
 "3.7":
   - title: "⬅ ScalarDB Enterprise docs home" 
@@ -532,6 +595,27 @@ versions:
         url: /docs/3.7/scalardb-cluster/
       - title: "ScalarDB SQL Grammar"
         url: /docs/3.7/scalardb-sql/grammar/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/releases/
+      # - title: "v3.10"
+      #   url: /docs/releases/release-3.10/
+      # - title: "v3.9"
+      #   url: /docs/releases/release-3.9/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy
 
 "3.6":
   - title: "⬅ ScalarDB Enterprise docs home" 
@@ -651,6 +735,27 @@ versions:
         url: /docs/3.6/scalardb-cluster/
       - title: "ScalarDB SQL Grammar"
         url: /docs/3.6/scalardb-sql/grammar/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/releases/
+      # - title: "v3.10"
+      #   url: /docs/releases/release-3.10/
+      # - title: "v3.9"
+      #   url: /docs/releases/release-3.9/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy
 
 "3.5":
   - title: "⬅ ScalarDB Enterprise docs home" 
@@ -760,6 +865,27 @@ versions:
         url: /docs/3.5/scalardb-benchmarks/README/
       - title: "ScalarDB Cluster"
         url: /docs/3.5/scalardb-cluster/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/releases/
+      # - title: "v3.10"
+      #   url: /docs/releases/release-3.10/
+      # - title: "v3.9"
+      #   url: /docs/releases/release-3.9/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy
 
 "3.4":
   - title: "⬅ ScalarDB Enterprise docs home" 
@@ -855,3 +981,24 @@ versions:
         url: /docs/3.4/scalardb-benchmarks/README/
       - title: "ScalarDB Cluster"
         url: /docs/3.4/scalardb-cluster/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/releases/
+      # - title: "v3.10"
+      #   url: /docs/releases/release-3.10/
+      # - title: "v3.9"
+      #   url: /docs/releases/release-3.9/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,0 +1,11 @@
+# Release Notes
+
+Select a version to see the release notes:
+
+- [ScalarDB 3.10](release-3.10.md)
+- [ScalarDB 3.9](release-3.9.md)
+- [ScalarDB 3.8](release-3.8.md)
+- [ScalarDB 3.7](release-3.7.md)
+- [ScalarDB 3.6](release-3.6.md)
+- [ScalarDB 3.5](release-3.5.md)
+- [ScalarDB 3.4](release-3.4.md)

--- a/docs/releases/release-3.10.md
+++ b/docs/releases/release-3.10.md
@@ -1,0 +1,74 @@
+# ScalarDB 3.10 Release Notes
+
+This page includes a list of release notes for ScalarDB 3.10.
+
+## v3.10.0
+
+**Release date:** July 20, 2023 
+
+### Summary
+
+ScalarDB 3.10 includes many new features, improvements, bug fixes, vulnerability fixes, and documentation updates. Please see the following for a list of detailed changes.
+
+### Change logs
+
+#### Enhancements
+
+- Make transaction metadata nullable to support existing databases ([#841](https://github.com/scalar-labs/scalardb/pull/841))
+- Add validation for consensus commit mutation operation ([#873](https://github.com/scalar-labs/scalardb/pull/873))
+- Add an interface to add conditions in ScanAll ([#889](https://github.com/scalar-labs/scalardb/pull/889))
+- Add relational scan for JDBC storage and consensus commit transaction ([#900](https://github.com/scalar-labs/scalardb/pull/900))
+- Support condition for transactional operations ([#899](https://github.com/scalar-labs/scalardb/pull/899))
+- Add relational scan for JDBC transactions ([#925](https://github.com/scalar-labs/scalardb/pull/925))
+- Add integration tests for MariaDB to CI ([#916](https://github.com/scalar-labs/scalardb/pull/916))
+- Add join() to DistributedTransactionManager ([#944](https://github.com/scalar-labs/scalardb/pull/944))
+- Add table importing feature ([#931](https://github.com/scalar-labs/scalardb/pull/931))
+
+#### Improvements
+
+- Bump com.azure:azure-cosmos from 4.44.0 to 4.45.0 ([#883](https://github.com/scalar-labs/scalardb/pull/883))
+- Add GHA workflow to automatically create pull requests to apply a merged PR changes ([#884](https://github.com/scalar-labs/scalardb/pull/884))
+- Bump slackapi/slack-github-action from 1.23.0 to 1.24.0 ([#886](https://github.com/scalar-labs/scalardb/pull/886))
+- Bump com.azure:azure-cosmos from 4.45.0 to 4.45.1 ([#887](https://github.com/scalar-labs/scalardb/pull/887))
+- Remove untagged container images ([#890](https://github.com/scalar-labs/scalardb/pull/890))
+- Bump com.oracle.database.jdbc:ojdbc8 from 21.9.0.0 to 21.10.0.0 ([#892](https://github.com/scalar-labs/scalardb/pull/892))
+- Bump dropwizardMetricsVersion from 4.2.18 to 4.2.19 ([#895](https://github.com/scalar-labs/scalardb/pull/895))
+- Bump info.picocli:picocli from 4.7.3 to 4.7.4 ([#896](https://github.com/scalar-labs/scalardb/pull/896))
+- Handle PRs created by dependabot in auto-pr GHA workflow ([#898](https://github.com/scalar-labs/scalardb/pull/898))
+- Bump com.azure:azure-cosmos from 4.45.1 to 4.46.0 ([#904](https://github.com/scalar-labs/scalardb/pull/904))
+- Bump com.scalar-labs:scalar-admin from 2.1.0 to 2.1.1 ([#910](https://github.com/scalar-labs/scalardb/pull/910))
+- Bump com.scalar-labs:scalar-admin from 2.1.1 to 2.1.2 ([#918](https://github.com/scalar-labs/scalardb/pull/918))
+- Bump com.azure:azure-cosmos from 4.46.0 to 4.47.0 ([#929](https://github.com/scalar-labs/scalardb/pull/929))
+- Revise Javadoc for exceptions ([#930](https://github.com/scalar-labs/scalardb/pull/930))
+- Add integration tests for transaction with relational scan ([#913](https://github.com/scalar-labs/scalardb/pull/913))
+- Add a constructor to UnsatisfiedConditionException ([#917](https://github.com/scalar-labs/scalardb/pull/917))
+- Improve some `toString` expressions of Selection Operators ([#920](https://github.com/scalar-labs/scalardb/pull/920))
+
+#### Bug fixes
+
+- Bump scalar-labs/jre8 from 1.1.12 to 1.1.13 in /server ([#881](https://github.com/scalar-labs/scalardb/pull/881))
+- Bump scalar-labs/jre8 from 1.1.12 to 1.1.13 in /schema-loader ([#882](https://github.com/scalar-labs/scalardb/pull/882))
+- Use a proper PAT in the GHA workflow for automated PR creation ([#885](https://github.com/scalar-labs/scalardb/pull/885))
+- Use the original Git commit author info not a response from GitHub API for the automated PR creation workflow ([#891](https://github.com/scalar-labs/scalardb/pull/891))
+- Fix the wrong argument validations in Auto PR workflow ([#906](https://github.com/scalar-labs/scalardb/pull/906))
+- Bump scalar-labs/jre8 from 1.1.13 to 1.1.14 in /schema-loader ([#903](https://github.com/scalar-labs/scalardb/pull/903))
+- Bump scalar-labs/jre8 from 1.1.13 to 1.1.14 in /server ([#902](https://github.com/scalar-labs/scalardb/pull/902))
+- Fix relational scan builder to keep ordering information and so on ([#908](https://github.com/scalar-labs/scalardb/pull/908))
+- Bump org.xerial:sqlite-jdbc from 3.41.2.1 to 3.42.0.0 ([#888](https://github.com/scalar-labs/scalardb/pull/888))
+- Run `git cherry-pick --abort` after it fails ([#924](https://github.com/scalar-labs/scalardb/pull/924))
+- Records should not be rolled back in rollback() when the transaction state is marked as COMMITTED in 2PC ([#909](https://github.com/scalar-labs/scalardb/pull/909))
+- Avoid decrementing outstanding requests counter duplicately ([#935](https://github.com/scalar-labs/scalardb/pull/935))
+- Should call abort() when aborting transaction in transaction wrapper classes ([#919](https://github.com/scalar-labs/scalardb/pull/919))
+- Fix [CVE-2023-1428](https://github.com/advisories/GHSA-6628-q6j9-w8vg "CVE-2023-1428") and [CVE-2023-32731](https://github.com/advisories/GHSA-cfgp-2977-2fmm "CVE-2023-32731") ([#943](https://github.com/scalar-labs/scalardb/pull/943))
+- Fix [CVE-2023-2976](https://github.com/advisories/GHSA-7g45-4rm6-3mm3 "CVE-2023-2976") ([#954](https://github.com/scalar-labs/scalardb/pull/954))
+- Fix utility method to check transactional table metadata ([#950](https://github.com/scalar-labs/scalardb/pull/950))
+
+#### Documentation
+
+- Change HTML syntax to Markdown for images (master) ([#880](https://github.com/scalar-labs/scalardb/pull/880))
+- Improve documents for Handle Exceptions ([#897](https://github.com/scalar-labs/scalardb/pull/897))
+- Move Jekyll files for redirecting from the docs site hosted in this repository to the new docs site ([#907](https://github.com/scalar-labs/scalardb/pull/907))
+- Revise configuration related documents ([#905](https://github.com/scalar-labs/scalardb/pull/905))
+- Update the ScalarDB dependency version to 3.9.1 ([#927](https://github.com/scalar-labs/scalardb/pull/927))
+- Add a redirect from the docs site hosted in this repository to the new docs site ([#901](https://github.com/scalar-labs/scalardb/pull/901))
+- Revise document for handling exceptions ([#932](https://github.com/scalar-labs/scalardb/pull/932))

--- a/docs/releases/release-3.4.md
+++ b/docs/releases/release-3.4.md
@@ -1,0 +1,214 @@
+# ScalarDB 3.4 Release Notes
+
+This page includes a list of release notes for ScalarDB 3.4.
+
+## v3.4.9
+
+**Release date:** December 27, 2022 
+
+### Summary
+
+This release has several bug fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Upgrade docker image version to fix [CVE-2021-46848](https://github.com/advisories/GHSA-6468-68pw-9chw "CVE-2021-46848") ([#766](https://github.com/scalar-labs/scalardb/pull/766))
+- Fix [CVE-2022-21363](https://github.com/advisories/GHSA-g76j-4cxx-23h9 "CVE-2022-21363") and [CVE-2021-2471](https://github.com/advisories/GHSA-w6f2-8wx4-47r5 "CVE-2021-2471") ([#773](https://github.com/scalar-labs/scalardb/pull/773))
+- Fix [CVE-2022-41946](https://github.com/advisories/GHSA-562r-vg33-8x8h "CVE-2022-41946") ([#774](https://github.com/scalar-labs/scalardb/pull/774))
+
+## v3.4.8
+
+**Release date:** December 1, 2022 
+
+### Summary
+
+This release has several bug fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Update protobuf and grpc to fix [CVE-2022-3171](https://github.com/advisories/GHSA-h4h5-3hr4-j3g2 "CVE-2022-3171") ([#738](https://github.com/scalar-labs/scalardb/pull/738))
+- Fix [CVE-2022-40151](https://github.com/advisories/GHSA-f8cc-g7j8-xxpm "CVE-2022-40151") and [CVE-2022-40152](https://github.com/advisories/GHSA-3f7h-mf4q-vrm4 "CVE-2022-40152") ([#743](https://github.com/scalar-labs/scalardb/pull/743))
+
+## v3.4.7
+
+**Release date:** November 16, 2022 
+
+### Summary
+
+This release has several bug fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Fix [CVE-2021-3999](https://github.com/advisories/GHSA-vfch-2fr8-r5c2 "CVE-2021-3999"), [CVE-2022-1586](https://github.com/advisories/GHSA-f3pv-9fwh-mp3x "CVE-2022-1586") and [CVE-2022-1587](https://github.com/advisories/GHSA-jmvm-hj36-w5hc "CVE-2022-1587") ([#700](https://github.com/scalar-labs/scalardb/pull/700))
+- Fix [CVE-2022-27664](https://github.com/advisories/GHSA-69cg-p879-7622 "CVE-2022-27664") ([#716](https://github.com/scalar-labs/scalardb/pull/716))
+- Fix [CVE-2022-32149](https://github.com/advisories/GHSA-69ch-w2m2-3vjp "CVE-2022-32149") ([#727](https://github.com/scalar-labs/scalardb/pull/727))
+- Fix [CVE-2022-42003](https://github.com/advisories/GHSA-jjjh-jjxp-wpff "CVE-2022-42003") and [CVE-2022-42004](https://github.com/advisories/GHSA-rgv9-q543-rqg4 "CVE-2022-42004") ([#726](https://github.com/scalar-labs/scalardb/pull/726))
+- Fix dependency errors for Maven projects ([#735](https://github.com/scalar-labs/scalardb/pull/735))
+- Fix typos in exception messages ([#714](https://github.com/scalar-labs/scalardb/pull/714))
+
+## v3.4.6
+
+**Release date:** September 2, 2022 
+
+### Summary
+
+This release has several bug fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Fix [CVE-2022-31197](https://github.com/advisories/GHSA-r38f-c4h4-hqq2 "CVE-2022-31197") affecting PostgreSQL driver ([#650](https://github.com/scalar-labs/scalardb/pull/650))
+- Fix [CVE-2021-46828](https://github.com/advisories/GHSA-x62c-6mxr-74fh "CVE-2021-46828") by bumping the jre8 dependency version ([#653](https://github.com/scalar-labs/scalardb/pull/653))
+- Fix [CVE-2022-2509](https://github.com/advisories/GHSA-w33j-4mrg-pgc3 "CVE-2022-2509") ([#654](https://github.com/scalar-labs/scalardb/pull/654))
+- Fix [CVE-2022-37434](https://github.com/advisories/GHSA-cfmr-vrgj-vqwv "CVE-2022-37434") ([#677](https://github.com/scalar-labs/scalardb/pull/677))
+
+## v3.4.5
+
+**Release date:** July 8, 2022 
+
+### Improvements
+
+- Update jre8 base image to 1.1.2 ([#587](https://github.com/scalar-labs/scalardb/pull/587))
+- Update dependencies to fix [CVE-2022-25647](https://github.com/advisories/GHSA-4jrv-ppp4-jm57 "CVE-2022-25647") ([#589](https://github.com/scalar-labs/scalardb/pull/589))
+- Fix [CVE-2022-1664](https://github.com/advisories/GHSA-q7pv-fjh6-6xq6 "CVE-2022-1664") ([#604](https://github.com/scalar-labs/scalardb/pull/604))
+- Fix [CVE-2022-2068](https://github.com/advisories/GHSA-xjxr-x4h8-946x "CVE-2022-2068") ([#623](https://github.com/scalar-labs/scalardb/pull/623))
+
+## v3.4.4
+
+**Release date:** April 28, 2022 
+
+### Enhancements
+
+- Release SNAPSHOT versions ([#561](https://github.com/scalar-labs/scalardb/pull/561))
+
+### Improvements
+
+- Fix typo in the integrationTestTwoPhaseConsensusCommit gradle task name ([#546](https://github.com/scalar-labs/scalardb/pull/546))
+- Update the base image jre8 to 1.1.0 ([#551](https://github.com/scalar-labs/scalardb/pull/551))
+- Migrate CI to GitHub actions ([#541](https://github.com/scalar-labs/scalardb/pull/541))
+- Trigger CI for "push" event on the master branch ([#557](https://github.com/scalar-labs/scalardb/pull/557))
+- Update the base image jre8 to 1.1.1 ([#560](https://github.com/scalar-labs/scalardb/pull/560))
+- Add docker check to CI ([#568](https://github.com/scalar-labs/scalardb/pull/568))
+- Add CI triggers for "push" events on support and release branches ([#572](https://github.com/scalar-labs/scalardb/pull/572))
+
+### Bug fixes
+
+- Fix `Query condition missed key schema element` error in DynamoDB ([#544](https://github.com/scalar-labs/scalardb/pull/544))
+- Fix SQL syntax error that happens when scanning a table without clustering key in JDBC adapter ([#550](https://github.com/scalar-labs/scalardb/pull/550))
+- Upgrade grpc_health_probe ([#562](https://github.com/scalar-labs/scalardb/pull/562))
+- Upgrade PostgreSQL driver ([#563](https://github.com/scalar-labs/scalardb/pull/563))
+- Upgrade Cosmos DB client ([#564](https://github.com/scalar-labs/scalardb/pull/564))
+
+### Documentation
+
+- Update CI status badge in index.md ([#556](https://github.com/scalar-labs/scalardb/pull/556))
+
+## v3.4.3
+
+**Release date:** March 28, 2022 
+
+### Improvements
+
+- Use the internal JRE Docker image to avoid CVE fixing commands ([#420](https://github.com/scalar-labs/scalardb/pull/420))
+- Refactor integration tests ([#442](https://github.com/scalar-labs/scalardb/pull/442))
+
+### Bug fixes
+
+- Log in GitHub Container Registry first ([#421](https://github.com/scalar-labs/scalardb/pull/421))
+- Handle lastEvaluatedKey for query in DynamoDB ([#534](https://github.com/scalar-labs/scalardb/pull/534))
+
+## v3.4.2
+
+**Release date:** February 10, 2022 
+
+### Improvements
+
+- Upgrade log4j to 2.17.0 ([#436](https://github.com/scalar-labs/scalardb/pull/436))
+- Add end-to-end test for schema loader to CI ([#349](https://github.com/scalar-labs/scalardb/pull/349))
+- Upgrade log4j to 2.17.1 ([#449](https://github.com/scalar-labs/scalardb/pull/449))
+- Refactor Schema Loader ([#448](https://github.com/scalar-labs/scalardb/pull/448))
+
+### Bug fixes
+
+- Add -u option for Cosmos DB in schema loader for backward compatibility ([#440](https://github.com/scalar-labs/scalardb/pull/440))
+- Should close FileInputStream in XXXConfig ([#451](https://github.com/scalar-labs/scalardb/pull/451))
+- Should rollback a transaction when expiring it in Two-phase commit transactions ([#452](https://github.com/scalar-labs/scalardb/pull/452))
+- Transactions that have multiple scans are always rejected in EXTRA_READ ([#457](https://github.com/scalar-labs/scalardb/pull/457))
+- Handling namespaces/tables/columns with reserved keywords in Cassandra and JDBC adapters ([#441](https://github.com/scalar-labs/scalardb/pull/441))
+- Handling namespaces/tables/columns with reserved keywords in DynamoDB adapter ([#462](https://github.com/scalar-labs/scalardb/pull/462))
+- Handling namespaces/tables/columns with reserved keywords in Cosmos DB adapter ([#461](https://github.com/scalar-labs/scalardb/pull/461))
+- Fix OperationChecker for mutation operations ([#476](https://github.com/scalar-labs/scalardb/pull/476))
+- Should not publish a fat jar for Schema Loader to the maven repository ([#490](https://github.com/scalar-labs/scalardb/pull/490))
+- Update PostgreSQL driver version for vulnerability fix ([#493](https://github.com/scalar-labs/scalardb/pull/493))
+
+## v3.4.1
+
+**Release date:** December 13, 2021 
+
+### Improvements
+
+- Move Isolation to the consensuscommit package ([#404](https://github.com/scalar-labs/scalardb/pull/404))
+- Upgrade log4j version ([#429](https://github.com/scalar-labs/scalardb/pull/429))
+
+### Bug fixes
+
+- Add mergeServiceFiles for shadowJar in Schema Loader ([#406](https://github.com/scalar-labs/scalardb/pull/406))
+- Fix get tables in Dynamo adapter when actual number of tables exceed the maximum in a response. ([#415](https://github.com/scalar-labs/scalardb/pull/415))
+
+## v3.4.0
+
+**Release date:** December 2, 2021 
+
+### Enhancements
+
+- Add ConsensusCommitUtils ([#367](https://github.com/scalar-labs/scalardb/pull/367))
+- Add KeyBytesEncoder that converts a key to bytes while preserving the sort order ([#369](https://github.com/scalar-labs/scalardb/pull/369))
+- Add clustering order support to JDBC adapter ([#378](https://github.com/scalar-labs/scalardb/pull/378))
+- Add clustering order support to Dynamo adapter ([#385](https://github.com/scalar-labs/scalardb/pull/385))
+- Add supporting schema creation/deletion can be called from program ([#366](https://github.com/scalar-labs/scalardb/pull/366))
+
+### Improvements
+
+- Refactor XXXConfig classes ([#372](https://github.com/scalar-labs/scalardb/pull/372))
+- Remove UnsupportedTypeException ([#373](https://github.com/scalar-labs/scalardb/pull/373))
+- Add null or empty check for partition key and clustering key ([#370](https://github.com/scalar-labs/scalardb/pull/370))
+- Allow empty value for partition key and clustering key ([#374](https://github.com/scalar-labs/scalardb/pull/374))
+- Add dockerize to Dockerfile for grpc-server ([#376](https://github.com/scalar-labs/scalardb/pull/376))
+- Add more tests to the multiple clustering key integration test ([#380](https://github.com/scalar-labs/scalardb/pull/380))
+- Refactor CosmosAdmin ([#382](https://github.com/scalar-labs/scalardb/pull/382))
+- Disallow empty values for Partition key and Clustering key ([#381](https://github.com/scalar-labs/scalardb/pull/381))
+- DynamoDB sort key optimization ([#375](https://github.com/scalar-labs/scalardb/pull/375))
+- Add single clustering key scan integration test ([#386](https://github.com/scalar-labs/scalardb/pull/386))
+- Add column value integration test ([#387](https://github.com/scalar-labs/scalardb/pull/387))
+- Add secondary index integration test ([#389](https://github.com/scalar-labs/scalardb/pull/389))
+- Add partition key integration tests ([#388](https://github.com/scalar-labs/scalardb/pull/388))
+- Add syntax highlighting for the dependency in README.md ([#384](https://github.com/scalar-labs/scalardb/pull/384))
+- Run integration tests concurrently ([#390](https://github.com/scalar-labs/scalardb/pull/390))
+- Introduce prometheus simpleclient_hotspot ([#391](https://github.com/scalar-labs/scalardb/pull/391))
+- Add integration tests for clustering order ([#393](https://github.com/scalar-labs/scalardb/pull/393))
+- Reduce integration test concurrency ([#397](https://github.com/scalar-labs/scalardb/pull/397))
+- Add some more admin integration tests ([#394](https://github.com/scalar-labs/scalardb/pull/394))
+- Modify Dockerfile to run as non-root ([#395](https://github.com/scalar-labs/scalardb/pull/395))
+- Add -XX:MaxRAMPercentage parameter to SCALARDB_SERVER_OPTS ([#392](https://github.com/scalar-labs/scalardb/pull/392))
+- Improve KeyBytesEncoderTest ([#379](https://github.com/scalar-labs/scalardb/pull/379))
+- Reduce Intellij warnings ([#400](https://github.com/scalar-labs/scalardb/pull/400))
+- Adjust integration test concurrency ([#399](https://github.com/scalar-labs/scalardb/pull/399))
+- Small fix for release.yaml ([#402](https://github.com/scalar-labs/scalardb/pull/402))
+
+### Bug fixes
+
+- Fix hashCode() in XXXValue and Key classes ([#377](https://github.com/scalar-labs/scalardb/pull/377))
+- Should show the warning message only when specifying storage specific options ([#396](https://github.com/scalar-labs/scalardb/pull/396))
+- Should add a suffix to the metadata table name in DynamoWithReservedKeywordIntegrationTest ([#401](https://github.com/scalar-labs/scalardb/pull/401))
+
+### Documentation
+
+- Improve Multi-storage documentation ([#365](https://github.com/scalar-labs/scalardb/pull/365))
+- Improve Schema loader document ([#368](https://github.com/scalar-labs/scalardb/pull/368))

--- a/docs/releases/release-3.5.md
+++ b/docs/releases/release-3.5.md
@@ -1,0 +1,261 @@
+# ScalarDB 3.5 Release Notes
+
+This page includes a list of release notes for ScalarDB 3.5.
+
+## v3.5.9
+
+**Release date:** June 30, 2023
+
+### Summary
+
+This release has several small improvements and vulnerability fixes.
+
+### Change logs
+
+#### Improvements
+
+- Improve some `toString` expressions of Selection Operators ([#920](https://github.com/scalar-labs/scalardb/pull/920))
+
+#### Bug fixes
+
+- Bump scalar-labs/jre8 from 1.1.12 to 1.1.13 in /server ([#881](https://github.com/scalar-labs/scalardb/pull/881))
+- Bump scalar-labs/jre8 from 1.1.12 to 1.1.13 in /schema-loader ([#882](https://github.com/scalar-labs/scalardb/pull/882))
+- Bump scalar-labs/jre8 from 1.1.13 to 1.1.14 in /schema-loader ([#903](https://github.com/scalar-labs/scalardb/pull/903))
+- Bump scalar-labs/jre8 from 1.1.13 to 1.1.14 in /server ([#902](https://github.com/scalar-labs/scalardb/pull/902))
+
+#### Documentation
+
+- Change HTML syntax to Markdown for images (3.5) ([#875](https://github.com/scalar-labs/scalardb/pull/875))
+
+## v3.5.8
+
+**Release date:** April 28, 2023
+
+### Summary
+
+This release has several vulnerability fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Fix CVE-2022-42898 ([#794](https://github.com/scalar-labs/scalardb/pull/794))
+- Fix [CVE-2023-0286](https://github.com/advisories/GHSA-x4qr-2fvf-3mr5 "CVE-2023-0286") ([#821](https://github.com/scalar-labs/scalardb/pull/821))
+- Fix [CVE-2023-0361](https://github.com/advisories/GHSA-5547-g9w2-52xj "CVE-2023-0361") and [CVE-2022-41723](https://github.com/advisories/GHSA-vvpx-j8f3-3w6h "CVE-2022-41723") ([#834](https://github.com/scalar-labs/scalardb/pull/834))
+- Fix [CVE-2022-41721](https://github.com/advisories/GHSA-fxg5-wq6x-vr4w "CVE-2022-41721") ([#808](https://github.com/scalar-labs/scalardb/pull/808))
+
+## v3.5.7
+
+**Release date:** December 27, 2022
+
+### Summary
+
+This release has several bug fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Upgrade docker image version to fix [CVE-2021-46848](https://github.com/advisories/GHSA-6468-68pw-9chw "CVE-2021-46848") ([#766](https://github.com/scalar-labs/scalardb/pull/766))
+- Fix [CVE-2022-21363](https://github.com/advisories/GHSA-g76j-4cxx-23h9 "CVE-2022-21363") and [CVE-2021-2471](https://github.com/advisories/GHSA-w6f2-8wx4-47r5 "CVE-2021-2471") ([#773](https://github.com/scalar-labs/scalardb/pull/773))
+- Fix [CVE-2022-41946](https://github.com/advisories/GHSA-562r-vg33-8x8h "CVE-2022-41946") ([#774](https://github.com/scalar-labs/scalardb/pull/774))
+
+## v3.5.6
+
+**Release date:** December 1, 2022
+
+### Summary
+
+This release has several bug fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Update protobuf and grpc to fix [CVE-2022-3171](https://github.com/advisories/GHSA-h4h5-3hr4-j3g2 "CVE-2022-3171") ([#738](https://github.com/scalar-labs/scalardb/pull/738))
+- Fix [CVE-2022-40151](https://github.com/advisories/GHSA-f8cc-g7j8-xxpm "CVE-2022-40151") and [CVE-2022-40152](https://github.com/advisories/GHSA-3f7h-mf4q-vrm4 "CVE-2022-40152") ([#743](https://github.com/scalar-labs/scalardb/pull/743))
+
+## v3.5.5
+
+**Release date:** November 16, 2022
+
+### Summary
+
+This release has several bug fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Fix [CVE-2021-3999](https://github.com/advisories/GHSA-vfch-2fr8-r5c2 "CVE-2021-3999"), [CVE-2022-1586](https://github.com/advisories/GHSA-f3pv-9fwh-mp3x "CVE-2022-1586") and [CVE-2022-1587](https://github.com/advisories/GHSA-jmvm-hj36-w5hc "CVE-2022-1587") ([#700](https://github.com/scalar-labs/scalardb/pull/700))
+- Fix [CVE-2022-27664](https://github.com/advisories/GHSA-69cg-p879-7622 "CVE-2022-27664") ([#716](https://github.com/scalar-labs/scalardb/pull/716))
+- Fix [CVE-2022-32149](https://github.com/advisories/GHSA-69ch-w2m2-3vjp "CVE-2022-32149") ([#727](https://github.com/scalar-labs/scalardb/pull/727))
+- Fix [CVE-2022-42003](https://github.com/advisories/GHSA-jjjh-jjxp-wpff "CVE-2022-42003") and [CVE-2022-42004](https://github.com/advisories/GHSA-rgv9-q543-rqg4 "CVE-2022-42004") ([#726](https://github.com/scalar-labs/scalardb/pull/726))
+- Fix dependency errors for Maven projects ([#735](https://github.com/scalar-labs/scalardb/pull/735))
+- Fix typos in exception messages ([#714](https://github.com/scalar-labs/scalardb/pull/714))
+
+## v3.5.4
+
+**Release date:** September 2, 2022
+
+### Summary
+
+This release has several bug fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Fix [CVE-2022-31197](https://github.com/advisories/GHSA-r38f-c4h4-hqq2 "CVE-2022-31197") affecting PostgreSQL driver ([#650](https://github.com/scalar-labs/scalardb/pull/650))
+- Fix [CVE-2021-46828](https://github.com/advisories/GHSA-x62c-6mxr-74fh "CVE-2021-46828") by bumping the jre8 dependency version ([#653](https://github.com/scalar-labs/scalardb/pull/653))
+- Fix [CVE-2022-2509](https://github.com/advisories/GHSA-w33j-4mrg-pgc3 "CVE-2022-2509") ([#654](https://github.com/scalar-labs/scalardb/pull/654))
+- Fix [CVE-2022-37434](https://github.com/advisories/GHSA-cfmr-vrgj-vqwv "CVE-2022-37434") ([#677](https://github.com/scalar-labs/scalardb/pull/677))
+
+## v3.5.3
+
+**Release date:** July 8, 2022
+
+### Improvements
+
+- Update jre8 base image to 1.1.2 ([#587](https://github.com/scalar-labs/scalardb/pull/587))
+- Update dependencies to fix [CVE-2022-25647](https://github.com/advisories/GHSA-4jrv-ppp4-jm57 "CVE-2022-25647") ([#589](https://github.com/scalar-labs/scalardb/pull/589))
+- Fix [CVE-2022-1664](https://github.com/advisories/GHSA-q7pv-fjh6-6xq6 "CVE-2022-1664") ([#604](https://github.com/scalar-labs/scalardb/pull/604))
+- Fix [CVE-2022-2068](https://github.com/advisories/GHSA-xjxr-x4h8-946x "CVE-2022-2068") ([#623](https://github.com/scalar-labs/scalardb/pull/623))
+
+## v3.5.2
+
+**Release date:** April 28, 2022
+
+### Enhancements
+
+- Release SNAPSHOT versions ([#561](https://github.com/scalar-labs/scalardb/pull/561))
+
+### Improvements
+
+- Fix typo in the integrationTestTwoPhaseConsensusCommit gradle task name ([#546](https://github.com/scalar-labs/scalardb/pull/546))
+- Update the base image jre8 to 1.1.0 ([#551](https://github.com/scalar-labs/scalardb/pull/551))
+- Migrate CI to GitHub actions ([#541](https://github.com/scalar-labs/scalardb/pull/541))
+- Trigger CI for "push" event on the master branch ([#557](https://github.com/scalar-labs/scalardb/pull/557))
+- Update the base image jre8 to 1.1.1 ([#560](https://github.com/scalar-labs/scalardb/pull/560))
+- Add docker check to CI ([#568](https://github.com/scalar-labs/scalardb/pull/568))
+- Add CI triggers for "push" events on support and release branches ([#572](https://github.com/scalar-labs/scalardb/pull/572))
+
+### Bug fixes
+
+- Fix `Query condition missed key schema element` error in DynamoDB ([#544](https://github.com/scalar-labs/scalardb/pull/544))
+- Fix SQL syntax error that happens when scanning a table without clustering key in JDBC adapter ([#550](https://github.com/scalar-labs/scalardb/pull/550))
+- Upgrade grpc_health_probe ([#562](https://github.com/scalar-labs/scalardb/pull/562))
+- Upgrade PostgreSQL driver ([#563](https://github.com/scalar-labs/scalardb/pull/563))
+- Upgrade Cosmos DB client ([#564](https://github.com/scalar-labs/scalardb/pull/564))
+
+### Documentation
+
+- Update CI status badge in index.md ([#556](https://github.com/scalar-labs/scalardb/pull/556))
+
+## v3.5.1
+
+**Release date:** March 28, 2022
+
+### Bug fixes
+
+- Handle lastEvaluatedKey for query in DynamoDB ([#534](https://github.com/scalar-labs/scalardb/pull/534))
+- Should return primary key when key is contained in WriteSet and ReadSet but the result in ReadSet is empty in Consensus Commit ([#535](https://github.com/scalar-labs/scalardb/pull/535))
+
+## v3.5.0
+
+**Release date:** February 16, 2022 
+
+### Enhancements
+
+- Make JDBC isolation level configurable ([#412](https://github.com/scalar-labs/scalardb/pull/412))
+- Support parallel preparation/commit/rollback in Consensus Commit ([#438](https://github.com/scalar-labs/scalardb/pull/438))
+- Support async commit/rollback in Consensus Commit ([#445](https://github.com/scalar-labs/scalardb/pull/445))
+- Add connection pool configurations for JdbcAdmin ([#458](https://github.com/scalar-labs/scalardb/pull/458))
+- Add TransactionalTableMetadataManager ([#465](https://github.com/scalar-labs/scalardb/pull/465))
+- Support parallel validation for EXTRA_READ in Consensus Commit ([#459](https://github.com/scalar-labs/scalardb/pull/459))
+- Add ByteBuffer support for Blob type ([#497](https://github.com/scalar-labs/scalardb/pull/497))
+- Add ByteBuffer support to Value ([#508](https://github.com/scalar-labs/scalardb/pull/508))
+
+### Improvements
+
+- Refactor DistributedStorageAdmin ([#405](https://github.com/scalar-labs/scalardb/pull/405))
+- Move ReadRepairableExecutionException to the Cassandra package ([#411](https://github.com/scalar-labs/scalardb/pull/411))
+- Throw RetriableExecutionException when TransactionConflict happens in the Dynamo adapter ([#407](https://github.com/scalar-labs/scalardb/pull/407))
+- Throw RetriableExecutionException in mutate operations when conflicts happen in the JDBC adapter ([#408](https://github.com/scalar-labs/scalardb/pull/408))
+- Handle RetriableExecutionException in ConsensusCommit ([#409](https://github.com/scalar-labs/scalardb/pull/409))
+- Move Isolation to the consensuscommit package ([#404](https://github.com/scalar-labs/scalardb/pull/404))
+- Result.getClusteringKey() should return empty when there is no clustering key ([#410](https://github.com/scalar-labs/scalardb/pull/410))
+- Use the internal JRE Docker image to avoid CVE fixing commands ([#420](https://github.com/scalar-labs/scalardb/pull/420))
+- Revisit logging in Consensus Commit ([#419](https://github.com/scalar-labs/scalardb/pull/419))
+- Remove synchronized from ConsensusCommitManager ([#418](https://github.com/scalar-labs/scalardb/pull/418))
+- Upgrade supported storage database version in the CI ([#416](https://github.com/scalar-labs/scalardb/pull/416))
+- Refactor OperationChecker ([#423](https://github.com/scalar-labs/scalardb/pull/423))
+- Add `SCALAR_DB_SERVER_PORT` to database.properties.tmpl ([#426](https://github.com/scalar-labs/scalardb/pull/426))
+- Rename utility classes for consistency ([#425](https://github.com/scalar-labs/scalardb/pull/425))
+- Upgrade log4j version ([#429](https://github.com/scalar-labs/scalardb/pull/429))
+- Filter transactional columns and support projection for get/scan in Consensus Commit ([#428](https://github.com/scalar-labs/scalardb/pull/428))
+- Use different datasource for table metadata in JDBC adapter ([#431](https://github.com/scalar-labs/scalardb/pull/431))
+- Remove TransactionRuntimeException ([#430](https://github.com/scalar-labs/scalardb/pull/430))
+- Move CoordinatorException to the consensuscommit package ([#434](https://github.com/scalar-labs/scalardb/pull/434))
+- Upgrade log4j to 2.17.0 ([#436](https://github.com/scalar-labs/scalardb/pull/436))
+- Add end-to-end test for schema loader to CI ([#349](https://github.com/scalar-labs/scalardb/pull/349))
+- Refactor integration tests ([#442](https://github.com/scalar-labs/scalardb/pull/442))
+- Upgrade log4j to 2.17.1 ([#449](https://github.com/scalar-labs/scalardb/pull/449))
+- Refactor Schema Loader ([#448](https://github.com/scalar-labs/scalardb/pull/448))
+- Rename JdbcDatabaseAdmin to JdbcAdmin ([#456](https://github.com/scalar-labs/scalardb/pull/456))
+- Deprecate XXXService classes ([#455](https://github.com/scalar-labs/scalardb/pull/455))
+- Refactor TableMetadataManager ([#454](https://github.com/scalar-labs/scalardb/pull/454))
+- Refactor JDBC adapter ([#468](https://github.com/scalar-labs/scalardb/pull/468))
+- Sort order for Scan without orderings should follow clustering order in Cosmos adapter ([#473](https://github.com/scalar-labs/scalardb/pull/473))
+- Allow getting already written data in Consensus Commit ([#474](https://github.com/scalar-labs/scalardb/pull/474))
+- Rename JDBC integration tests ([#475](https://github.com/scalar-labs/scalardb/pull/475))
+- Handle SQL Server conflict error ([#478](https://github.com/scalar-labs/scalardb/pull/478))
+- Add more integration tests for Scan ([#477](https://github.com/scalar-labs/scalardb/pull/477))
+- Increase no_output_timeout for Cosmos DB adapter CI ([#483](https://github.com/scalar-labs/scalardb/pull/483))
+- Use only id and version to check if a read record is not changed in the validation in EXTRA_READ ([#482](https://github.com/scalar-labs/scalardb/pull/482))
+- Add annotations ([#491](https://github.com/scalar-labs/scalardb/pull/491))
+- Move ResultImpl to the util package ([#492](https://github.com/scalar-labs/scalardb/pull/492))
+- Unnecessary columns are not read any more in Consensus Commit ([#488](https://github.com/scalar-labs/scalardb/pull/488))
+- Add constructors to ConditionalExpression ([#496](https://github.com/scalar-labs/scalardb/pull/496))
+- Use before image column names from TransactionalTableMetadata in RollbackMutationComposer ([#494](https://github.com/scalar-labs/scalardb/pull/494))
+- Revisit Key construction ([#447](https://github.com/scalar-labs/scalardb/pull/447))
+- Should not change states of operation instances passed as arguments ([#498](https://github.com/scalar-labs/scalardb/pull/498))
+- Classes/Methods deprecated in 3.x should be removed in 5.0.0 ([#506](https://github.com/scalar-labs/scalardb/pull/506))
+- Reduce Intellij warnings ([#503](https://github.com/scalar-labs/scalardb/pull/503))
+- Change Key builder ([#504](https://github.com/scalar-labs/scalardb/pull/504))
+- Move the rollbackRecords method from RecoveryHandler to CommitHandler ([#500](https://github.com/scalar-labs/scalardb/pull/500))
+- Revisit logging ([#502](https://github.com/scalar-labs/scalardb/pull/502))
+- Refactor Scalar DB Server code ([#453](https://github.com/scalar-labs/scalardb/pull/453))
+- Add ConfigUtils.getStringArray() ([#501](https://github.com/scalar-labs/scalardb/pull/501))
+- Rename `keyspace` to `namespace` in unit tests ([#507](https://github.com/scalar-labs/scalardb/pull/507))
+
+### Bug fixes
+
+- Add mergeServiceFiles for shadowJar in Schema Loader ([#406](https://github.com/scalar-labs/scalardb/pull/406))
+- Fix get tables in Dynamo adapter when actual number of tables exceed the maximum in a response. ([#415](https://github.com/scalar-labs/scalardb/pull/415))
+- Restore JdbcUtils.initDataSource(JdbcConfig config) ([#417](https://github.com/scalar-labs/scalardb/pull/417))
+- Log in GitHub Container Registry first ([#421](https://github.com/scalar-labs/scalardb/pull/421))
+- Add -u option for Cosmos DB in schema loader for backward compatibility ([#440](https://github.com/scalar-labs/scalardb/pull/440))
+- Should close FileInputStream in XXXConfig ([#451](https://github.com/scalar-labs/scalardb/pull/451))
+- Should rollback a transaction when expiring it in Two-phase commit transactions ([#452](https://github.com/scalar-labs/scalardb/pull/452))
+- Transactions that have multiple scans are always rejected in EXTRA_READ ([#457](https://github.com/scalar-labs/scalardb/pull/457))
+- Handling namespaces/tables/columns with reserved keywords in Cassandra and JDBC adapters ([#441](https://github.com/scalar-labs/scalardb/pull/441))
+- Handling namespaces/tables/columns with reserved keywords in DynamoDB adapter ([#462](https://github.com/scalar-labs/scalardb/pull/462))
+- Handling namespaces/tables/columns with reserved keywords in Cosmos DB adapter ([#461](https://github.com/scalar-labs/scalardb/pull/461))
+- Fix OperationChecker for mutation operations ([#476](https://github.com/scalar-labs/scalardb/pull/476))
+- Fix Scan logic in CrudHandler in Consensus Commit ([#479](https://github.com/scalar-labs/scalardb/pull/479))
+- Should not publish a fat jar for Schema Loader to the maven repository ([#490](https://github.com/scalar-labs/scalardb/pull/490))
+- Update PostgreSQL driver version for vulnerability fix ([#493](https://github.com/scalar-labs/scalardb/pull/493))
+
+### Documentation
+
+- Update the Scalar DB version in README ([#403](https://github.com/scalar-labs/scalardb/pull/403))
+- Update schema-loader javadoc to fix warning ([#413](https://github.com/scalar-labs/scalardb/pull/413))
+- Update the Scalar DB version of the dependency in README ([#433](https://github.com/scalar-labs/scalardb/pull/433))
+- Improve Getting Started with Scalar DB on X ([#432](https://github.com/scalar-labs/scalardb/pull/432))
+- Add gRPC deadline duration configuration to the Scalar DB Server documentation ([#437](https://github.com/scalar-labs/scalardb/pull/437))
+- Update the Getting Started doc and code ([#446](https://github.com/scalar-labs/scalardb/pull/446))
+- Add A Guide on How to Handle Exceptions ([#450](https://github.com/scalar-labs/scalardb/pull/450))
+- Update Scalar DB backup and restoration guide ([#486](https://github.com/scalar-labs/scalardb/pull/486))
+- Support SQL Server and Amazon Aurora officially ([#499](https://github.com/scalar-labs/scalardb/pull/499))
+- Update the Scalar DB version of the dependency in README ([#509](https://github.com/scalar-labs/scalardb/pull/509))

--- a/docs/releases/release-3.6.md
+++ b/docs/releases/release-3.6.md
@@ -1,0 +1,264 @@
+# ScalarDB 3.6 Release Notes
+
+This page includes a list of release notes for ScalarDB 3.6.
+
+## v3.6.6
+
+**Release date:** June 30, 2023 
+
+### Summary
+
+This release has several small improvements and vulnerability fixes.
+
+### Change logs
+
+#### Improvements
+
+- Improve some `toString` expressions of Selection Operators ([#920](https://github.com/scalar-labs/scalardb/pull/920))
+
+#### Bug fixes
+
+- Bump scalar-labs/jre8 from 1.1.12 to 1.1.13 in /server ([#881](https://github.com/scalar-labs/scalardb/pull/881))
+- Bump scalar-labs/jre8 from 1.1.12 to 1.1.13 in /schema-loader ([#882](https://github.com/scalar-labs/scalardb/pull/882))
+- Bump scalar-labs/jre8 from 1.1.13 to 1.1.14 in /schema-loader ([#903](https://github.com/scalar-labs/scalardb/pull/903))
+- Bump scalar-labs/jre8 from 1.1.13 to 1.1.14 in /server ([#902](https://github.com/scalar-labs/scalardb/pull/902))
+
+#### Documentation
+
+- Change HTML syntax to Markdown for images (3.6) ([#876](https://github.com/scalar-labs/scalardb/pull/876))
+
+## v3.6.5
+
+**Release date:** April 28, 2023 
+
+### Summary
+
+This release has several bug fixes and vulnerability fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Should care about ScanWithIndex in ScalarDbUtils.copyAndSetTargetToIfNot() ([#793](https://github.com/scalar-labs/scalardb/pull/793))
+- Fix CVE-2022-42898 ([#794](https://github.com/scalar-labs/scalardb/pull/794))
+- Fix [CVE-2023-0286](https://github.com/advisories/GHSA-x4qr-2fvf-3mr5 "CVE-2023-0286") ([#821](https://github.com/scalar-labs/scalardb/pull/821))
+- Fix [CVE-2023-0361](https://github.com/advisories/GHSA-5547-g9w2-52xj "CVE-2023-0361") and [CVE-2022-41723](https://github.com/advisories/GHSA-vvpx-j8f3-3w6h "CVE-2022-41723") ([#834](https://github.com/scalar-labs/scalardb/pull/834))
+- Fix [CVE-2022-41721](https://github.com/advisories/GHSA-fxg5-wq6x-vr4w "CVE-2022-41721") ([#808](https://github.com/scalar-labs/scalardb/pull/808))
+
+## v3.6.4
+
+**Release date:** December 27, 2022 
+
+### Summary
+
+This release adds [several configurations for gRPC](https://github.com/scalar-labs/scalardb/pull/776) and has several bug fixes.
+
+### Change logs
+
+#### Enhancements
+
+- Add configurations for gRPC ([#776](https://github.com/scalar-labs/scalardb/pull/776))
+
+#### Bug fixes
+
+- Upgrade docker image version to fix [CVE-2021-46848](https://github.com/advisories/GHSA-6468-68pw-9chw "CVE-2021-46848") ([#766](https://github.com/scalar-labs/scalardb/pull/766))
+- Fix [CVE-2022-21363](https://github.com/advisories/GHSA-g76j-4cxx-23h9 "CVE-2022-21363") and [CVE-2021-2471](https://github.com/advisories/GHSA-w6f2-8wx4-47r5 "CVE-2021-2471") ([#773](https://github.com/scalar-labs/scalardb/pull/773))
+- Fix [CVE-2022-41946](https://github.com/advisories/GHSA-562r-vg33-8x8h "CVE-2022-41946") ([#774](https://github.com/scalar-labs/scalardb/pull/774))
+
+## v3.6.3
+
+**Release date:** December 1, 2022 
+
+### Summary
+
+This release has several bug fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Update protobuf and grpc to fix [CVE-2022-3171](https://github.com/advisories/GHSA-h4h5-3hr4-j3g2 "CVE-2022-3171") ([#738](https://github.com/scalar-labs/scalardb/pull/738))
+- Fix [CVE-2022-40151](https://github.com/advisories/GHSA-f8cc-g7j8-xxpm "CVE-2022-40151") and [CVE-2022-40152](https://github.com/advisories/GHSA-3f7h-mf4q-vrm4 "CVE-2022-40152") ([#743](https://github.com/scalar-labs/scalardb/pull/743))
+
+## v3.6.2
+
+**Release date:** November 16, 2022 
+
+### Summary
+
+This release has several bug fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Fix [CVE-2021-3999](https://github.com/advisories/GHSA-vfch-2fr8-r5c2 "CVE-2021-3999"), [CVE-2022-1586](https://github.com/advisories/GHSA-f3pv-9fwh-mp3x "CVE-2022-1586") and [CVE-2022-1587](https://github.com/advisories/GHSA-jmvm-hj36-w5hc "CVE-2022-1587") ([#700](https://github.com/scalar-labs/scalardb/pull/700))
+- Commit/rollback records should always be done for all records even on error ([#680](https://github.com/scalar-labs/scalardb/pull/680))
+- Should use partition key and clustering key from result in recovery ([#681](https://github.com/scalar-labs/scalardb/pull/681))
+- Fix [CVE-2022-27664](https://github.com/advisories/GHSA-69cg-p879-7622 "CVE-2022-27664") ([#716](https://github.com/scalar-labs/scalardb/pull/716))
+- Should check the value range of BigIntColumn ([#720](https://github.com/scalar-labs/scalardb/pull/720))
+- Fix [CVE-2022-32149](https://github.com/advisories/GHSA-69ch-w2m2-3vjp "CVE-2022-32149") ([#727](https://github.com/scalar-labs/scalardb/pull/727))
+- Fix [CVE-2022-42003](https://github.com/advisories/GHSA-jjjh-jjxp-wpff "CVE-2022-42003") and [CVE-2022-42004](https://github.com/advisories/GHSA-rgv9-q543-rqg4 "CVE-2022-42004") ([#726](https://github.com/scalar-labs/scalardb/pull/726))
+- Fix dependency errors for Maven projects ([#735](https://github.com/scalar-labs/scalardb/pull/735))
+- Fix typos in exception messages ([#714](https://github.com/scalar-labs/scalardb/pull/714))
+
+## v3.6.1
+
+**Release date:** September 2, 2022 
+
+### Summary
+
+This release has several bug fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Fix [CVE-2022-31197](https://github.com/advisories/GHSA-r38f-c4h4-hqq2 "CVE-2022-31197") affecting PostgreSQL driver ([#650](https://github.com/scalar-labs/scalardb/pull/650))
+- Fix [CVE-2021-46828](https://github.com/advisories/GHSA-x62c-6mxr-74fh "CVE-2021-46828") by bumping the jre8 dependency version ([#653](https://github.com/scalar-labs/scalardb/pull/653))
+- Fix [CVE-2022-2509](https://github.com/advisories/GHSA-w33j-4mrg-pgc3 "CVE-2022-2509") ([#654](https://github.com/scalar-labs/scalardb/pull/654))
+- Fix [CVE-2022-37434](https://github.com/advisories/GHSA-cfmr-vrgj-vqwv "CVE-2022-37434") ([#677](https://github.com/scalar-labs/scalardb/pull/677))
+
+## v3.6.0
+
+**Release date:** July 8, 2022
+
+### Summary
+
+This release has a lot of API changes while preserving backward compatibility. Please see [Java API Guide](https://github.com/scalar-labs/scalardb/blob/v3.6.0/docs/api-guide.md) for the details of the API. 
+ 
+Also, it has a lot of enhancements, improvements, bug fixes, vulnerability fixes, and document improvements. Please see the following Change logs for the details.
+
+### Change logs
+
+#### Enhancements
+
+- Add suspend method to TwoPhaseCommitTransactionManager ([#588](https://github.com/scalar-labs/scalardb/pull/588))
+- Allow null values ([#512](https://github.com/scalar-labs/scalardb/pull/512))
+- Add factory methods to Key ([#517](https://github.com/scalar-labs/scalardb/pull/517))
+- Add factory methods to Scan.Ordering ([#520](https://github.com/scalar-labs/scalardb/pull/520))
+- Add ConditionBuilder ([#519](https://github.com/scalar-labs/scalardb/pull/519))
+- Add creating and dropping index support to DistributedStorageAdmin ([#526](https://github.com/scalar-labs/scalardb/pull/526))
+- Introduce DistributedTransactionAdmin ([#528](https://github.com/scalar-labs/scalardb/pull/528))
+- Add support for isNull and isNotNull conditions ([#529](https://github.com/scalar-labs/scalardb/pull/529))
+- Add SQL API ([#525](https://github.com/scalar-labs/scalardb/pull/525))
+- Support parameterized statement in SQL API ([#547](https://github.com/scalar-labs/scalardb/pull/547))
+- Introduce ScanAll operation ([#548](https://github.com/scalar-labs/scalardb/pull/548))
+- Release SNAPSHOT versions ([#561](https://github.com/scalar-labs/scalardb/pull/561))
+- Add scanAll for cassandra storage ([#570](https://github.com/scalar-labs/scalardb/pull/570))
+- Add DistributedTransactionAdminService to Scalar DB Server ([#575](https://github.com/scalar-labs/scalardb/pull/575))
+- Add ScanAll for Cosmos DB storage ([#578](https://github.com/scalar-labs/scalardb/pull/578))
+- Add new steps in the release.yaml to push container to Azure Container Registry ([#580](https://github.com/scalar-labs/scalardb/pull/580))
+- Add ScanAll for DynamoDB storage ([#577](https://github.com/scalar-labs/scalardb/pull/577))
+- Add ScanAll for JDBC storage ([#582](https://github.com/scalar-labs/scalardb/pull/582))
+- Implement the checkPaused service according to scalar-admin 1.2.0 ([#583](https://github.com/scalar-labs/scalardb/pull/583))
+- Add ScanAll to GRPC storage ([#584](https://github.com/scalar-labs/scalardb/pull/584))
+- Use `max_pause_wait_time` in AdminService ([#585](https://github.com/scalar-labs/scalardb/pull/585))
+- Implement ScanAll for Consensus Commit ([#586](https://github.com/scalar-labs/scalardb/pull/586))
+- Add builder for Put, Delete, Scan and Get operations ([#601](https://github.com/scalar-labs/scalardb/pull/601))
+- Add some useful methods ([#614](https://github.com/scalar-labs/scalardb/pull/614))
+- Introduce GetWithIndex and ScanWithIndex operations ([#618](https://github.com/scalar-labs/scalardb/pull/618))
+- Add methods to repair table and coordinator table to the Admin interfaces ([#613](https://github.com/scalar-labs/scalardb/pull/613))
+- Add repair table command to the Schema Loader Tool ([#622](https://github.com/scalar-labs/scalardb/pull/622))
+
+#### Improvements
+
+- Refactor ImmutableLinkedHashSet ([#513](https://github.com/scalar-labs/scalardb/pull/513))
+- Hide `Value` from users ([#515](https://github.com/scalar-labs/scalardb/pull/515))
+- Add more explicit methods to Put ([#516](https://github.com/scalar-labs/scalardb/pull/516))
+- Deprecate the methods for default namespace and table ([#518](https://github.com/scalar-labs/scalardb/pull/518))
+- Add conditional mutation integration test ([#522](https://github.com/scalar-labs/scalardb/pull/522))
+- Add a method to get DataType of the column to Value ([#523](https://github.com/scalar-labs/scalardb/pull/523))
+- Introduce Column ([#527](https://github.com/scalar-labs/scalardb/pull/527))
+- Extract Admin interface from XXXAdmin ([#531](https://github.com/scalar-labs/scalardb/pull/531))
+- Add a integration test putting a null value for secondary index column ([#530](https://github.com/scalar-labs/scalardb/pull/530))
+- Extract an interface for transaction CRUD operations ([#533](https://github.com/scalar-labs/scalardb/pull/533))
+- Move commonly used classes to `common` package ([#532](https://github.com/scalar-labs/scalardb/pull/532))
+- Execute conditional mutation integration tests in parallel ([#536](https://github.com/scalar-labs/scalardb/pull/536))
+- Refactor SQL API ([#538](https://github.com/scalar-labs/scalardb/pull/538))
+- Add more methods to SQL builders ([#540](https://github.com/scalar-labs/scalardb/pull/540))
+- Rename metadata cache expiration time configuration name ([#539](https://github.com/scalar-labs/scalardb/pull/539))
+- Support alias in SQL API ([#542](https://github.com/scalar-labs/scalardb/pull/542))
+- Cache metadata in SQL API ([#543](https://github.com/scalar-labs/scalardb/pull/543))
+- Fix typo in the integrationTestTwoPhaseConsensusCommit gradle task name ([#546](https://github.com/scalar-labs/scalardb/pull/546))
+- Use collectors in Guava ([#545](https://github.com/scalar-labs/scalardb/pull/545))
+- Update the base image jre8 to 1.1.0 ([#551](https://github.com/scalar-labs/scalardb/pull/551))
+- Invalidate metadata cache when schema change happens in SQL API ([#549](https://github.com/scalar-labs/scalardb/pull/549))
+- Change Gradle dependencies format ([#554](https://github.com/scalar-labs/scalardb/pull/554))
+- Add validations for create table statements in SQL API ([#552](https://github.com/scalar-labs/scalardb/pull/552))
+- Migrate CI to GitHub actions ([#541](https://github.com/scalar-labs/scalardb/pull/541))
+- Upgrade JUnit to 5 ([#555](https://github.com/scalar-labs/scalardb/pull/555))
+- Trigger CI for "push" event on the master branch ([#557](https://github.com/scalar-labs/scalardb/pull/557))
+- Rearrange integration tests ([#558](https://github.com/scalar-labs/scalardb/pull/558))
+- Update the base image jre8 to 1.1.1 ([#560](https://github.com/scalar-labs/scalardb/pull/560))
+- Add transaction integration tests ([#559](https://github.com/scalar-labs/scalardb/pull/559))
+- Rearrange schema loader integration tests ([#565](https://github.com/scalar-labs/scalardb/pull/565))
+- Rearrange server integration tests ([#566](https://github.com/scalar-labs/scalardb/pull/566))
+- Add integration tests for SQL API ([#567](https://github.com/scalar-labs/scalardb/pull/567))
+- Add docker check to CI ([#568](https://github.com/scalar-labs/scalardb/pull/568))
+- Add ifNotExists and ifExists flags to RPC ([#569](https://github.com/scalar-labs/scalardb/pull/569))
+- Add CI triggers for "push" events on support and release branches ([#572](https://github.com/scalar-labs/scalardb/pull/572))
+- Refactor DistributedTransactionAdmin ([#574](https://github.com/scalar-labs/scalardb/pull/574))
+- Remove SQL API ([#576](https://github.com/scalar-labs/scalardb/pull/576))
+- Refactor DatabaseConfig related things ([#579](https://github.com/scalar-labs/scalardb/pull/579))
+- Enable PITR for metadata table in Dynamo DB adapter ([#581](https://github.com/scalar-labs/scalardb/pull/581))
+- Update jre8 base image to 1.1.2 ([#587](https://github.com/scalar-labs/scalardb/pull/587))
+- Update dependencies to fix [CVE-2022-25647](https://github.com/advisories/GHSA-4jrv-ppp4-jm57 "CVE-2022-25647") ([#589](https://github.com/scalar-labs/scalardb/pull/589))
+- Use dockerize command by default in the Dockerfile ([#590](https://github.com/scalar-labs/scalardb/pull/590))
+- Handle projections in query for Cosmos DB ([#591](https://github.com/scalar-labs/scalardb/pull/591))
+- For Dynamo storage, throw an exception when a Put set a secondary index column value to null ([#593](https://github.com/scalar-labs/scalardb/pull/593))
+- Do not return primary key columns by default for selection operation in Storage mode ([#592](https://github.com/scalar-labs/scalardb/pull/592))
+- Add check for empty key ([#594](https://github.com/scalar-labs/scalardb/pull/594))
+- Add integration test for scanning table without clustering key ([#595](https://github.com/scalar-labs/scalardb/pull/595))
+- Merge protocVersion and protobufVersion ([#596](https://github.com/scalar-labs/scalardb/pull/596))
+- Add toString() to condition related classes ([#599](https://github.com/scalar-labs/scalardb/pull/599))
+- Add a way to disable metadata cache ([#598](https://github.com/scalar-labs/scalardb/pull/598))
+- Refactor ConsensusCommitUtils ([#600](https://github.com/scalar-labs/scalardb/pull/600))
+- Remove copyDependencies task ([#602](https://github.com/scalar-labs/scalardb/pull/602))
+- Fix [CVE-2022-1664](https://github.com/advisories/GHSA-q7pv-fjh6-6xq6 "CVE-2022-1664") ([#604](https://github.com/scalar-labs/scalardb/pull/604))
+- Refactor Gradle Plugin things ([#606](https://github.com/scalar-labs/scalardb/pull/606))
+- Introduce Column in Protocol Buffers ([#607](https://github.com/scalar-labs/scalardb/pull/607))
+- Upgrade SpotBugs ([#597](https://github.com/scalar-labs/scalardb/pull/597))
+- Refactor Scalar DB Server ([#609](https://github.com/scalar-labs/scalardb/pull/609))
+- Add `@deprecated` javadoc to overriding methods ([#610](https://github.com/scalar-labs/scalardb/pull/610))
+- Fix non constant names ([#611](https://github.com/scalar-labs/scalardb/pull/611))
+- Refactor Guice modules ([#608](https://github.com/scalar-labs/scalardb/pull/608))
+- Use ThreadLocal for Random in integration test ([#612](https://github.com/scalar-labs/scalardb/pull/612))
+- Fix [CVE-2022-2068](https://github.com/advisories/GHSA-xjxr-x4h8-946x "CVE-2022-2068") ([#623](https://github.com/scalar-labs/scalardb/pull/623))
+- Add Scanner paging support for scan operations to the Cosmos adapter ([#619](https://github.com/scalar-labs/scalardb/pull/619))
+- Remove non useful operation in ScannerImpl from the Cosmos DB adapter ([#624](https://github.com/scalar-labs/scalardb/pull/624))
+- Rename getCreateOptions() to getCreationOptions() in integration tests ([#629](https://github.com/scalar-labs/scalardb/pull/629))
+- Refactor Schema Loader ([#631](https://github.com/scalar-labs/scalardb/pull/631))
+- Rename `transactional` to `transaction` ([#632](https://github.com/scalar-labs/scalardb/pull/632))
+- Reduce Intellij warnings ([#633](https://github.com/scalar-labs/scalardb/pull/633))
+
+#### Bug fixes
+
+- Fix typo in the javadoc ([#514](https://github.com/scalar-labs/scalardb/pull/514))
+- Handle lastEvaluatedKey for query in DynamoDB ([#534](https://github.com/scalar-labs/scalardb/pull/534))
+- Fix `Query condition missed key schema element` error in DynamoDB ([#544](https://github.com/scalar-labs/scalardb/pull/544))
+- Fix SQL syntax error that happens when scanning a table without clustering key in JDBC adapter ([#550](https://github.com/scalar-labs/scalardb/pull/550))
+- Fix equals method of Value for bytes type ([#553](https://github.com/scalar-labs/scalardb/pull/553))
+- Upgrade grpc_health_probe ([#562](https://github.com/scalar-labs/scalardb/pull/562))
+- Upgrade PostgreSQL driver ([#563](https://github.com/scalar-labs/scalardb/pull/563))
+- Upgrade Cosmos DB client ([#564](https://github.com/scalar-labs/scalardb/pull/564))
+- Update the docs ([#603](https://github.com/scalar-labs/scalardb/pull/603))
+- Fix incompatible change ([#605](https://github.com/scalar-labs/scalardb/pull/605))
+
+#### Documentation
+
+- Update ScalarDB compatibility test matrix ([#510](https://github.com/scalar-labs/scalardb/pull/510))
+- Change terms in data model ([#521](https://github.com/scalar-labs/scalardb/pull/521))
+- Update CI status badge in index.md ([#556](https://github.com/scalar-labs/scalardb/pull/556))
+- Update backup creation and restoration procedures ([#571](https://github.com/scalar-labs/scalardb/pull/571))
+- Update Javadoc ([#615](https://github.com/scalar-labs/scalardb/pull/615))
+- Update documents ([#616](https://github.com/scalar-labs/scalardb/pull/616))
+- Update Getting Started ([#617](https://github.com/scalar-labs/scalardb/pull/617))
+- Add documentation for Consensus Commit configurations ([#621](https://github.com/scalar-labs/scalardb/pull/621))
+- Add API guide ([#620](https://github.com/scalar-labs/scalardb/pull/620))
+- Add myself in the released pom file "developers" information ([#628](https://github.com/scalar-labs/scalardb/pull/628))
+- Add documentation for Storage abstraction ([#625](https://github.com/scalar-labs/scalardb/pull/625))
+- Refactor Scalar DB Server documentation ([#627](https://github.com/scalar-labs/scalardb/pull/627))
+- Add GraphQL and SQL to License section in README ([#626](https://github.com/scalar-labs/scalardb/pull/626))
+- Fix typo ([#630](https://github.com/scalar-labs/scalardb/pull/630))
+- Small modifications for documentation ([#634](https://github.com/scalar-labs/scalardb/pull/634))

--- a/docs/releases/release-3.7.md
+++ b/docs/releases/release-3.7.md
@@ -1,0 +1,159 @@
+# ScalarDB 3.7 Release Notes
+
+This page includes a list of release notes for ScalarDB 3.7.
+
+## v3.7.5
+
+**Release date:** July 1, 2023
+
+### Summary
+
+This release has several small improvements and vulnerability fixes.
+
+### Change logs
+
+#### Improvements
+
+- Improve some `toString` expressions of Selection Operators ([#920](https://github.com/scalar-labs/scalardb/pull/920))
+
+#### Bug fixes
+
+- Bump scalar-labs/jre8 from 1.1.12 to 1.1.13 in /server ([#881](https://github.com/scalar-labs/scalardb/pull/881))
+- Bump scalar-labs/jre8 from 1.1.12 to 1.1.13 in /schema-loader ([#882](https://github.com/scalar-labs/scalardb/pull/882))
+- Bump scalar-labs/jre8 from 1.1.13 to 1.1.14 in /schema-loader ([#903](https://github.com/scalar-labs/scalardb/pull/903))
+- Bump scalar-labs/jre8 from 1.1.13 to 1.1.14 in /server ([#902](https://github.com/scalar-labs/scalardb/pull/902))
+- Should call abort() when aborting transaction in transaction wrapper classes ([#919](https://github.com/scalar-labs/scalardb/pull/919))
+
+#### Documentation
+
+- Change HTML syntax to Markdown for images (3.7) ([#877](https://github.com/scalar-labs/scalardb/pull/877))
+
+## v3.7.4
+
+**Release date:** April 28, 2023
+
+### Summary
+
+This release has several bug fixes and vulnerability fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- fix: DynamoAdmin.namespaceExists to check full namespace (not prefix) ([#782](https://github.com/scalar-labs/scalardb/pull/782))
+- Should care about ScanWithIndex in ScalarDbUtils.copyAndSetTargetToIfNot() ([#793](https://github.com/scalar-labs/scalardb/pull/793))
+- Fix CVE-2022-42898 ([#794](https://github.com/scalar-labs/scalardb/pull/794))
+- Fix [CVE-2023-0286](https://github.com/advisories/GHSA-x4qr-2fvf-3mr5 "CVE-2023-0286") ([#821](https://github.com/scalar-labs/scalardb/pull/821))
+- Fix [CVE-2023-0361](https://github.com/advisories/GHSA-5547-g9w2-52xj "CVE-2023-0361") and [CVE-2022-41723](https://github.com/advisories/GHSA-vvpx-j8f3-3w6h "CVE-2022-41723") ([#834](https://github.com/scalar-labs/scalardb/pull/834))
+- Fix [CVE-2022-41721](https://github.com/advisories/GHSA-fxg5-wq6x-vr4w "CVE-2022-41721") ([#808](https://github.com/scalar-labs/scalardb/pull/808))
+
+## v3.7.3
+
+**Release date:** December 27, 2022
+
+### Summary
+
+This release adds [several configurations for gRPC](https://github.com/scalar-labs/scalardb/pull/776) and has several bug fixes.
+
+### Change logs
+
+#### Enhancements
+
+- Add configurations for gRPC ([#776](https://github.com/scalar-labs/scalardb/pull/776))
+
+#### Bug fixes
+
+- Upgrade docker image version to fix [CVE-2021-46848](https://github.com/advisories/GHSA-6468-68pw-9chw "CVE-2021-46848") ([#766](https://github.com/scalar-labs/scalardb/pull/766))
+- Fix [CVE-2022-21363](https://github.com/advisories/GHSA-g76j-4cxx-23h9 "CVE-2022-21363") and [CVE-2021-2471](https://github.com/advisories/GHSA-w6f2-8wx4-47r5 "CVE-2021-2471") ([#773](https://github.com/scalar-labs/scalardb/pull/773))
+- Fix [CVE-2022-41946](https://github.com/advisories/GHSA-562r-vg33-8x8h "CVE-2022-41946") ([#774](https://github.com/scalar-labs/scalardb/pull/774))
+
+## v3.7.2
+
+**Release date:** December 1, 2022
+
+### Summary
+
+This release has several bug fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Update protobuf and grpc to fix [CVE-2022-3171](https://github.com/advisories/GHSA-h4h5-3hr4-j3g2 "CVE-2022-3171") ([#738](https://github.com/scalar-labs/scalardb/pull/738))
+- Fix [CVE-2022-40151](https://github.com/advisories/GHSA-f8cc-g7j8-xxpm "CVE-2022-40151") and [CVE-2022-40152](https://github.com/advisories/GHSA-3f7h-mf4q-vrm4 "CVE-2022-40152") ([#743](https://github.com/scalar-labs/scalardb/pull/743))
+
+## v3.7.1
+
+**Release date:** November 16, 2022
+
+### Summary
+
+This release has several bug fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Fix [CVE-2021-3999](https://github.com/advisories/GHSA-vfch-2fr8-r5c2 "CVE-2021-3999"), [CVE-2022-1586](https://github.com/advisories/GHSA-f3pv-9fwh-mp3x "CVE-2022-1586") and [CVE-2022-1587](https://github.com/advisories/GHSA-jmvm-hj36-w5hc "CVE-2022-1587") ([#700](https://github.com/scalar-labs/scalardb/pull/700))
+- Commit/rollback records should always be done for all records even on error ([#680](https://github.com/scalar-labs/scalardb/pull/680))
+- Should use partition key and clustering key from result in recovery ([#681](https://github.com/scalar-labs/scalardb/pull/681))
+- Fix [CVE-2022-27664](https://github.com/advisories/GHSA-69cg-p879-7622 "CVE-2022-27664") ([#716](https://github.com/scalar-labs/scalardb/pull/716))
+- Should check the value range of BigIntColumn ([#720](https://github.com/scalar-labs/scalardb/pull/720))
+- Fix [CVE-2022-32149](https://github.com/advisories/GHSA-69ch-w2m2-3vjp "CVE-2022-32149") ([#727](https://github.com/scalar-labs/scalardb/pull/727))
+- Fix [CVE-2022-42003](https://github.com/advisories/GHSA-jjjh-jjxp-wpff "CVE-2022-42003") and [CVE-2022-42004](https://github.com/advisories/GHSA-rgv9-q543-rqg4 "CVE-2022-42004") ([#726](https://github.com/scalar-labs/scalardb/pull/726))
+- Fix dependency errors for Maven projects ([#735](https://github.com/scalar-labs/scalardb/pull/735))
+- Fix typos in exception messages ([#714](https://github.com/scalar-labs/scalardb/pull/714))
+
+## v3.7.0
+
+**Release date:** September 3, 2022
+
+### Summary
+
+This release has several enhancements, improvements, bug fixes, vulnerability fixes, and document improvements.
+
+Highlights of this release are as follows:
+
+- Add namespace prefix support for Dynamo (The configuration name is `scalar.db.dynamo.namespace.prefix`. Please see [this document](https://github.com/scalar-labs/scalardb/blob/v3.7.0/docs/getting-started-with-scalardb-on-dynamodb.md) for the details
+- Add alter table command to Schema Loader tool (Please see [this document](https://github.com/scalar-labs/scalardb/blob/v3.7.0/schema-loader/README.md#alter-tables) for the details)
+
+### Change logs
+
+#### Enhancements
+
+- Add capability to add a new column to an existing table in the Administration interface ([#638](https://github.com/scalar-labs/scalardb/pull/638))
+- Add alter table command to Schema Loader tool ([#648](https://github.com/scalar-labs/scalardb/pull/648))
+- Add begin() and rollback() methods to Distributed Transaction API ([#656](https://github.com/scalar-labs/scalardb/pull/656))
+- Add begin() and abort() to Two-phase Commit Transaction API ([#657](https://github.com/scalar-labs/scalardb/pull/657))
+- Add new configuration to include transaction metadata on Get and Scan operations results when using Consensus Commit ([#649](https://github.com/scalar-labs/scalardb/pull/649))
+- Add namespace prefix support for Dynamo ([#658](https://github.com/scalar-labs/scalardb/pull/658))
+
+#### Improvements
+
+- Modify descriptions in archive.gradle ([#637](https://github.com/scalar-labs/scalardb/pull/637))
+- Update Scalar DB dependency in Getting Started ([#640](https://github.com/scalar-labs/scalardb/pull/640))
+- Deprecate table mapping in Multi-storage ([#641](https://github.com/scalar-labs/scalardb/pull/641))
+- Change default value of is-transaction-table in Schema Loader ([#642](https://github.com/scalar-labs/scalardb/pull/642))
+- Admin "repairTable()" handle metadata corruption ([#652](https://github.com/scalar-labs/scalardb/pull/652))
+- Refactor TableMetadataManager ([#651](https://github.com/scalar-labs/scalardb/pull/651))
+- Refactor Scalar DB proto ([#655](https://github.com/scalar-labs/scalardb/pull/655))
+- Add `@Nullable` to Admin.getTableMetadata() ([#659](https://github.com/scalar-labs/scalardb/pull/659))
+
+#### Bug fixes
+
+- In the Admin create and drop index methods, alter column type if necessary ([#645](https://github.com/scalar-labs/scalardb/pull/645))
+- Fix [CVE-2022-31197](https://github.com/advisories/GHSA-r38f-c4h4-hqq2 "CVE-2022-31197") affecting PostgreSQL driver ([#650](https://github.com/scalar-labs/scalardb/pull/650))
+- Fix [CVE-2021-46828](https://github.com/advisories/GHSA-x62c-6mxr-74fh "CVE-2021-46828") by bumping the jre8 dependency version ([#653](https://github.com/scalar-labs/scalardb/pull/653))
+- Fix [CVE-2022-2509](https://github.com/advisories/GHSA-w33j-4mrg-pgc3 "CVE-2022-2509") ([#654](https://github.com/scalar-labs/scalardb/pull/654))
+- Revert Proto package name ([#660](https://github.com/scalar-labs/scalardb/pull/660))
+- Fix [CVE-2022-37434](https://github.com/advisories/GHSA-cfmr-vrgj-vqwv "CVE-2022-37434") ([#677](https://github.com/scalar-labs/scalardb/pull/677))
+
+#### Documentation
+
+- Several fixes for documents ([#639](https://github.com/scalar-labs/scalardb/pull/639))
+- Add database compatibility of Scalar DB 3.6 ([#635](https://github.com/scalar-labs/scalardb/pull/635))
+- Add documentation for admin.addNewColumnToTable() ([#643](https://github.com/scalar-labs/scalardb/pull/643))
+- Refactor documents ([#646](https://github.com/scalar-labs/scalardb/pull/646))
+- Update Two-phase Commit Transactions document ([#644](https://github.com/scalar-labs/scalardb/pull/644))
+- Unify schema document and Schema Loader document ([#647](https://github.com/scalar-labs/scalardb/pull/647))
+- Update API Guide ([#662](https://github.com/scalar-labs/scalardb/pull/662))

--- a/docs/releases/release-3.8.md
+++ b/docs/releases/release-3.8.md
@@ -1,0 +1,166 @@
+# ScalarDB 3.8 Release Notes
+
+This page includes a list of release notes for ScalarDB 3.8.
+
+## v3.8.2
+
+**Release date:** July 3, 2023
+
+### Summary
+
+This release has several small improvements and vulnerability fixes.
+
+### Change logs
+
+#### Improvements
+
+- Bump com.scalar-labs:scalar-admin from 2.1.0 to 2.1.1 ([#910](https://github.com/scalar-labs/scalardb/pull/910))
+- Improve some `toString` expressions of Selection Operators ([#920](https://github.com/scalar-labs/scalardb/pull/920))
+
+#### Bug fixes
+
+- Bump scalar-labs/jre8 from 1.1.12 to 1.1.13 in /server ([#881](https://github.com/scalar-labs/scalardb/pull/881))
+- Bump scalar-labs/jre8 from 1.1.12 to 1.1.13 in /schema-loader ([#882](https://github.com/scalar-labs/scalardb/pull/882))
+- Bump scalar-labs/jre8 from 1.1.13 to 1.1.14 in /schema-loader ([#903](https://github.com/scalar-labs/scalardb/pull/903))
+- Bump scalar-labs/jre8 from 1.1.13 to 1.1.14 in /server ([#902](https://github.com/scalar-labs/scalardb/pull/902))
+- Should call abort() when aborting transaction in transaction wrapper classes ([#919](https://github.com/scalar-labs/scalardb/pull/919))
+
+#### Documentation
+
+- Change HTML syntax to Markdown for images (3.8) ([#878](https://github.com/scalar-labs/scalardb/pull/878))
+
+## v3.8.1
+
+**Release date:** April 28, 2023
+
+### Summary
+
+This release has several vulnerability fixes.
+
+### Change logs
+
+#### Bug fixes
+
+- Fix [CVE-2023-0361](https://github.com/advisories/GHSA-5547-g9w2-52xj "CVE-2023-0361") and [CVE-2022-41723](https://github.com/advisories/GHSA-vvpx-j8f3-3w6h "CVE-2022-41723") ([#834](https://github.com/scalar-labs/scalardb/pull/834))
+- Fix [CVE-2022-41721](https://github.com/advisories/GHSA-fxg5-wq6x-vr4w "CVE-2022-41721") ([#808](https://github.com/scalar-labs/scalardb/pull/808))
+- Fix [CVE-2023-0286](https://github.com/advisories/GHSA-x4qr-2fvf-3mr5 "CVE-2023-0286") ([#821](https://github.com/scalar-labs/scalardb/pull/821))
+
+## v3.8.0
+
+**Release date:** January 17, 2023 
+
+### Summary
+
+This release has a lot of enhancements, improvements, bug fixes, vulnerability fixes, and document improvements. Please see Change logs for the details.
+
+### Change logs
+
+#### Enhancements
+
+- Remove suspend() from TwoPhaseCommitTransactionManager ([#715](https://github.com/scalar-labs/scalardb/pull/715))
+- Update release workflow to push container to ECR of Marketplace ([#699](https://github.com/scalar-labs/scalardb/pull/699))
+- Add resume() to DistributedTransactionManager ([#717](https://github.com/scalar-labs/scalardb/pull/717))
+- Add several methods to ActiveExpiringMap ([#722](https://github.com/scalar-labs/scalardb/pull/722))
+- Allow to use placeholders in configuration values ([#770](https://github.com/scalar-labs/scalardb/pull/770))
+- Add configurations for gRPC ([#776](https://github.com/scalar-labs/scalardb/pull/776))
+
+#### Improvements
+
+- Refactor server integration tests ([#663](https://github.com/scalar-labs/scalardb/pull/663))
+- Use toUpperCase() for valueOf() of enum type ([#666](https://github.com/scalar-labs/scalardb/pull/666))
+- Use ServiceLoader to load storage and transaction modules ([#661](https://github.com/scalar-labs/scalardb/pull/661))
+- Improve error messages in OperationChecker ([#667](https://github.com/scalar-labs/scalardb/pull/667))
+- Add logging for UnknownTransactionStatusException in Scalar DB Server ([#669](https://github.com/scalar-labs/scalardb/pull/669))
+- Refactor JdbcAdminTest ([#670](https://github.com/scalar-labs/scalardb/pull/670))
+- Refactor CosmosAdminTest ([#671](https://github.com/scalar-labs/scalardb/pull/671))
+- Rename endpoint override config in Dynamo ([#672](https://github.com/scalar-labs/scalardb/pull/672))
+- Enable EI_EXPOSE_REP and EI_EXPOSE_REP2 in SpotBugs ([#668](https://github.com/scalar-labs/scalardb/pull/668))
+- Enable parallel/async commit by default ([#676](https://github.com/scalar-labs/scalardb/pull/676))
+- Add more checks for conditions for Dynamo and Cosmos ([#675](https://github.com/scalar-labs/scalardb/pull/675))
+- Refactor schema loader integration tests ([#673](https://github.com/scalar-labs/scalardb/pull/673))
+- Delete setDriver() for BasicDataSource in JDBC ([#682](https://github.com/scalar-labs/scalardb/pull/682))
+- Use DistributedTransactionAdmin for transaction tables in SchemaOperator ([#684](https://github.com/scalar-labs/scalardb/pull/684))
+- Delete licenses ([#686](https://github.com/scalar-labs/scalardb/pull/686))
+- Suppress exception thrown when deleting scalable target and scaling policy when using DynamoDB local. ([#683](https://github.com/scalar-labs/scalardb/pull/683))
+- Upgrade Spotless Gradle Plugin ([#694](https://github.com/scalar-labs/scalardb/pull/694))
+- Fix typo in admin integration test classes ([#695](https://github.com/scalar-labs/scalardb/pull/695))
+- Move integration test base code to subproject ([#697](https://github.com/scalar-labs/scalardb/pull/697))
+- Refactor ServiceLoader related classes ([#698](https://github.com/scalar-labs/scalardb/pull/698))
+- Make the ConsensusCommitAdmin only return transaction table ([#702](https://github.com/scalar-labs/scalardb/pull/702))
+- Add external Scalar DB property file support to getting-started application ([#701](https://github.com/scalar-labs/scalardb/pull/701))
+- Refactor ConsensusCommitAdmin unit test ([#704](https://github.com/scalar-labs/scalardb/pull/704))
+- In the Cosmos DB job of the CI, add a step to clean up gradle daemon logs file ([#705](https://github.com/scalar-labs/scalardb/pull/705))
+- Disable include metadata tests if external server used in server integration tests ([#711](https://github.com/scalar-labs/scalardb/pull/711))
+- Refactor consensus commit specific integration tests ([#713](https://github.com/scalar-labs/scalardb/pull/713))
+- Refactor two-phase commit transaction integration tests ([#712](https://github.com/scalar-labs/scalardb/pull/712))
+- Small integration test modifications for the resume feature ([#724](https://github.com/scalar-labs/scalardb/pull/724))
+- Should throw IllegalStateException when transaction is not found and already exists ([#718](https://github.com/scalar-labs/scalardb/pull/718))
+- Add transaction state management ([#719](https://github.com/scalar-labs/scalardb/pull/719))
+- Separate active transaction management from AbstractDistributedTransactionManager and AbstractTwoPhaseCommitTransactionManager ([#723](https://github.com/scalar-labs/scalardb/pull/723))
+- Fix dependency and spotbugs issues for >JDK 8 ([#728](https://github.com/scalar-labs/scalardb/pull/728))
+- Fix two unit tests of OperationChecker ([#731](https://github.com/scalar-labs/scalardb/pull/731))
+- Throw an exception when putting an empty value to a secondary index column in Dynamo DB ([#729](https://github.com/scalar-labs/scalardb/pull/729))
+- Make JDK11+ use the same google java format version as JDK8 uses ([#734](https://github.com/scalar-labs/scalardb/pull/734))
+- Make ParallelExecutor workers daemon thread ([#733](https://github.com/scalar-labs/scalardb/pull/733))
+- Move vuln check to a separate daily workflow ([#737](https://github.com/scalar-labs/scalardb/pull/737))
+- Conduct daily vulnerability checks on releases not only on `main` branch ([#741](https://github.com/scalar-labs/scalardb/pull/741))
+- Should drop namespace only when no tables are in the namespace in Schema Loader ([#740](https://github.com/scalar-labs/scalardb/pull/740))
+- Move common classes ([#744](https://github.com/scalar-labs/scalardb/pull/744))
+- Throw TransactionNotFoundException when resuming a transaction but it's not found ([#746](https://github.com/scalar-labs/scalardb/pull/746))
+- Post the vulnerability check result to Slack channel ([#745](https://github.com/scalar-labs/scalardb/pull/745))
+- Deprecate getPartitionKey() and getClusteringKey() of Result ([#750](https://github.com/scalar-labs/scalardb/pull/750))
+- Remove usages of getPartitionKey() and getClusteringKey() of Result from integration tests ([#751](https://github.com/scalar-labs/scalardb/pull/751))
+- Validate contact points size in XxxxConfig to avoid "java.lang.ArrayIndexOutOfBoundsException: 0" ([#752](https://github.com/scalar-labs/scalardb/pull/752))
+- Make integration test bases for transaction extendable ([#754](https://github.com/scalar-labs/scalardb/pull/754))
+- Refactor server integration tests ([#755](https://github.com/scalar-labs/scalardb/pull/755))
+- Small modifications for Javadoc and comments ([#756](https://github.com/scalar-labs/scalardb/pull/756))
+- Should close admin in afterEach() in the repair integration tests ([#767](https://github.com/scalar-labs/scalardb/pull/767))
+- build(fix): bump-up protobufVersion to 3.21.12 (latest) ([#760](https://github.com/scalar-labs/scalardb/pull/760))
+- Refactor prepare logic ([#771](https://github.com/scalar-labs/scalardb/pull/771))
+- Update Scheduled Vulnerability Check workflow ([#749](https://github.com/scalar-labs/scalardb/pull/749))
+- Refactor validation logic ([#775](https://github.com/scalar-labs/scalardb/pull/775))
+- Add transaction decorator ([#781](https://github.com/scalar-labs/scalardb/pull/781))
+- Revisit commit and abort state logic ([#783](https://github.com/scalar-labs/scalardb/pull/783))
+- Should synchronize in active transaction management ([#785](https://github.com/scalar-labs/scalardb/pull/785))
+- Allow commit() and rollback() to be called in parallel in all coordinator/participant processes in 2PC transactions ([#786](https://github.com/scalar-labs/scalardb/pull/786))
+- Load admins lazily in Schema Loader ([#792](https://github.com/scalar-labs/scalardb/pull/792))
+- Rename Scalar DB to ScalarDB ([#795](https://github.com/scalar-labs/scalardb/pull/795))
+- DynamoDB supports up to 100 actions per transaction ([#796](https://github.com/scalar-labs/scalardb/pull/796))
+- Revert async commit default value ([#797](https://github.com/scalar-labs/scalardb/pull/797))
+
+#### Bug fixes
+
+- Should support `--config=` and `-c=` styles for configuration file option in Schema Loader ([#690](https://github.com/scalar-labs/scalardb/pull/690))
+- Fix [CVE-2021-3999](https://github.com/advisories/GHSA-vfch-2fr8-r5c2 "CVE-2021-3999"), [CVE-2022-1586](https://github.com/advisories/GHSA-f3pv-9fwh-mp3x "CVE-2022-1586") and [CVE-2022-1587](https://github.com/advisories/GHSA-jmvm-hj36-w5hc "CVE-2022-1587") ([#700](https://github.com/scalar-labs/scalardb/pull/700))
+- Commit/rollback records should always be done for all records even on error ([#680](https://github.com/scalar-labs/scalardb/pull/680))
+- Should use partition key and clustering key from result in recovery ([#681](https://github.com/scalar-labs/scalardb/pull/681))
+- Fix typo in integration-test/archive.gradle ([#706](https://github.com/scalar-labs/scalardb/pull/706))
+- Fix [CVE-2022-27664](https://github.com/advisories/GHSA-69cg-p879-7622 "CVE-2022-27664") ([#716](https://github.com/scalar-labs/scalardb/pull/716))
+- Should check the value range of BigIntColumn ([#720](https://github.com/scalar-labs/scalardb/pull/720))
+- Fix [CVE-2022-32149](https://github.com/advisories/GHSA-69ch-w2m2-3vjp "CVE-2022-32149") ([#727](https://github.com/scalar-labs/scalardb/pull/727))
+- Fix [CVE-2022-42003](https://github.com/advisories/GHSA-jjjh-jjxp-wpff "CVE-2022-42003") and [CVE-2022-42004](https://github.com/advisories/GHSA-rgv9-q543-rqg4 "CVE-2022-42004") ([#726](https://github.com/scalar-labs/scalardb/pull/726))
+- Fix dependency errors for Maven projects ([#735](https://github.com/scalar-labs/scalardb/pull/735))
+- Fix typos in exception messages ([#714](https://github.com/scalar-labs/scalardb/pull/714))
+- Update protobuf and grpc to fix [CVE-2022-3171](https://github.com/advisories/GHSA-h4h5-3hr4-j3g2 "CVE-2022-3171") ([#738](https://github.com/scalar-labs/scalardb/pull/738))
+- Fix [CVE-2022-40151](https://github.com/advisories/GHSA-f8cc-g7j8-xxpm "CVE-2022-40151") and [CVE-2022-40152](https://github.com/advisories/GHSA-3f7h-mf4q-vrm4 "CVE-2022-40152") ([#743](https://github.com/scalar-labs/scalardb/pull/743))
+- Upgrade docker image version to fix [CVE-2021-46848](https://github.com/advisories/GHSA-6468-68pw-9chw "CVE-2021-46848") ([#766](https://github.com/scalar-labs/scalardb/pull/766))
+- Fix [CVE-2022-21363](https://github.com/advisories/GHSA-g76j-4cxx-23h9 "CVE-2022-21363") and [CVE-2021-2471](https://github.com/advisories/GHSA-w6f2-8wx4-47r5 "CVE-2021-2471") ([#773](https://github.com/scalar-labs/scalardb/pull/773))
+- Fix [CVE-2022-41946](https://github.com/advisories/GHSA-562r-vg33-8x8h "CVE-2022-41946") ([#774](https://github.com/scalar-labs/scalardb/pull/774))
+- fix: DynamoAdmin.namespaceExists to check full namespace (not prefix) ([#782](https://github.com/scalar-labs/scalardb/pull/782))
+- Should care about ScanWithIndex in ScalarDbUtils.copyAndSetTargetToIfNot() ([#793](https://github.com/scalar-labs/scalardb/pull/793))
+- Fix CVE-2022-42898 ([#794](https://github.com/scalar-labs/scalardb/pull/794))
+
+#### Documentation
+
+- Remove readthedocs ([#664](https://github.com/scalar-labs/scalardb/pull/664))
+- Move Schema Loader document to docs directory ([#665](https://github.com/scalar-labs/scalardb/pull/665))
+- Fix Javadoc warnings ([#685](https://github.com/scalar-labs/scalardb/pull/685))
+- Update the Scalar DB supported database matrix with Scalar DB 3.7 ([#703](https://github.com/scalar-labs/scalardb/pull/703))
+- Add description of limitations of data types ([#721](https://github.com/scalar-labs/scalardb/pull/721))
+- Fix the broken link in the backup document ([#725](https://github.com/scalar-labs/scalardb/pull/725))
+- Remove unnecessary key definition from API guide ([#742](https://github.com/scalar-labs/scalardb/pull/742))
+- Add note for Put/Delete operation in the API guide ([#747](https://github.com/scalar-labs/scalardb/pull/747))
+- Add ScalarDB Server's license description in the README ([#753](https://github.com/scalar-labs/scalardb/pull/753))
+- docs: Clearer description on when to use online backups ([#761](https://github.com/scalar-labs/scalardb/pull/761))
+- Add description how to build docker image of ScalarDB Server ([#779](https://github.com/scalar-labs/scalardb/pull/779))
+- Update slides links ([#789](https://github.com/scalar-labs/scalardb/pull/789))

--- a/docs/releases/release-3.9.md
+++ b/docs/releases/release-3.9.md
@@ -1,0 +1,159 @@
+# ScalarDB 3.9 Release Notes
+
+This page includes a list of release notes for ScalarDB 3.9.
+
+## v3.9.1
+
+**Release date:** July 3, 2023
+
+### Summary
+
+This release has several small improvements and vulnerability fixes.
+
+### Change logs
+
+#### Improvements
+
+- Bump com.scalar-labs:scalar-admin from 2.1.0 to 2.1.1 ([#910](https://github.com/scalar-labs/scalardb/pull/910))
+- Improve some `toString` expressions of Selection Operators ([#920](https://github.com/scalar-labs/scalardb/pull/920))
+
+#### Bug fixes
+
+- Bump scalar-labs/jre8 from 1.1.12 to 1.1.13 in /server ([#881](https://github.com/scalar-labs/scalardb/pull/881))
+- Bump scalar-labs/jre8 from 1.1.12 to 1.1.13 in /schema-loader ([#882](https://github.com/scalar-labs/scalardb/pull/882))
+- Bump scalar-labs/jre8 from 1.1.13 to 1.1.14 in /schema-loader ([#903](https://github.com/scalar-labs/scalardb/pull/903))
+- Bump scalar-labs/jre8 from 1.1.13 to 1.1.14 in /server ([#902](https://github.com/scalar-labs/scalardb/pull/902))
+- Records should not be rolled back in rollback() when the transaction state is marked as COMMITTED in 2PC ([#909](https://github.com/scalar-labs/scalardb/pull/909))
+- Should call abort() when aborting transaction in transaction wrapper classes ([#919](https://github.com/scalar-labs/scalardb/pull/919))
+- Bump org.xerial:sqlite-jdbc from 3.41.2.1 to 3.42.0.0 ([#888](https://github.com/scalar-labs/scalardb/pull/888))
+
+#### Documentation
+
+- Change HTML syntax to Markdown for images (3.9) ([#879](https://github.com/scalar-labs/scalardb/pull/879))
+- Change version in `add-scalardb-to-your-build.md` from `3.8.0` to `3.9.0` ([#893](https://github.com/scalar-labs/scalardb/pull/893))
+- Revise configuration related documents ([#905](https://github.com/scalar-labs/scalardb/pull/905))
+
+## v3.9.0
+
+**Release date:** April 27, 2023 
+
+### Summary
+
+ScalarDB 3.9 includes many new features, improvements, bug fixes, vulnerability fixes, and documentation updates. Please see the following for a list of detailed changes.
+
+ScalarDB provides a community edition and an enterprise edition. The community edition is available as open-source software that you can use under the Apache 2.0 License. The enterprise edition includes not only the features of the community edition but also many advanced features. Release notes for the enterprise edition are available under the “Enterprise edition” section. To use the features in the enterprise edition, you must have a license agreement with Scalar Inc.
+
+### Community edition
+
+#### New features
+
+- Added SQLite as a database that ScalarDB supports. ([#762](https://github.com/scalar-labs/scalardb/pull/762))
+
+#### Improvements
+
+- Added `slf4j-simple` to the sample application for getting started with ScalarDB. ([#835](https://github.com/scalar-labs/scalardb/pull/835))
+- Updated the supported Java version when getting started to Java 8 or higher. ([#840](https://github.com/scalar-labs/scalardb/pull/840))
+- Added the `Decommissioning` state to ScalarDB Server to achieve graceful shutdown. ([#851](https://github.com/scalar-labs/scalardb/pull/851))
+- Unified the error-handling behavior of the admin API (e.g., an exception is thrown when dropping a namespace but the namespace has some tables). ([#856](https://github.com/scalar-labs/scalardb/pull/856))
+
+#### Bug fixes
+
+- Upgraded the integrated Java Runtime Environment (JRE) Docker image to 1.1.11 to fix security issues. [CVE-2023-0286](https://nvd.nist.gov/vuln/detail/CVE-2023-0286) ([#821](https://github.com/scalar-labs/scalardb/pull/821))
+- Fixed issues where ScalarDB could not handle the write operation correctly when using the columns prefixed with `before_` with Consensus Commit. ([#844](https://github.com/scalar-labs/scalardb/pull/844))
+
+#### Documentation
+
+- Updated the documentation for transaction APIs and exceptions, the Java API guide, and the two-phase commit transaction guide. ([#804](https://github.com/scalar-labs/scalardb/pull/804), [#831](https://github.com/scalar-labs/scalardb/pull/831))
+- Updated the Cosmos DB name from `Cosmos DB` to `Cosmos DB for NoSQL` in the supported databases document. ([#813](https://github.com/scalar-labs/scalardb/pull/813))
+- Updated the steps to create and configure a Cosmos DB for NoSQL account for ScalarDB in the getting-started guide. ([#814](https://github.com/scalar-labs/scalardb/pull/814))
+- Updated the links for ScalarDB Server and Schema Loader in the backup and restore guide. ([#810](https://github.com/scalar-labs/scalardb/pull/810))
+- Added how to repair stored procedures when using Cosmos DB for NoSQL in the backup and restore guide. ([#825](https://github.com/scalar-labs/scalardb/pull/825))
+
+### Enterprise edition
+
+#### New features
+
+##### ScalarDB Cluster
+
+- Integrated the ScalarDB GraphQL and ScalarDB SQL interfaces with ScalarDB Cluster. As of ScalarDB 3.9, you no longer need to deploy dedicated components (i.e., containers) to provide GraphQL and SQL interfaces, respectively. In addition, you can more easily manage a ScalarDB Cluster.
+- Added the `direct-kubernetes` client mode into the Client mode.
+- Added the dedicated Schema Loader for ScalarDB Cluster.
+- Added ScalarDB GraphQL integration to ScalarDB Cluster.
+
+##### ScalarDB Analytics with PostgreSQL
+
+- Added ScalarDB Analytics with PostgreSQL. As of ScalarDB 3.9, you can perform analytical queries on data in heterogeneous databases (i.e., RDBMS and NoSQL) managed by ScalarDB transparently by using a PostgreSQL foreign data wrapper (FDW). This feature eliminates the need for you to implement join or aggregation operations in applications, and enables you to easily perform routine or ad-hoc analysis by simply issuing SQL to PostgreSQL.
+
+##### ScalarDB GraphQL
+
+- Added two-phase commit (2PC) support for ScalarDB GraphQL. As of ScalarDB 3.9, you can more easily guarantee data consistency between GraphQL-based microservices. Adding support for 2PC not only reduces system development costs but also facilitates maintenance.
+- Added two mechanisms to rebuild the GraphQL schema after a schema metadata change while the server is running.
+
+##### ScalarDB SQL
+
+- Added two-phase commit (2PC) support for Spring Data JDBC for ScalarDB. As of ScalarDB 3.9, you can more easily guarantee data consistency between Spring Framework–based microservices. Adding support for 2PC not only reduces system development costs but also facilitates maintenance.
+- Enabled `ScalarDbRepository#findAll()` and `ScalarDbRepository#count()` in Spring Data JDBC for ScalarDB.
+- Published JAR files for `ScalarDB SQL CLI` to the Maven repository.
+- Added the default namespace name configuration `scalar.db.sql.default_namespace_name`. The value of this configuration is used when a namespace name is not specified in a SQL statement.
+
+#### Improvements
+
+##### ScalarDB Cluster
+
+- Added logging to cluster nodes for recording detailed information.
+- Unified `scalar.db.cluster.node_port` and `scalar.db.cluster.node.port` into `scalar.db.cluster.node.port`.
+- Added an expiration time to the cluster node cache to wait for the current requests to finish before invalidating the cache.
+- Added the `Decommissioning` state to gracefully shut down a cluster node.
+- Revised to get the IP addresses of initial members when Kubernetes membership starts.
+- Removed an unnecessary `throws` clause from the `Membership#getMembersIpAddresses` method.
+
+##### ScalarDB GraphQL
+
+- Revised to abort transactions that execute a CRUD or transaction operation (i.e., abort and commit) and throw an exception, except if `transaction.commit()` throws an `UnknownTransactionStatusException` error.
+
+##### ScalarDB SQL
+
+- Improved the ScalarDB SQL error mapping table and `AbstractSqlJdbcStatement#execute` error handling.
+- Improved the Spring Data fragment repository class for ScalarDB.
+- Updated `com.scalar.db.sql.springdata.exception.ScalarDb*Exception` to always have a transactionId field value.
+- Revised the ScalarDB SQL API entirely.
+- Added the `Decommissioning` state to ScalarDB SQL Server.
+- Added a mechanism to expire the `SqlSessionFactory` cache and close the instance in ScalarDB JDBC.
+- Updated the exception translator in Spring Data JDBC for ScalarDB.
+- Updated the Metadata service interface to make it more intuitive.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded gRPC Health Probe to 0.4.15 to fix security issues. [CVE-2022-41721](https://nvd.nist.gov/vuln/detail/CVE-2022-41721)
+- Upgraded the integrated JRE Docker image to 1.1.11 to fix security issues. [CVE-2023-0286](https://nvd.nist.gov/vuln/detail/CVE-2023-0286)
+
+##### ScalarDB GraphQL
+
+- Upgraded the integrated JRE Docker image to 1.1.11 to fix security issues. [CVE-2023-0286](https://nvd.nist.gov/vuln/detail/CVE-2023-0286)
+- Upgraded the integrated JRE Docker image to 1.1.12 to fix security issues. [CVE-2023-0361](https://nvd.nist.gov/vuln/detail/CVE-2023-0361)
+- Upgraded the `graphql-java` version to 20.2 to fix security issues. [CVE-2023-28867](https://nvd.nist.gov/vuln/detail/CVE-2023-28867)
+
+##### ScalarDB SQL
+
+- Upgraded gRPC Health Probe to 0.4.15 to fix security issues. [CVE-2022-41721](https://nvd.nist.gov/vuln/detail/CVE-2022-41721)
+- Upgraded the integrated JRE Docker image to 1.1.11 to fix security issues. [CVE-2023-0286](https://nvd.nist.gov/vuln/detail/CVE-2023-0286)
+- Fixed an incorrect error message when an error occurred while executing the SELECT operation.
+- Upgraded the integrated JRE Docker image to 1.1.12 and gRPC Health Probe to 0.4.17 to fix security issues. [CVE-2023-0361](https://nvd.nist.gov/vuln/detail/CVE-2023-0361) [CVE-2022-41723](https://nvd.nist.gov/vuln/detail/cve-2022-41723)
+- Revised to set the finished status of the failed transaction to avoid timeout error in the bidirectional streams flow in Server mode.
+
+#### Documentation
+
+##### ScalarDB GraphQL
+
+- Added documentation for how to run ScalarDB GraphQL Server.
+- Fixed some minor issues, such as typos and unnecessary statements.
+
+##### ScalarDB SQL
+
+- Updated the Spring Data JDBC for ScalarDB guide to mention users can use other retry libraries.
+- Added a link to the Spring Data JDBC for ScalarDB guide to the README.
+- Revised a heading for clarification when users are getting started with ScalarDB SQL.
+- Revised the name of the "Spring Data integration with ScalarDB" feature to "Spring Data JDBC for ScalarDB".
+- Updated the Javadoc files to match the changes in the release.


### PR DESCRIPTION
## Description

This PR adds a Releases category to the side navigation and adds individual release notes for ScalarDB 3.4 to 3.10.

### Related issue or PR

N/A

### Type of change

- [x] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, visited the new pages, and confirmed that the content appeared as expected. Also confirmed that the side navigation worked as expected with the new Releases category.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
