### PR TITLE
Change link for "Getting Started with ScalarDB"

### DIFF
--- a/docs/3.10/helm-charts/configure-custom-values-scalardl-schema-loader.md
+++ b/docs/3.10/helm-charts/configure-custom-values-scalardl-schema-loader.md
@@ -22,7 +22,7 @@ If you use AWS/Azure Marketplace, please refer to the following documents for mo
 
 ### Database configurations
 
-You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for more details on the database configuration of ScalarDB.
+You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for more details on the database configuration of ScalarDB.
 
 ```yaml
 schemaLoading:

--- a/docs/3.10/scalardb-graphql/getting-started-with-scalardb-graphql.md
+++ b/docs/3.10/scalardb-graphql/getting-started-with-scalardb-graphql.md
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/docs/3.10/scalardb-sql/sql-server.md
+++ b/docs/3.10/scalardb-sql/sql-server.md
@@ -153,5 +153,5 @@ Please see [ScalarDB SQL Configurations](configurations.md) for more details of 
 
 * [Getting Started with ScalarDB SQL](getting-started-with-sql.md)
 * [Getting Started with ScalarDB JDBC](getting-started-with-jdbc.md)
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL Configurations](configurations.md)

--- a/docs/3.5/helm-charts/configure-custom-values-scalardl-schema-loader.md
+++ b/docs/3.5/helm-charts/configure-custom-values-scalardl-schema-loader.md
@@ -22,7 +22,7 @@ If you use AWS/Azure Marketplace, please refer to the following documents for mo
 
 ### Database configurations
 
-You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for more details on the database configuration of ScalarDB.
+You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for more details on the database configuration of ScalarDB.
 
 ```yaml
 schemaLoading:

--- a/docs/3.5/how-to-handle-exceptions.md
+++ b/docs/3.5/how-to-handle-exceptions.md
@@ -101,6 +101,6 @@ If you catch `ValidationConflictException`, like the `CrudConflictException` cas
 
 ## References
 
-- [Getting Started with Scalar DB](getting-started.md)
+- [Getting Started with Scalar DB](getting-started-with-scalardb.md)
 - [Two-phase Commit Transactions](two-phase-commit-transactions.md)
 - [Microservice Transaction Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/microservice-transaction-sample)

--- a/docs/3.5/scalardb-graphql/getting-started-with-scalardb-graphql.md
+++ b/docs/3.5/scalardb-graphql/getting-started-with-scalardb-graphql.md
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/docs/3.5/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.5/scalardb-samples/scalardb-server-sample/README.md
@@ -1,6 +1,6 @@
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md).
+For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
@@ -54,7 +54,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.

--- a/docs/3.6/helm-charts/configure-custom-values-scalardl-schema-loader.md
+++ b/docs/3.6/helm-charts/configure-custom-values-scalardl-schema-loader.md
@@ -22,7 +22,7 @@ If you use AWS/Azure Marketplace, please refer to the following documents for mo
 
 ### Database configurations
 
-You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for more details on the database configuration of ScalarDB.
+You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for more details on the database configuration of ScalarDB.
 
 ```yaml
 schemaLoading:

--- a/docs/3.6/scalardb-graphql/getting-started-with-scalardb-graphql.md
+++ b/docs/3.6/scalardb-graphql/getting-started-with-scalardb-graphql.md
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/docs/3.6/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.6/scalardb-samples/scalardb-server-sample/README.md
@@ -1,6 +1,6 @@
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md).
+For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
@@ -54,7 +54,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.

--- a/docs/3.6/scalardb-sql/configurations.md
+++ b/docs/3.6/scalardb-sql/configurations.md
@@ -29,7 +29,7 @@ The configurations for Direct mode are as follows:
 | scalar.db.sql.statement_cache.size | The maximum number of cached statement. | 100 |
 
 Note that in the Direct mode, you need to configure underlining storage/database, as well.
-Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for the details of the underlining storage/database configurations.
+Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of the underlining storage/database configurations.
 
 Please see also [Scalar DB SQL Server](sql-server.md) for the details of Scalar DB SQL Server.
 

--- a/docs/3.6/scalardb-sql/getting-started-with-jdbc.md
+++ b/docs/3.6/scalardb-sql/getting-started-with-jdbc.md
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with Scalar DB JDBC with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for Scalar DB exists.
 
@@ -229,7 +229,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how Scalar DB JDBC is used. For more information, please take a look at the following documents.
 
-* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md)
+* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [Scalar DB JDBC Guide](jdbc-guide.md)
 * [Scalar DB SQL Grammar](grammar.md)
 * [Scalar DB SQL Command Line interface](command-line-interface.md)

--- a/docs/3.6/scalardb-sql/getting-started-with-sql.md
+++ b/docs/3.6/scalardb-sql/getting-started-with-sql.md
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with Scalar DB SQL with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for Scalar DB exists.
 
@@ -217,7 +217,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how Scalar DB SQL is used. For more information, please take a look at the following documents.
 
-* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md)
+* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [Scalar DB SQL API Guide](sql-api-guide.md)
 * [Scalar DB SQL Grammar](grammar.md)
 * [Scalar DB SQL Command Line interface](command-line-interface.md)

--- a/docs/3.6/scalardb-sql/sql-server.md
+++ b/docs/3.6/scalardb-sql/sql-server.md
@@ -148,5 +148,5 @@ scalar.db.sql.default_transaction_mode=TRANSACTION
 
 * [Getting Started with Scalar DB SQL](getting-started-with-sql.md)
 * [Getting Started with Scalar DB JDBC](getting-started-with-jdbc.md)
-* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md)
+* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [Scalar DB SQL Configurations](configurations.md)

--- a/docs/3.7/helm-charts/configure-custom-values-scalardl-schema-loader.md
+++ b/docs/3.7/helm-charts/configure-custom-values-scalardl-schema-loader.md
@@ -22,7 +22,7 @@ If you use AWS/Azure Marketplace, please refer to the following documents for mo
 
 ### Database configurations
 
-You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for more details on the database configuration of ScalarDB.
+You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for more details on the database configuration of ScalarDB.
 
 ```yaml
 schemaLoading:

