### PR TITLE
Add out-of-support banner for ScalarDB 3.4

### DIFF
--- a/_includes/end-of-support.html
+++ b/_includes/end-of-support.html
@@ -1,7 +1,7 @@
 {% capture notice-2 %}
 **Warning**
 
-This version of ScalarDB is no longer supported. We recommend that you update to the [latest version](/docs/latest/) of ScalarDB.
+This version of ScalarDB is no longer supported. We recommend that you update to the [latest version](/docs/latest/getting-started-with-scalardb/) of ScalarDB.
 {% endcapture %}
 
 <div class="notice--danger">{{ notice-2 | markdownify }}</div>

--- a/docs/3.4/add-scalardb-to-your-build.md
+++ b/docs/3.4/add-scalardb-to-your-build.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Add ScalarDB to your build
 
 The library is available on [maven central repository](https://mvnrepository.com/artifact/com.scalar-labs/scalardb).

--- a/docs/3.4/backup-restore.md
+++ b/docs/3.4/backup-restore.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # A Guide on How to Back up and Restore Databases Integrated with Scalar DB
 
 Since Scalar DB provides transaction capability on top of non-transactional (possibly transactional) databases non-invasively, you need to take special care of backing up and restoring the databases in a transactionally-consistent way.

--- a/docs/3.4/development-configurations.md
+++ b/docs/3.4/development-configurations.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Configuration Guides for ScalarDB
 
 The following is a list of configuration guides for ScalarDB:

--- a/docs/3.4/getting-started-with-scalardb-on-cassandra.md
+++ b/docs/3.4/getting-started-with-scalardb-on-cassandra.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB on Cassandra
     
 ## Overview

--- a/docs/3.4/getting-started-with-scalardb-on-cosmosdb.md
+++ b/docs/3.4/getting-started-with-scalardb-on-cosmosdb.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB on Cosmos DB
 
 ## Overview

--- a/docs/3.4/getting-started-with-scalardb-on-dynamodb.md
+++ b/docs/3.4/getting-started-with-scalardb-on-dynamodb.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB on DynamoDB
 
 ## Overview

--- a/docs/3.4/getting-started-with-scalardb-on-jdbc.md
+++ b/docs/3.4/getting-started-with-scalardb-on-jdbc.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB on JDBC databases
 
 ## Overview

--- a/docs/3.4/getting-started-with-scalardb.md
+++ b/docs/3.4/getting-started-with-scalardb.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB
 
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.

--- a/docs/3.4/getting-started.md
+++ b/docs/3.4/getting-started.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar DB
 
 ## Overview

--- a/docs/3.4/helm-charts/README.md
+++ b/docs/3.4/helm-charts/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Index
 
 ## For users

--- a/docs/3.4/helm-charts/ReleaseFlow.md
+++ b/docs/3.4/helm-charts/ReleaseFlow.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Release Flow
 
 ## Requirements

--- a/docs/3.4/helm-charts/configure-custom-values-envoy.md
+++ b/docs/3.4/helm-charts/configure-custom-values-envoy.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Configure a custom values file for Scalar Envoy
 
 This document explains how to create your custom values file for the Scalar Envoy chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/envoy/README.md) of the Scalar Envoy chart.

--- a/docs/3.4/helm-charts/configure-custom-values-file.md
+++ b/docs/3.4/helm-charts/configure-custom-values-file.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Configure a custom values file for Scalar Helm Charts
 
 When you deploy Scalar products using Scalar Helm Charts, you must prepare your custom values file based on your environment. Please refer to the following documents for more details on how to a create custom values file for each product.

--- a/docs/3.4/helm-charts/configure-custom-values-scalar-manager.md
+++ b/docs/3.4/helm-charts/configure-custom-values-scalar-manager.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Configure a custom values file for Scalar Manager
 
 This document explains how to create your custom values file for the Scalar Manager chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalar-manager/README.md) of the Scalar Manager chart.

--- a/docs/3.4/helm-charts/configure-custom-values-scalardb-cluster.md
+++ b/docs/3.4/helm-charts/configure-custom-values-scalardb-cluster.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Configure a custom values file for ScalarDB Cluster
 
 This document explains how to create your custom values file for the ScalarDB Cluster chart. For details on the parameters, see the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalardb-cluster/README.md) of the ScalarDB Cluster chart.

--- a/docs/3.4/helm-charts/configure-custom-values-scalardb-graphql.md
+++ b/docs/3.4/helm-charts/configure-custom-values-scalardb-graphql.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Configure a custom values file for ScalarDB GraphQL
 
 This document explains how to create your custom values file for the ScalarDB GraphQL chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalardb-graphql/README.md) of the ScalarDB GraphQL chart.

--- a/docs/3.4/helm-charts/configure-custom-values-scalardb.md
+++ b/docs/3.4/helm-charts/configure-custom-values-scalardb.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Configure a custom values file for ScalarDB Server
 
 This document explains how to create your custom values file for the ScalarDB Server chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalardb/README.md) of the ScalarDB Server chart.

--- a/docs/3.4/helm-charts/configure-custom-values-scalardl-auditor.md
+++ b/docs/3.4/helm-charts/configure-custom-values-scalardl-auditor.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Configure a custom values file for ScalarDL Auditor
 
 This document explains how to create your custom values file for the ScalarDL Auditor chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalardl-audit/README.md) of the ScalarDL Auditor chart.

--- a/docs/3.4/helm-charts/configure-custom-values-scalardl-ledger.md
+++ b/docs/3.4/helm-charts/configure-custom-values-scalardl-ledger.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Configure a custom values file for ScalarDL Ledger
 
 This document explains how to create your custom values file for the ScalarDL Ledger chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalardl/README.md) of the ScalarDL Ledger chart.

--- a/docs/3.4/helm-charts/configure-custom-values-scalardl-schema-loader.md
+++ b/docs/3.4/helm-charts/configure-custom-values-scalardl-schema-loader.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Configure a custom values file for ScalarDL Schema Loader
 
 This document explains how to create your custom values file for the ScalarDL Schema Loader chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/schema-loading/README.md) of the ScalarDL Schema Loader chart.

--- a/docs/3.4/helm-charts/getting-started-logging.md
+++ b/docs/3.4/helm-charts/getting-started-logging.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Helm Charts (Logging using Loki Stack)
 
 This document explains how to get started with log aggregation for Scalar products on Kubernetes using Grafana Loki (with Promtail).

--- a/docs/3.4/helm-charts/getting-started-monitoring.md
+++ b/docs/3.4/helm-charts/getting-started-monitoring.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Helm Charts (Monitoring using Prometheus Operator)
 
 This document explains how to get started with Scalar products monitoring on Kubernetes using Prometheus Operator (kube-prometheus-stack). Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.

--- a/docs/3.4/helm-charts/getting-started-scalar-helm-charts.md
+++ b/docs/3.4/helm-charts/getting-started-scalar-helm-charts.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Scalar Helm Charts
 
 This document explains how to get started with Scalar Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.

--- a/docs/3.4/helm-charts/getting-started-scalar-manager.md
+++ b/docs/3.4/helm-charts/getting-started-scalar-manager.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Helm Charts (Scalar Manager)
 Scalar Manager is a web-based dashboard that allows users to:
 * check the health of the Scalar products

--- a/docs/3.4/helm-charts/getting-started-scalardb.md
+++ b/docs/3.4/helm-charts/getting-started-scalardb.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Helm Charts (ScalarDB Server)
 
 This document explains how to get started with ScalarDB Server using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.

--- a/docs/3.4/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/3.4/helm-charts/getting-started-scalardl-auditor.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Helm Charts (ScalarDL Ledger and Auditor / Auditor mode)
 
 This document explains how to get started with ScalarDL Ledger and Auditor using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.

--- a/docs/3.4/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/3.4/helm-charts/getting-started-scalardl-ledger.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)
 
 This document explains how to get started with ScalarDL Ledger using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.

--- a/docs/3.4/helm-charts/how-to-deploy-scalar-manager.md
+++ b/docs/3.4/helm-charts/how-to-deploy-scalar-manager.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # How to deploy Scalar Manager
 
 This document explains how to deploy Scalar Manager using Scalar Helm Charts. You must prepare your custom values file. Please refer to the following document for more details on the custom values file for Scalar Manager.

--- a/docs/3.4/helm-charts/how-to-deploy-scalar-products.md
+++ b/docs/3.4/helm-charts/how-to-deploy-scalar-products.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Deploy Scalar products using Scalar Helm Charts
 
 This document explains how to deploy Scalar products using Scalar Helm Charts. If you want to test Scalar products on your local environment using a minikube cluster, please refer to the following getting started guide.