--- a/docs/3.7/scalardb-graphql/getting-started-with-scalardb-graphql.md
+++ b/docs/3.7/scalardb-graphql/getting-started-with-scalardb-graphql.md
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/docs/3.7/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.7/scalardb-samples/scalardb-server-sample/README.md
@@ -1,6 +1,6 @@
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md).
+For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
@@ -54,7 +54,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.

--- a/docs/3.7/scalardb-sql/configurations.md
+++ b/docs/3.7/scalardb-sql/configurations.md
@@ -29,7 +29,7 @@ The configurations for Direct mode are as follows:
 | scalar.db.sql.statement_cache.size | The maximum number of cached statement. | 100 |
 
 Note that in the Direct mode, you need to configure underlining storage/database, as well.
-Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for the details of the underlining storage/database configurations.
+Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of the underlining storage/database configurations.
 
 Please see also [Scalar DB SQL Server](sql-server.md) for the details of Scalar DB SQL Server.
 

--- a/docs/3.7/scalardb-sql/getting-started-with-jdbc.md
+++ b/docs/3.7/scalardb-sql/getting-started-with-jdbc.md
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with Scalar DB JDBC with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for Scalar DB exists.
 
@@ -229,7 +229,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how Scalar DB JDBC is used. For more information, please take a look at the following documents.
 
-* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md)
+* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [Scalar DB JDBC Guide](jdbc-guide.md)
 * [Scalar DB SQL Grammar](grammar.md)
 * [Scalar DB SQL Command Line interface](command-line-interface.md)

--- a/docs/3.7/scalardb-sql/getting-started-with-sql.md
+++ b/docs/3.7/scalardb-sql/getting-started-with-sql.md
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with Scalar DB SQL with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for Scalar DB exists.
 
@@ -217,7 +217,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how Scalar DB SQL is used. For more information, please take a look at the following documents.
 
-* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md)
+* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [Scalar DB SQL API Guide](sql-api-guide.md)
 * [Scalar DB SQL Grammar](grammar.md)
 * [Scalar DB SQL Command Line interface](command-line-interface.md)

--- a/docs/3.7/scalardb-sql/sql-server.md
+++ b/docs/3.7/scalardb-sql/sql-server.md
@@ -148,5 +148,5 @@ scalar.db.sql.default_transaction_mode=TRANSACTION
 
 * [Getting Started with Scalar DB SQL](getting-started-with-sql.md)
 * [Getting Started with Scalar DB JDBC](getting-started-with-jdbc.md)
-* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md)
+* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [Scalar DB SQL Configurations](configurations.md)

--- a/docs/3.8/helm-charts/configure-custom-values-scalardl-schema-loader.md
+++ b/docs/3.8/helm-charts/configure-custom-values-scalardl-schema-loader.md
@@ -22,7 +22,7 @@ If you use AWS/Azure Marketplace, please refer to the following documents for mo
 
 ### Database configurations
 
-You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for more details on the database configuration of ScalarDB.
+You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for more details on the database configuration of ScalarDB.
 
 ```yaml
 schemaLoading:

--- a/docs/3.8/scalardb-graphql/getting-started-with-scalardb-graphql.md
+++ b/docs/3.8/scalardb-graphql/getting-started-with-scalardb-graphql.md
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/docs/3.8/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.8/scalardb-samples/scalardb-server-sample/README.md
@@ -1,6 +1,6 @@
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md).
+For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
@@ -54,7 +54,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.

--- a/docs/3.8/scalardb-sql/configurations.md
+++ b/docs/3.8/scalardb-sql/configurations.md
@@ -29,7 +29,7 @@ The configurations for Direct mode are as follows:
 | scalar.db.sql.statement_cache.size | The maximum number of cached statement. | 100 |
 
 Note that in the Direct mode, you need to configure underlining storage/database, as well.
-Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for the details of the underlining storage/database configurations.
+Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of the underlining storage/database configurations.
 
 Please see also [ScalarDB SQL Server](sql-server.md) for the details of ScalarDB SQL Server.
 

--- a/docs/3.8/scalardb-sql/getting-started-with-jdbc.md
+++ b/docs/3.8/scalardb-sql/getting-started-with-jdbc.md
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with ScalarDB JDBC with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for ScalarDB exists.
 
@@ -229,7 +229,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how ScalarDB JDBC is used. For more information, please take a look at the following documents.
 
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB JDBC Guide](jdbc-guide.md)
 * [ScalarDB SQL Grammar](grammar.md)
 * [ScalarDB SQL Command Line interface](command-line-interface.md)

--- a/docs/3.8/scalardb-sql/getting-started-with-sql.md
+++ b/docs/3.8/scalardb-sql/getting-started-with-sql.md
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with ScalarDB SQL with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for ScalarDB exists.
 
@@ -217,7 +217,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how ScalarDB SQL is used. For more information, please take a look at the following documents.
 
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL API Guide](sql-api-guide.md)
 * [ScalarDB SQL Grammar](grammar.md)
 * [ScalarDB SQL Command Line interface](command-line-interface.md)

--- a/docs/3.8/scalardb-sql/sql-server.md
+++ b/docs/3.8/scalardb-sql/sql-server.md
@@ -148,5 +148,5 @@ scalar.db.sql.default_transaction_mode=TRANSACTION
 
 * [Getting Started with ScalarDB SQL](getting-started-with-sql.md)
 * [Getting Started with ScalarDB JDBC](getting-started-with-jdbc.md)
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL Configurations](configurations.md)

--- a/docs/3.9/helm-charts/configure-custom-values-scalardl-schema-loader.md
+++ b/docs/3.9/helm-charts/configure-custom-values-scalardl-schema-loader.md
@@ -22,7 +22,7 @@ If you use AWS/Azure Marketplace, please refer to the following documents for mo
 
 ### Database configurations
 
-You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for more details on the database configuration of ScalarDB.
+You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for more details on the database configuration of ScalarDB.
 
 ```yaml
 schemaLoading:

--- a/docs/3.9/scalardb-graphql/getting-started-with-scalardb-graphql.md
+++ b/docs/3.9/scalardb-graphql/getting-started-with-scalardb-graphql.md
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/docs/3.9/scalardb-sql/sql-server.md
+++ b/docs/3.9/scalardb-sql/sql-server.md
@@ -153,5 +153,5 @@ Please see [ScalarDB SQL Configurations](configurations.md) for more details of 
 
 * [Getting Started with ScalarDB SQL](getting-started-with-sql.md)
 * [Getting Started with ScalarDB JDBC](getting-started-with-jdbc.md)
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL Configurations](configurations.md)

--- a/docs/latest/helm-charts/configure-custom-values-scalardl-schema-loader.md
+++ b/docs/latest/helm-charts/configure-custom-values-scalardl-schema-loader.md
@@ -22,7 +22,7 @@ If you use AWS/Azure Marketplace, please refer to the following documents for mo
 
 ### Database configurations
 
-You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) for more details on the database configuration of ScalarDB.
+You must set `schemaLoading.databaseProperties`. Please set your `database.properties` to access the backend database to this parameter. Please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for more details on the database configuration of ScalarDB.
 
 ```yaml
 schemaLoading:

--- a/docs/latest/scalardb-graphql/getting-started-with-scalardb-graphql.md
+++ b/docs/latest/scalardb-graphql/getting-started-with-scalardb-graphql.md
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/docs/latest/scalardb-sql/sql-server.md
+++ b/docs/latest/scalardb-sql/sql-server.md
@@ -153,5 +153,5 @@ Please see [ScalarDB SQL Configurations](configurations.md) for more details of 
 
 * [Getting Started with ScalarDB SQL](getting-started-with-sql.md)
 * [Getting Started with ScalarDB JDBC](getting-started-with-jdbc.md)
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL Configurations](configurations.md)


### PR DESCRIPTION
## Description

This PR updates the link for the "Getting Started with ScalarDB" doc in other docs. (This is an interim fix until all PRs in source code repositories are merged.) 

### Related issue or PR

- https://github.com/scalar-labs/scalardb/pull/990

### Type of change

- [x] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, and confirmed that the updated links worked as expected.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