--- a/docs/3.4/helm-charts/how-to-deploy-scalardb-cluster.md
+++ b/docs/3.4/helm-charts/how-to-deploy-scalardb-cluster.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # How to deploy ScalarDB Cluster
 
 This document explains how to deploy ScalarDB Cluster by using Scalar Helm Charts. For details on the custom values file for ScalarDB Cluster, see [Configure a custom values file for ScalarDB Cluster](./configure-custom-values-scalardb-cluster.md).

--- a/docs/3.4/helm-charts/how-to-deploy-scalardb-graphql.md
+++ b/docs/3.4/helm-charts/how-to-deploy-scalardb-graphql.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # How to deploy ScalarDB GraphQL
 
 This document explains how to deploy ScalarDB GraphQL using Scalar Helm Charts. You must prepare your custom values file. Please refer to the following document for more details on the custom values file for ScalarDB GraphQL.

--- a/docs/3.4/helm-charts/how-to-deploy-scalardb.md
+++ b/docs/3.4/helm-charts/how-to-deploy-scalardb.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # How to deploy ScalarDB Server
 
 This document explains how to deploy ScalarDB Server using Scalar Helm Charts. You must prepare your custom values file. Please refer to the following document for more details on the custom values file for ScalarDB Server.

--- a/docs/3.4/helm-charts/how-to-deploy-scalardl-auditor.md
+++ b/docs/3.4/helm-charts/how-to-deploy-scalardl-auditor.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # How to deploy ScalarDL Auditor
 
 This document explains how to deploy ScalarDL Auditor using Scalar Helm Charts. You must prepare your custom values file. Please refer to the following document for more details on the custom values file for ScalarDL Auditor and ScalarDL Schema Loader.

--- a/docs/3.4/helm-charts/how-to-deploy-scalardl-ledger.md
+++ b/docs/3.4/helm-charts/how-to-deploy-scalardl-ledger.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # How to deploy ScalarDL Ledger
 
 This document explains how to deploy ScalarDL Ledger using Scalar Helm Charts. You must prepare your custom values file. Please refer to the following document for more details on the custom values file for ScalarDL Ledger and ScalarDL Schema Loader.

--- a/docs/3.4/helm-charts/mount-files-or-volumes-on-scalar-pods.md
+++ b/docs/3.4/helm-charts/mount-files-or-volumes-on-scalar-pods.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Mount any files or volumes on Scalar product pods
 
 You can mount any files or volumes on Scalar product pods when you use ScalarDB Server, ScalarDB Cluster, or ScalarDL Helm Charts (ScalarDL Ledger and ScalarDL Auditor).

--- a/docs/3.4/helm-charts/samples/scalardb/scalardb-multi-storage-sample/README.md
+++ b/docs/3.4/helm-charts/samples/scalardb/scalardb-multi-storage-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # ScalarDB Deployment Sample on Kubernetes (Multi-Storage Transactions)
 
 ## Version

--- a/docs/3.4/helm-charts/samples/scalardl/scalardl-auditor-mode-sample/README.md
+++ b/docs/3.4/helm-charts/samples/scalardl/scalardl-auditor-mode-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # ScalarDL Deployment Sample on Kubernetes (Auditor mode)
 
 ## Version

--- a/docs/3.4/helm-charts/use-secret-for-credentials.md
+++ b/docs/3.4/helm-charts/use-secret-for-credentials.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # How to use Secret resources to pass credentials as environment variables into the properties file
 
 You can pass credentials like **username** or **password** as environment variables via a `Secret` resource in Kubernetes. The docker images for previous versions of Scalar products use the `dockerize` command for templating properties files. The docker images for the latest versions of Scalar products get values directly from environment variables.

--- a/docs/3.4/index.md
+++ b/docs/3.4/index.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 ## Scalar DB
 
 [![CI](https://github.com/scalar-labs/scalardb/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/scalar-labs/scalardb/actions/workflows/ci.yaml)

--- a/docs/3.4/requirements.md
+++ b/docs/3.4/requirements.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Requirements in the Underlining Databases of Scalar DB
 
 This document explains the requirements in the underlining databases of Scalar DB to make Scalar DB applications work correctly.

--- a/docs/3.4/scalar-kubernetes/AccessScalarProducts.md
+++ b/docs/3.4/scalar-kubernetes/AccessScalarProducts.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Make ScalarDB or ScalarDL deployed in a Kubernetes cluster environment available from applications
 
 This document explains how to make ScalarDB or ScalarDL deployed in a Kubernetes cluster environment available from applications. To make ScalarDB or ScalarDL available from applications, you can use Scalar Envoy via a Kubernetes service resource named `<HELM_RELEASE_NAME>-envoy`. You can use `<HELM_RELEASE_NAME>-envoy` in several ways, such as:

--- a/docs/3.4/scalar-kubernetes/AwsMarketplaceGuide.md
+++ b/docs/3.4/scalar-kubernetes/AwsMarketplaceGuide.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # How to install Scalar products through AWS Marketplace
 
 Scalar products (ScalarDB, ScalarDL, and their tools) are available in the AWS Marketplace as container images. This guide explains how to install Scalar products through the AWS Marketplace.

--- a/docs/3.4/scalar-kubernetes/AzureMarketplaceGuide.md
+++ b/docs/3.4/scalar-kubernetes/AzureMarketplaceGuide.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # How to install Scalar products through Azure Marketplace
 
 Scalar products (ScalarDB, ScalarDL, and their tools) are provided in Azure Marketplace as container offers. This guide explains how to install Scalar products through Azure Marketplace.

--- a/docs/3.4/scalar-kubernetes/BackupNoSQL.md
+++ b/docs/3.4/scalar-kubernetes/BackupNoSQL.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Back up a NoSQL database in a Kubernetes environment
 
 This guide explains how to create a transactionally consistent backup of managed databases that ScalarDB or ScalarDL uses in a Kubernetes environment. Please note that, when using a NoSQL database or multiple databases, you **must** pause ScalarDB or ScalarDL to create a transactionally consistent backup.

--- a/docs/3.4/scalar-kubernetes/BackupRDB.md
+++ b/docs/3.4/scalar-kubernetes/BackupRDB.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Back up an RDB in a Kubernetes environment
 
 This guide explains how to create a backup of a single relational database (RDB) that ScalarDB or ScalarDL uses in a Kubernetes environment. Please note that this guide assumes that you are using a managed database from a cloud services provider.

--- a/docs/3.4/scalar-kubernetes/BackupRestoreGuide.md
+++ b/docs/3.4/scalar-kubernetes/BackupRestoreGuide.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Back up and restore ScalarDB or ScalarDL data in a Kubernetes environment
 
 This guide explains how to backup and restore ScalarDB or ScalarDL data in a Kubernetes environment. Please note that this guide assumes that you are using a managed database from a cloud services provider as the backend database for ScalarDB or ScalarDL. The following is a list of the managed databases that this guide assumes you might be using:

--- a/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarProducts.md
+++ b/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarProducts.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Guidelines for creating an AKS cluster for Scalar products
 
 To create an Azure Kubernetes Service (AKS) cluster for Scalar products, refer to the following:

--- a/docs/3.4/scalar-kubernetes/CreateBastionServer.md
+++ b/docs/3.4/scalar-kubernetes/CreateBastionServer.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Create a bastion server
 
 This document explains how to create a bastion server and install some tools for the deployment of Scalar products.

--- a/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
+++ b/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Guidelines for creating an Amazon EKS cluster for Scalar products
 
 To create an Amazon Elastic Kubernetes Service (EKS) cluster for Scalar products, refer to the following:

--- a/docs/3.4/scalar-kubernetes/K8sLogCollectionGuide.md
+++ b/docs/3.4/scalar-kubernetes/K8sLogCollectionGuide.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Collecting logs from Scalar products on a Kubernetes cluster
 
 This document explains how to deploy Grafana Loki and Promtail on Kubernetes with Helm. After following this document, you can collect logs of Scalar products on your Kubernetes environment.

--- a/docs/3.4/scalar-kubernetes/K8sMonitorGuide.md
+++ b/docs/3.4/scalar-kubernetes/K8sMonitorGuide.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Monitoring Scalar products on a Kubernetes cluster
 
 This document explains how to deploy Prometheus Operator on Kubernetes with Helm. After following this document, you can use Prometheus, Alertmanager, and Grafana for monitoring Scalar products on your Kubernetes environment.

--- a/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDBServerOnAKS.md
+++ b/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDBServerOnAKS.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Deploy ScalarDB Server on Azure Kubernetes Service (AKS)
 
 This guide explains how to deploy ScalarDB Server on Azure Kubernetes Service (AKS).

--- a/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDBServerOnEKS.md
+++ b/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDBServerOnEKS.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Deploy ScalarDB Server on Amazon Elastic Kubernetes Service (EKS)
 
 This guide explains how to deploy ScalarDB Server on Amazon Elastic Kubernetes Service (EKS).

--- a/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLAuditorOnAKS.md
+++ b/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLAuditorOnAKS.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Deploy ScalarDL Ledger and ScalarDL Auditor on Azure Kubernetes Service (AKS)
 
 This guide explains how to deploy ScalarDL Ledger and ScalarDL Auditor on Azure Kubernetes Service (AKS).

--- a/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLAuditorOnEKS.md
+++ b/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLAuditorOnEKS.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Deploy ScalarDL Ledger and ScalarDL Auditor on Amazon Elastic Kubernetes Service (EKS)
 
 This guide explains how to deploy ScalarDL Ledger and ScalarDL Auditor on Amazon Elastic Kubernetes Service (EKS).

--- a/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLOnAKS.md
+++ b/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLOnAKS.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Deploy ScalarDL Ledger on Azure Kubernetes Service (AKS)
 
 This document explains how to deploy **ScalarDL Ledger** on Azure Kubernetes Service (AKS).

--- a/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLOnEKS.md
+++ b/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLOnEKS.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Deploy ScalarDL Ledger on Amazon Elastic Kubernetes Service (EKS)
 
 This document explains how to deploy **ScalarDL Ledger** on Amazon Elastic Kubernetes Service (EKS).

--- a/docs/3.4/scalar-kubernetes/NetworkPeeringForScalarDLAuditor.md
+++ b/docs/3.4/scalar-kubernetes/NetworkPeeringForScalarDLAuditor.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Configure Network Peering for ScalarDL Auditor Mode
 
 This document explains how to connect multiple private networks for ScalarDL Auditor mode to perform network peering. For ScalarDL Auditor mode to work properly, you must connect ScalarDL Ledger to ScalarDL Auditor.

--- a/docs/3.4/scalar-kubernetes/RegularCheck.md
+++ b/docs/3.4/scalar-kubernetes/RegularCheck.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Components to Regularly Check When Running in a Kubernetes Environment
 
 Most of the components deployed by manual deployment guides are self-healing with the help of the managed Kubernetes services and Kubernetes self-healing capability. There are also configured alerts that occur when some unexpected behavior happens. Thus, there shouldn't be so many things to do day by day for the deployment of Scalar products on the managed Kubernetes cluster. However, it is recommended to check the status of a system on a regular basis to see if everything is working fine. Here is the list of things you might want to do on a regular basis.

--- a/docs/3.4/scalar-kubernetes/RestoreDatabase.md
+++ b/docs/3.4/scalar-kubernetes/RestoreDatabase.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Restore databases in a Kubernetes environment
 
 This guide explains how to restore databases that ScalarDB or ScalarDL uses in a Kubernetes environment. Please note that this guide assumes that you are using a managed database from a cloud services provider as the backend database for ScalarDB or ScalarDL.

--- a/docs/3.4/scalar-kubernetes/SetupDatabaseForAWS.md
+++ b/docs/3.4/scalar-kubernetes/SetupDatabaseForAWS.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Set up a database for ScalarDB/ScalarDL deployment on AWS
 
 This guide explains how to set up a database for ScalarDB/ScalarDL deployment on AWS.

--- a/docs/3.4/scalar-kubernetes/SetupDatabaseForAzure.md
+++ b/docs/3.4/scalar-kubernetes/SetupDatabaseForAzure.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Set up a database for ScalarDB/ScalarDL deployment on Azure
 
 This guide explains how to set up a database for ScalarDB/ScalarDL deployment on Azure.

--- a/docs/3.4/scalar-kubernetes/deploy-kubernetes.md
+++ b/docs/3.4/scalar-kubernetes/deploy-kubernetes.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Deploying ScalarDB on Managed Kubernetes Services
 
 The following documentation is to help you set up and deploy a ScalarDB environment on managed Kubernetes services.

--- a/docs/3.4/scalar-kubernetes/manage-kubernetes.md
+++ b/docs/3.4/scalar-kubernetes/manage-kubernetes.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Managing ScalarDB on Managed Kubernetes Services
 
 The following documentation is to help you manage a ScalarDB environment on managed Kubernetes services.

--- a/docs/3.4/scalardb-benchmarks/README.md
+++ b/docs/3.4/scalardb-benchmarks/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # ScalarDB Benchmarks
 
 This repository contains benchmark programs for ScalarDB.

--- a/docs/3.4/scalardb-cluster/index.md
+++ b/docs/3.4/scalardb-cluster/index.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # ScalarDB Cluster
 
 ScalarDB Cluster is a distributed transaction state manager for ScalarDB.

--- a/docs/3.4/scalardb-data-loader/getting-started-export.md
+++ b/docs/3.4/scalardb-data-loader/getting-started-export.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting started with Export
 
 This document explains how you can get started with the Scalar DB Data Loader Export function.

--- a/docs/3.4/scalardb-data-loader/getting-started-import.md
+++ b/docs/3.4/scalardb-data-loader/getting-started-import.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Getting started with Import
 
 This document explains how you can get started with the Scalar DB Data Loader Import function.

--- a/docs/3.4/scalardb-samples/README.md
+++ b/docs/3.4/scalardb-samples/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # ScalarDB Samples
 
 This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):

--- a/docs/3.4/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.4/scalardb-samples/microservice-transaction-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Microservice Transaction Sample
 
 This tutorial describes how to create a sample application for Microservice Transaction that uses Two-phase Commit Transactions in ScalarDB.

--- a/docs/3.4/scalardb-samples/multi-storage-transaction-sample/README.md
+++ b/docs/3.4/scalardb-samples/multi-storage-transaction-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Multi-storage Transaction Sample
 
 This tutorial describes how to create a sample application by using ScalarDB with Multi-storage Transactions.

--- a/docs/3.4/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
+++ b/docs/3.4/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Sample Application for ScalarDB Analytics with PostgreSQL
 
 This tutorial describes how to create a sample application for ScalarDB Analytics with PostgreSQL.

--- a/docs/3.4/scalardb-samples/scalardb-graphql-sample/README.md
+++ b/docs/3.4/scalardb-samples/scalardb-graphql-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # ScalarDB GraphQL Sample
 
 This sample application is a simple CLI electronic money application that has the following features:

--- a/docs/3.4/scalardb-samples/scalardb-sample/README.md
+++ b/docs/3.4/scalardb-samples/scalardb-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # ScalarDB Sample
 
 This tutorial describes how to create a sample application by using ScalarDB.

--- a/docs/3.4/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.4/scalardb-samples/scalardb-server-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
 For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md).

--- a/docs/3.4/scalardb-samples/scalardb-sql-jdbc-sample/README.md
+++ b/docs/3.4/scalardb-samples/scalardb-sql-jdbc-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # ScalarDB SQL (JDBC) Sample
 
 This tutorial describes how to create a sample application by using ScalarDB SQL (JDBC).

--- a/docs/3.4/scalardb-samples/spring-data-microservice-transaction-sample/README.md
+++ b/docs/3.4/scalardb-samples/spring-data-microservice-transaction-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Sample application of Spring Data JDBC for ScalarDB with Microservice Transactions
 
 This tutorial describes how to create a sample Spring Boot application for microservice transactions by using Spring Data JDBC for ScalarDB.

--- a/docs/3.4/scalardb-samples/spring-data-multi-storage-transaction-sample/README.md
+++ b/docs/3.4/scalardb-samples/spring-data-multi-storage-transaction-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Sample application of Spring Data JDBC for ScalarDB with Multi-storage Transactions
 
 This tutorial describes how to create a sample Spring Boot application by using Spring Data JDBC for ScalarDB with Multi-storage Transactions.

--- a/docs/3.4/scalardb-samples/spring-data-sample/README.md
+++ b/docs/3.4/scalardb-samples/spring-data-sample/README.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Sample application of Spring Data JDBC for ScalarDB
 
 This tutorial describes how to create a sample Spring Boot application by using Spring Data JDBC for ScalarDB.

--- a/docs/3.4/scalardb-server.md
+++ b/docs/3.4/scalardb-server.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Scalar DB server
 
 Scalar DB server is a gRPC server that implements Scalar DB interface. 

--- a/docs/3.4/schema.md
+++ b/docs/3.4/schema.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Database schema in Scalar DB
 
 Scalar DB has its own data model and schema, that maps to the implementation specific data model and schema.

--- a/docs/3.4/two-phase-commit-transactions.md
+++ b/docs/3.4/two-phase-commit-transactions.md
@@ -1,3 +1,5 @@
+{% include end-of-support.html %}
+
 # Two-phase Commit Transactions
 
 Scalar DB also supports two-phase commit style transactions called *Two-phase Commit Transactions*.


### PR DESCRIPTION
## Description

This PR:

- Adds an out-of-support banner to the top of ScalarDB 3.4 docs.
- Updates the link in the out-of-support banner.

### Related issue or PR

N/A

### Type of change

- [x] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

**Please describe the tests that you ran to verify your changes and provide instructions so that we can reproduce. Please also list any relevant details for your test configuration.**

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, and confirmed that the out-of-support banner appeared as expected on version 3.4 docs only.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
