### PR TITLE
Fix code block formatting in Scalar Helm Charts docs

### DIFF
--- a/docs/3.10/helm-charts/ReleaseFlow.md
+++ b/docs/3.10/helm-charts/ReleaseFlow.md
@@ -1,22 +1,28 @@
 # Release Flow
 
 ## Requirements
+
 | Name | Version | Mandatory | link |
 |:------|:-------|:----------|:------|
 | Helm | 3.2.1 or latest | no | https://helm.sh/docs/intro/install/ |
 
 ## Release
+
 * You create a branch (`prepare-release-*`).
 * You make sure to create the tag from the previous version of the target version.
+
 ``` console
 $ git checkout -b prepare-release-v3.0.2  refs/tags/scalardl-3.0.1
 ```
 
 * You need to set the `version` of the `Chart.yaml` of each `helm-charts` to the version to be released.
+
 ``` yaml
 version: 3.0.2
 ```
+
 * Pushing commits to a remote repository.
+
 ``` console
 $ git push origin prepare-release-v3.0.2
 ```

--- a/docs/3.10/helm-charts/configure-custom-values-envoy.md
+++ b/docs/3.10/helm-charts/configure-custom-values-envoy.md
@@ -9,6 +9,7 @@ The Scalar Envoy chart is used via other charts (scalardb, scalardl, and scalard
 For example, if you want to configure the Scalar Envoy for ScalarDB Server, you can configure some Scalar Envoy configurations in the custom values file of ScalarDB as follows.
 
 * Example (scalardb-custom-values.yaml)
+
   ```yaml
   envoy:
     configurationsForScalarEnvoy: 

--- a/docs/3.10/helm-charts/configure-custom-values-file.md
+++ b/docs/3.10/helm-charts/configure-custom-values-file.md
@@ -5,4 +5,8 @@ When you deploy Scalar products using Scalar Helm Charts, you must prepare your 
 * [ScalarDB Server](./configure-custom-values-scalardb.md)
 * [ScalarDB GraphQL](./configure-custom-values-scalardb-graphql.md)
 * [ScalarDB Cluster](./configure-custom-values-scalardb-cluster.md)
+* [ScalarDL Ledger](./configure-custom-values-scalardl-ledger.md)
+* [ScalarDL Auditor](./configure-custom-values-scalardl-auditor.md)
+* [ScalarDL Schema Loader](./configure-custom-values-scalardl-schema-loader.md)
+* [Scalar Manager](./configure-custom-values-scalar-manager.md)
 * [Envoy](./configure-custom-values-envoy.md)

--- a/docs/3.10/helm-charts/getting-started-logging.md
+++ b/docs/3.10/helm-charts/getting-started-logging.md
@@ -47,11 +47,13 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 2. Deploy `loki-stack`
 
 1. Add the `grafana` helm repository.
+
    ```console
    helm repo add grafana https://grafana.github.io/helm-charts
    ```
 
 1. Deploy the `loki-stack` helm chart.
+
    ```console
    helm install scalar-logging-loki grafana/loki-stack -n monitoring -f scalar-loki-stack-custom-values.yaml
    ```
@@ -59,6 +61,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 3. Add a Loki data source in the Grafana configuration
 
 1. Add a configuration of the Loki data source in the `scalar-prometheus-custom-values.yaml` file.
+
    ```yaml
    grafana:
      additionalDataSources:
@@ -72,6 +75,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
    ```
 
 1. Apply the configuration (upgrade the deployment of `kube-prometheus-stack`).
+
    ```console
    helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -86,6 +90,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 5. Delete the `loki-stack` helm chart
 
 1. Uninstall `loki-stack`.
+
    ```console
    helm uninstall scalar-logging-loki -n monitoring
    ```

--- a/docs/3.10/helm-charts/getting-started-monitoring.md
+++ b/docs/3.10/helm-charts/getting-started-monitoring.md
@@ -45,6 +45,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * `grafana.service.type` to `LoadBalancer`
        * `grafana.service.port` to `3000`
    * Example
+
      ```yaml
      alertmanager:
      
@@ -68,6 +69,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
      
      ...
      ```
+
    * Note:
        * If you want to customize the Prometheus Operator deployment using Helm Charts, you need to set the following configuration for monitoring Scalar products.
            * The `serviceMonitorSelectorNilUsesHelmValues` and `ruleSelectorNilUsesHelmValues` must be set to `false` (`true` by default) to make Prometheus Operator detects `ServiceMonitor` and `PrometheusRule` of Scalar products.
@@ -75,23 +77,26 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 ## Step 3. Deploy `kube-prometheus-stack`
 
 1. Add the `prometheus-community` helm repository.
+
    ```console
    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
    ```
 
 1. Create a namespace `monitoring` on the Kubernetes.
+
    ```console
    kubectl create namespace monitoring
    ```
 
 1. Deploy the `kube-prometheus-stack`.
+
    ```console
    helm install scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
 
 ## Step 4. Deploy (or Upgrade) Scalar products using Helm Charts
 
-* Note: 
+* Note:
    * The following explains the minimum steps. If you want to know more details about the deployment of ScalarDB and ScalarDL, please refer to the following documents.
        * [Getting Started with Helm Charts (ScalarDB Server)](./getting-started-scalardb.md)
        * [Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)](./getting-started-scalardl-ledger.md)
@@ -104,6 +109,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * `*.serviceMonitor.enabled`
    * Sample configuration files
        * ScalarDB (scalardb-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -121,7 +127,9 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            serviceMonitor:
              enabled: true
          ```
+
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -139,7 +147,9 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            serviceMonitor:
              enabled: true
          ```
+
        * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -161,23 +171,31 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 1. Deploy (or Upgrade) Scalar products using Helm Charts with the above custom values file.
    * Examples
        * ScalarDB
+
          ```console
          helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
+
        * ScalarDL Ledger
+
          ```console
          helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
+
        * ScalarDL Auditor
+
          ```console
          helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
@@ -187,15 +205,19 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 ### If you use minikube
 
 1. To expose each service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
+
    ```console
    minikube tunnel
    ```
 
    After running the `minikube tunnel` command, you can see the EXTERNAL-IP of each service resource as `127.0.0.1`.
+
    ```console
    kubectl get svc -n monitoring scalar-monitoring-kube-pro-prometheus scalar-monitoring-kube-pro-alertmanager scalar-monitoring-grafana
    ```
+
    [Command execution result]
+
    ```console
    NAME                                      TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
    scalar-monitoring-kube-pro-prometheus     LoadBalancer   10.98.11.12    127.0.0.1     9090:30550/TCP   26m
@@ -205,24 +227,33 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 
 1. Access each Dashboard.
    * Prometheus
+
      ```console
      http://localhost:9090/
      ```
+
    * Alertmanager
+
      ```console
      http://localhost:9093/
      ```
+
    * Grafana
+
      ```console
      http://localhost:3000/
      ```
+
        * Note:
            * You can see the user and password of Grafana as follows.
                * user
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-user}' | base64 -d
                  ```
+
                * password
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```
@@ -236,18 +267,22 @@ If you use a Kubernetes cluster other than minikube, you need to access the Load
 After completing the Monitoring tests on the Kubernetes cluster, remove all resources.
 
 1. Terminate the `minikube tunnel` command. (If you use minikube)
+
    ```console
    Ctrl + C
    ```
 
 1. Uninstall `kube-prometheus-stack`.
+
    ```console
    helm uninstall scalar-monitoring -n monitoring
    ```
 
 1. Delete minikube. (Optional / If you use minikube)
+
    ```console
    minikube delete --all
    ```
+
    * Note:
        * If you deploy the ScalarDB or ScalarDL, you need to remove them before deleting minikube.

--- a/docs/3.10/helm-charts/getting-started-scalar-helm-charts.md
+++ b/docs/3.10/helm-charts/getting-started-scalar-helm-charts.md
@@ -28,15 +28,19 @@ First, you need to install the following tools used in this guide.
 ## Step 2. Start minikube with docker driver (Optional / If you use minikube)
 
 1. Start minikube.
+
    ```console
    minikube start
    ```
 
 1. Check the status of the minikube and pods.
+
    ```console
    kubectl get pod -A
    ```
+
    [Command execution result]
+
    ```console
    NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
    kube-system   coredns-64897985d-lbsfr            1/1     Running   1 (20h ago)   21h
@@ -47,9 +51,10 @@ First, you need to install the following tools used in this guide.
    kube-system   kube-scheduler-minikube            1/1     Running   1 (20h ago)   21h
    kube-system   storage-provisioner                1/1     Running   2 (19s ago)   21h
    ```
+
    If the minikube starts properly, you can see some pods are **Running** in the kube-system namespace.
 
-## Step 3. 
+## Step 3.
 
 After the Kubernetes cluster starts, you can try each Scalar Helm Charts on it. Please refer to the following documents for more details.
 

--- a/docs/3.10/helm-charts/getting-started-scalar-manager.md
+++ b/docs/3.10/helm-charts/getting-started-scalar-manager.md
@@ -64,6 +64,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 1. Upgrade the `kube-prometheus-stack` to allow Grafana to be embedded
 
 1. Add or revise this value to the custom values file (e.g. scalar-prometheus-custom-values.yaml) of the `kube-prometheus-stack`
+
    ```yaml
    grafana:
      grafana.ini:
@@ -73,6 +74,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
    ```
 
 1. Upgrade the Helm installation
+
    ```console
    helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -82,6 +84,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 1. Get the sample file [scalar-manager-custom-values.yaml](./conf/scalar-manager-custom-values.yaml) for `scalar-manager`.
 
 1. Add the targets that you would like to manage. For example, if we want to manage a ledger cluster, then we can add the values as follows.
+
    ```yaml
    scalarManager:
      targets:
@@ -89,21 +92,25 @@ We will deploy the following components on a Kubernetes cluster as follows.
          adminSrv: _scalardl-admin._tcp.scalardl-headless.default.svc.cluster.local
          databaseType: cassandra
    ```
+
    Note: the `adminSrv` is the DNS Service URL that returns SRV record of pods. Kubernetes creates this URL for the named port of the headless service of the Scalar product. The format is `_{port name}._{protocol}.{service name}.{namespace}.svc.{cluster domain name}`
 
 1. Set the Grafana URL. For example, if your Grafana of the `kube-prometheus-stack` is exposed in `localhost:3000`, then we can set it as follows.
+
    ```yaml
    scalarManager:
      grafanaUrl: "http://localhost:3000"
    ```
 
 1. Set the refresh interval that Scalar Manager checks the status of the products. The default value is `30` seconds, but we can change it like:
+
    ```yaml
    scalarManager:
      refreshInterval: 60 # one minute
    ```
 
 1. Set the service type to access Scalar Manager. The default value is `ClusterIP`, but if we access using the `minikube tunnel` command or some load balancer, we can set it as `LoadBalancer`.
+
    ```yaml
    service:
      type: LoadBalancer
@@ -112,11 +119,13 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 3. Deploy `scalar-manager`
 
 1. Create a secret resource `reg-docker-secrets` to pull the Scalar Manager container image from GitHub Packages.
+
    ```console
    kubectl create secret docker-registry reg-docker-secrets --docker-server=ghcr.io --docker-username=<github-username> --docker-password=<github-personal-access-token>
    ```
 
 1. Deploy the `scalar-manager` Helm Chart.
+
    ```console
    helm install scalar-manager scalar-labs/scalar-manager -f scalar-manager-custom-values.yaml
    ```
@@ -126,6 +135,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ### If you use minikube
 
 1. To expose Scalar Manager's service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
+
    ```console
    minikube tunnel
    ```
@@ -138,6 +148,7 @@ If you use a Kubernetes cluster other than minikube, you need to access the Load
 
 ## Step 5. Delete Scalar Manager
 1. Uninstall `scalar-manager`
+
    ```console
    helm uninstall scalar-manager
    ```

--- a/docs/3.10/helm-charts/getting-started-scalardb.md
+++ b/docs/3.10/helm-charts/getting-started-scalardb.md
@@ -44,11 +44,13 @@ ScalarDB uses some kind of database system as a backend database. In this docume
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL.
+
    ```console
    helm install postgresql-scalardb bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -56,10 +58,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL container is running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                    READY   STATUS    RESTARTS   AGE
    postgresql-scalardb-0   1/1     Running   0          2m42s
@@ -68,19 +73,23 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 ## Step 3. Deploy ScalarDB Server on the Kubernetes cluster using Helm Charts
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDB container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -89,12 +98,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
 
    Please refer to the following documents for more details.
-   
+
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 1. Create a custom values file for ScalarDB Server (scalardb-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -118,7 +128,9 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -144,6 +156,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
 
 1. Create a Secret resource that includes a username and password for PostgreSQL.
+
    ```console
    kubectl create secret generic scalardb-credentials-secret \
      --from-literal=SCALAR_DB_POSTGRES_USERNAME=postgres \
@@ -151,15 +164,19 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Deploy ScalarDB Server.
+
    ```console
    helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
    ```
 
 1. Check if the ScalarDB Server pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                              READY   STATUS    RESTARTS   AGE
    postgresql-scalardb-0             1/1     Running   0          9m48s
@@ -170,13 +187,17 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    scalardb-envoy-84c475f77b-n74tk   1/1     Running   0          6s
    scalardb-envoy-84c475f77b-zbrwz   1/1     Running   0          6s
    ```
+
    If the ScalarDB Server Pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDB Server services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
    kubernetes               ClusterIP   10.96.0.1        <none>        443/TCP     47d
@@ -187,20 +208,25 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    scalardb-headless        ClusterIP   None             <none>        60051/TCP   41s
    scalardb-metrics         ClusterIP   10.108.188.10    <none>        8080/TCP    41s
    ```
+
    If the ScalarDB Server services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardb-headless` has no CLUSTER-IP.)  
 
 ## Step 4. Start a Client container
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    kubectl run scalardb-client --image eclipse-temurin:8 --command sleep inf
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardb-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardb-client   1/1     Running   0          23s
@@ -211,66 +237,86 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 The following explains the minimum steps. If you want to know more details about ScalarDB, please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardb-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git and curl commands in the Client container.
+
    ```console
    apt update && apt install -y git curl
    ```
 
 1. Clone ScalarDB git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardb.git
    ```
 
 1. Change the directory to `scalardb/`.
+
    ```console
    cd scalardb/
    ```
+
    ```console
    pwd
    ```
+
    [Command execution result]
+
    ```console
    /scalardb
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.7.0 refs/tags/v3.7.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
+
    ```console
      master
    * v3.7.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use.
 
 1. Change the directory to `docs/getting-started/`.
+
    ```console
    cd docs/getting-started/
    ```
+
    ```console
    pwd
    ```
+
    [Command execution result]
+
    ```console
    /scalardb/docs/getting-started
    ```
 
 1. Download Schema Loader from [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardb/releases/download/v3.7.0/scalardb-schema-loader-3.7.0.jar
    ```
+
    You need to use the same version of ScalarDB and Schema Loader.
 
 1. Create a configuration file (scalardb.properties) to access ScalarDB Server on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > scalardb.properties
    scalar.db.contact_points=scalardb-envoy.default.svc.cluster.local
@@ -281,6 +327,7 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Create a JSON file (emoney-transaction.json) that defines DB Schema for the sample applications.
+
    ```console
    cat << 'EOF' > emoney-transaction.json
    {
@@ -300,37 +347,50 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Run Schema Loader (Create sample TABLE).
+
    ```console
    java -jar ./scalardb-schema-loader-3.7.0.jar --config ./scalardb.properties -f emoney-transaction.json --coordinator
    ```
 
 1. Run the sample applications.
    * Charge `1000` to `user1`:
+
      ```console
      ./gradlew run --args="-action charge -amount 1000 -to user1"
      ```
+
    * Charge `0` to `merchant1` (Just create an account for `merchant1`):
+
      ```console
      ./gradlew run --args="-action charge -amount 0 -to merchant1"
      ```
+
    * Pay `100` from `user1` to `merchant1`:
+
      ```console
      ./gradlew run --args="-action pay -amount 100 -from user1 -to merchant1"
      ```
+
    * Get the balance of `user1`:
+
      ```console
      ./gradlew run --args="-action getBalance -id user1"
      ```
+
    * Get the balance of `merchant1`:
+
      ```console
      ./gradlew run --args="-action getBalance -id merchant1"
      ```
 
 1. (Optional) You can see the inserted and modified (INSERT/UPDATE) data through the sample applications using the following command. (This command needs to run on your localhost, not on the Client container.)  
+
    ```console
    kubectl exec -it postgresql-scalardb-0 -- bash -c 'export PGPASSWORD=postgres && psql -U postgres -d postgres -c "SELECT * FROM emoney.account"'
    ```
+
    [Command execution result]
+
    ```sql
        id     | balance |                tx_id                 | tx_state | tx_version | tx_prepared_at | tx_committed_at |             before_tx_id             | before_tx_state | before_tx_version | before_tx_prepared_at | before_tx_committed_at | before_balance
    -----------+---------+--------------------------------------+----------+------------+----------------+-----------------+--------------------------------------+-----------------+-------------------+-----------------------+------------------------+----------------
@@ -338,6 +398,7 @@ The following explains the minimum steps. If you want to know more details about
     user1     |     900 | 65a90225-0846-4e97-b729-151f76f6ca2f |        3 |          2 |  1667361909634 |1667361909679    | 5520cba4-625a-4886-b81f-6089bf846d18 |               3 |                 1 |         1667361897283 |          1667361897317 |           1000
    (2 rows)
    ```
+
    * Note:
        * Usually, you need to access data (records) through ScalarDB. The above command is used to explain and confirm the working of the sample applications.
 
@@ -346,12 +407,14 @@ The following explains the minimum steps. If you want to know more details about
 After completing the ScalarDB Server tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDB Server and PostgreSQL.
+
    ```console
    helm uninstall scalardb postgresql-scalardb
    ```
 
 1. Remove the Client container.
-   ```
+
+   ```console
    kubectl delete pod scalardb-client --force --grace-period 0
    ```
 

--- a/docs/3.10/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/3.10/helm-charts/getting-started-scalardl-auditor.md
@@ -72,11 +72,13 @@ ScalarDL Ledger and Auditor use some kind of database system as a backend databa
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL for Ledger.
+
    ```console
    helm install postgresql-ledger bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -84,6 +86,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Deploy PostgreSQL for Auditor.
+
    ```console
    helm install postgresql-auditor bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -91,10 +94,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL containers are running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                   READY   STATUS    RESTARTS   AGE
    postgresql-auditor-0   1/1     Running   0          11s
@@ -106,6 +112,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 We will create some configuration files and key/certificate files locally. So, create a working directory for them.
 
 1. Create a working directory.
+
    ```console
    mkdir -p ~/scalardl-test/certs/
    ```
@@ -115,11 +122,13 @@ We will create some configuration files and key/certificate files locally. So, c
 Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
 1. Change the working directory to `~/scalardl-test/certs/` directory.
+
    ```console
    cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
@@ -143,6 +152,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Auditor information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/auditor.json
    {
@@ -166,6 +176,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Client information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
@@ -189,25 +200,31 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create key/certificate files for the Ledger.
+
    ```console
    cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Auditor.
+
    ```console
    cfssl selfsign "" ./auditor.json | cfssljson -bare auditor
    ```
 
 1. Create key/certificate files for the Client.
+
    ```console
    cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
+
    ```console
    ls -1
    ```
+
    [Command execution result]
+
    ```console
    auditor-key.pem
    auditor.csr
@@ -229,24 +246,29 @@ We will deploy two ScalarDL Schema Loader pods on the Kubernetes cluster using H
 The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Auditor in PostgreSQL.  
 
 1. Change the working directory to `~/scalardl-test/`.
+
    ```console
    cd ~/scalardl-test/
    ```
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -255,12 +277,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
    Please refer to the following documents for more details.
-   
+
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 1. Create a custom values file for ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -278,7 +301,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -299,6 +324,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 
 1. Create a custom values file for ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -316,7 +342,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -336,6 +364,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Ledger.
+
    ```console
    kubectl create secret generic ledger-credentials-secret \
      --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
@@ -343,6 +372,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Auditor.
+
    ```console
    kubectl create secret generic auditor-credentials-secret \
      --from-literal=SCALAR_DL_AUDITOR_POSTGRES_USERNAME=postgres \
@@ -350,20 +380,25 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    ```
 
 1. Deploy the ScalarDL Schema Loader for Ledger.
+
    ```console
    helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Deploy the ScalarDL Schema Loader for Auditor.
+
    ```console
    helm install schema-loader-auditor scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Schema Loader pods are deployed and completed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
    postgresql-auditor-0                         1/1     Running     0          2m56s
@@ -371,12 +406,14 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          6s
    schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          10s
    ```
+
    If the ScalarDL Schema Loader pods are **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
 ## Step 6. Deploy ScalarDL Ledger and Auditor on the Kubernetes cluster using Helm Charts
 
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -411,7 +448,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -448,6 +487,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 
 1. Create a custom values file for ScalarDL Auditor (scalardl-auditor-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -482,7 +522,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -519,30 +561,37 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
 1. Create secret resource `ledger-keys`.
+
    ```console
    kubectl create secret generic ledger-keys --from-file=certificate=./certs/ledger.pem --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Create secret resource `auditor-keys`.
+
    ```console
    kubectl create secret generic auditor-keys --from-file=certificate=./certs/auditor.pem --from-file=private-key=./certs/auditor-key.pem
    ```
 
 1. Deploy the ScalarDL Ledger.
+
    ```console
    helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Deploy the ScalarDL Auditor.
+
    ```console
    helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Ledger and Auditor pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
    postgresql-auditor-0                         1/1     Running     0          14m
@@ -562,13 +611,17 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          11m
    schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          11m
    ```
+
    If the ScalarDL Ledger and Auditor pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDL Ledger and Auditor services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                             TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
    kubernetes                       ClusterIP   10.96.0.1        <none>        443/TCP                         47d
@@ -585,6 +638,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    scalardl-ledger-headless         ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   61s
    scalardl-ledger-metrics          ClusterIP   10.99.122.106    <none>        8080/TCP                        61s
    ```
+
    If the ScalarDL Ledger and Auditor services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` and `scalardl-auditor-headless` have no CLUSTER-IP.)  
 
 ## Step 7. Start a Client container
@@ -592,11 +646,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
 
 1. Create secret resource `client-keys`.
-   ```
+
+   ```console
    kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
@@ -634,10 +690,13 @@ We will use certificate files in a Client container. So, we create a secret reso
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardl-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardl-client   1/1     Running   0          4s
@@ -652,65 +711,82 @@ The following explains the minimum steps. If you want to know more details about
 When you use Auditor, you need to register the certificate for the Ledger and Auditor before starting the client application. Ledger needs to register its certificate to Auditor, and Auditor needs to register its certificate to Ledger.
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardl-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git, curl and unzip commands in the Client container.
+
    ```console
    apt update && apt install -y git curl unzip
    ```
 
 1. Clone ScalarDL Java Client SDK git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change the directory to `scalardl-java-client-sdk/`.
+
    ```console
    cd scalardl-java-client-sdk/
    ```
+
    ```console
    pwd
    ```
-   [Command execution result]
-   ```console
 
+   [Command execution result]
+
+   ```console
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
+
    ```console
      master
    * v3.6.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
 1. Build the sample contracts.
+
    ```console
    ./gradlew assemble
    ```
 
 1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
+
    You need to use the same version of CLI tools and ScalarDL Ledger.
 
 1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
+
    ```console
    unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (ledger.as.client.properties) to register the certificate of Ledger to Auditor.
+
    ```console
    cat << 'EOF' > ledger.as.client.properties
    # Ledger
@@ -728,6 +804,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Create a configuration file (auditor.as.client.properties) to register the certificate of Auditor to Ledger.
+
    ```console
    cat << 'EOF' > auditor.as.client.properties
    # Ledger
@@ -745,6 +822,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > client.properties
    # Ledger
@@ -762,46 +840,57 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Register the certificate file of Ledger.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./ledger.as.client.properties
    ```
 
 1. Register the certificate file of Auditor.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./auditor.as.client.properties
    ```
 
 1. Register the certificate file of client.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./client.properties
    ```
 
 1. Register the sample contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Register the contract `ValdateLedger` to execute a validate request.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id validate-ledger --contract-binary-name com.scalar.dl.client.contract.ValidateLedger --contract-class-file ./build/classes/java/main/com/scalar/dl/client/contract/ValidateLedger.class
    ```
 
 1. Execute the contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
+
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    ```
+
    [Command execution result]
+
    ```console
    Contract result:
    {
@@ -812,23 +901,29 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
      }
    }
    ```
+
    * Reference information
       * If the asset data is not tampered with, the contract execution request (execute-contract command) returns `OK` as a result.
       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the contract execution request (execute-contract command) returns a value other than `OK`  (e.g. `INCONSISTENT_STATES`) as a result, like the following.  
         [Command execution result (If the asset data is tampered with)]
+
         ```console
         {
           "status_code" : "INCONSISTENT_STATES",
           "error_message" : "The results from Ledger and Auditor don't match"
         }
         ```
+
           * In this way, the ScalarDL can detect data tampering.
 
 1. Execute a validation request for the asset.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
+
    [Command execution result]
+
    ```console
    {
      "status_code" : "OK",
@@ -848,16 +943,19 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
      }
    }
    ```
+
    * Reference information
       * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
         [Command execution result (If the asset data is tampered with)]
+
         ```console
         {
           "status_code" : "INCONSISTENT_STATES",
           "error_message" : "The results from Ledger and Auditor don't match"
         }
         ```
+
           * In this way, the ScalarDL Ledger can detect data tampering.
 
 ## Step 9. Delete all resources
@@ -865,19 +963,23 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
 After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
+
    ```console
    helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger scalardl-auditor schema-loader-auditor postgresql-auditor
    ```
 
 1. Remove the Client container.
+
    ```
    kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
 1. Remove the working directory and sample files (configuration file, key, and certificate).
+
    ```console
    cd ~
    ```
+   
    ```console
    rm -rf ~/scalardl-test/
    ```

--- a/docs/3.10/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/3.10/helm-charts/getting-started-scalardl-ledger.md
@@ -54,11 +54,13 @@ ScalarDL Ledger uses some kind of database system as a backend database. In this
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL.
+
    ```console
    helm install postgresql-ledger bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -66,10 +68,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL container is running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                  READY   STATUS    RESTARTS   AGE
    postgresql-ledger-0   1/1     Running   0          11s
@@ -80,6 +85,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 We will create some configuration files and key/certificate files locally. So, create a working directory for them.
 
 1. Create a working directory.
+
    ```console
    mkdir -p ~/scalardl-test/certs/
    ```
@@ -89,11 +95,13 @@ We will create some configuration files and key/certificate files locally. So, c
 Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
 1. Change the working directory to `~/scalardl-test/certs/` directory.
+
    ```console
    cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
@@ -117,6 +125,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Client information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
@@ -140,20 +149,25 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create key/certificate files for the Ledger.
+
    ```console
    cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Client.
+
    ```console
    cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
+
    ```console
    ls -1
    ```
+
    [Command execution result]
+
    ```console
    client-key.pem
    client.csr
@@ -171,24 +185,29 @@ We will deploy a ScalarDL Schema Loader on the Kubernetes cluster using Helm Cha
 The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in PostgreSQL.  
 
 1. Change the working directory to `~/scalardl-test/`.
+
    ```console
    cd ~/scalardl-test/
    ```
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -203,6 +222,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 
 1. Create a custom values file for ScalarDL Schema Loader (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -221,6 +241,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      EOF
      ```
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -240,6 +261,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL.
+
    ```console
    kubectl create secret generic ledger-credentials-secret \
      --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
@@ -247,26 +269,32 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    ```
 
 1. Deploy the ScalarDL Schema Loader.
+
    ```console
    helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Schema Loader pod is deployed and completed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    postgresql-ledger-0                         1/1     Running     0          11m
    schema-loader-ledger-schema-loading-46rcr   0/1     Completed   0          3s
    ```
+
    If the ScalarDL Schema Loader pod is **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
 ## Step 6. Deploy ScalarDL Ledger on the Kubernetes cluster using Helm Charts
 
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -300,7 +328,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -336,20 +366,25 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
 
 1. Create secret resource `ledger-keys`.
+
    ```console
    kubectl create secret generic ledger-keys --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Deploy the ScalarDL Ledger.
+
    ```console
    helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Ledger pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    postgresql-ledger-0                         1/1     Running     0          14m
@@ -361,13 +396,17 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    scalardl-ledger-ledger-9bdf7f8bd-9tw5x      1/1     Running     0          52s
    schema-loader-ledger-schema-loading-46rcr   0/1     Completed   0          3m38s
    ```
+
    If the ScalarDL Ledger pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDL Ledger services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
    kubernetes                      ClusterIP   10.96.0.1        <none>        443/TCP                         47d
@@ -378,6 +417,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    scalardl-ledger-headless        ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   83s
    scalardl-ledger-metrics         ClusterIP   10.98.4.217      <none>        8080/TCP                        83s
    ```
+
    If the ScalarDL Ledger services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` has no CLUSTER-IP.)  
 
 ## Step 7. Start a Client container
@@ -385,11 +425,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
 
 1. Create secret resource `client-keys`.
-   ```
+
+   ```console
    kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
@@ -415,10 +457,13 @@ We will use certificate files in a Client container. So, we create a secret reso
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardl-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardl-client   1/1     Running   0          11s
@@ -429,65 +474,81 @@ We will use certificate files in a Client container. So, we create a secret reso
 The following explains the minimum steps. If you want to know more details about ScalarDL and the contract, please refer to the [Getting Started with ScalarDL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md).
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardl-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git, curl and unzip commands in the Client container.
+
    ```console
    apt update && apt install -y git curl unzip
    ```
 
 1. Clone ScalarDL Java Client SDK git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change the directory to `scalardl-java-client-sdk/`.
+
    ```console
    cd scalardl-java-client-sdk/
    ```
+
    ```console
    pwd
    ```
-   [Command execution result]
-   ```console
 
+   [Command execution result]
+
+   ```console
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
    ```console
      master
    * v3.6.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
 1. Build the sample contracts.
+
    ```console
    ./gradlew assemble
    ```
 
 1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
+
    You need to use the same version of CLI tools and ScalarDL Ledger.
 
 1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
+
    ```console
    unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > client.properties
    scalar.dl.client.server.host=scalardl-ledger-envoy.default.svc.cluster.local
@@ -503,26 +564,32 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Register the sample contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Execute the contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    ```
+
    [Command execution result]
+
    ```console
    Contract result:
    {
@@ -535,10 +602,13 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Execute a validation request for the asset.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
+
    [Command execution result]
+
    ```console
    {
      "status_code" : "OK",
@@ -552,10 +622,12 @@ The following explains the minimum steps. If you want to know more details about
      "Auditor" : null
    }
    ```
+
    * Reference information
        * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
        * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
          [Command execution result (If the asset data is tampered with)]
+
          ```console
          {
            "status_code" : "INVALID_OUTPUT",
@@ -569,6 +641,7 @@ The following explains the minimum steps. If you want to know more details about
            "Auditor" : null
          }
          ```
+
            * In this way, the ScalarDL Ledger can detect data tampering.
 
 ## Step 9. Delete all resources
@@ -576,19 +649,23 @@ The following explains the minimum steps. If you want to know more details about
 After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
+
    ```console
    helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger
    ```
 
 1. Remove the Client container.
+
    ```
    kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
 1. Remove the working directory and sample files (configuration file, key, and certificate).
+
    ```console
    cd ~
    ```
+   
    ```console
    rm -rf ~/scalardl-test/
    ```

--- a/docs/3.10/helm-charts/how-to-deploy-scalar-products.md
+++ b/docs/3.10/helm-charts/how-to-deploy-scalar-products.md
@@ -15,6 +15,7 @@ You must install the helm command to use Scalar Helm Charts. Please install the 
 ```console
 helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
 ```
+
 ```console
 helm repo update scalar-labs
 ```
@@ -48,6 +49,9 @@ If you use a Kubernetes cluster other than EKS or AKS, you need to create a Secr
 
 Please refer to the following documents for more details on how to deploy each product.
 
+* [ScalarDB Server](./how-to-deploy-scalardb.md)
 * [ScalarDB GraphQL](./how-to-deploy-scalardb-graphql.md)
 * [ScalarDB Cluster](./how-to-deploy-scalardb-cluster.md)
+* [ScalarDL Ledger](./how-to-deploy-scalardl-ledger.md)
+* [ScalarDL Auditor](./how-to-deploy-scalardl-auditor.md)
 * [Scalar Manager](./how-to-deploy-scalar-manager.md)

--- a/docs/3.10/helm-charts/how-to-deploy-scalardb-cluster.md
+++ b/docs/3.10/helm-charts/how-to-deploy-scalardb-cluster.md
@@ -31,6 +31,7 @@ If you use ScalarDB Cluster with `direct-kubernetes` mode, you must:
 This method is necessary because the ScalarDB Cluster client library with `direct-kubernetes` mode runs the Kubernetes API from inside of your application pods to get information about the ScalarDB Cluster pods.
 
 * Role
+
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -42,7 +43,9 @@ This method is necessary because the ScalarDB Cluster client library with `direc
       resources: ["endpoints"]
       verbs: ["get", "watch", "list"]
   ```
+
 * RoleBinding
+
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
@@ -57,7 +60,9 @@ This method is necessary because the ScalarDB Cluster client library with `direc
     name: scalardb-cluster-role
     apiGroup: rbac.authorization.k8s.io
   ```
+
 * ServiceAccount
+
   ```yaml
   apiVersion: v1
   kind: ServiceAccount

--- a/docs/3.10/helm-charts/mount-files-or-volumes-on-scalar-pods.md
+++ b/docs/3.10/helm-charts/mount-files-or-volumes-on-scalar-pods.md
@@ -8,6 +8,7 @@ You must mount the key and certificate files to run ScalarDL Auditor.
 
 * Configuration example
     * ScalarDL Ledger
+
       ```yaml
       ledger:
         ledgerProperties: |
@@ -16,7 +17,9 @@ You must mount the key and certificate files to run ScalarDL Auditor.
           scalar.dl.ledger.auditor.enabled=true
           scalar.dl.ledger.proof.private_key_path=/keys/private-key
       ```
+
     * ScalarDL Auditor
+
       ```yaml
       auditor:
         auditorProperties: |
@@ -30,6 +33,7 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 1. Set `extraVolumes` and `extraVolumeMounts` in the custom values file using the same syntax of Kubernetes manifest. You need to specify the directory name to the key `mountPath`.
    * Example
         * ScalarDL Ledger
+
           ```yaml
           ledger:
             extraVolumes:
@@ -41,7 +45,9 @@ In this example, you need to mount a **private-key** and a **certificate** file 
                 mountPath: /keys
                 readOnly: true
           ```
+
        * ScalarDL Auditor
+
          ```yaml
          auditor:
             extraVolumes:
@@ -60,11 +66,14 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
    * Example
        * ScalarDL Ledger
+
          ```console
          kubectl create secret generic ledger-keys \
            --from-file=private-key=./ledger-key.pem
          ```
+
        * ScalarDL Auditor
+
          ```console
          kubectl create secret generic auditor-keys \
            --from-file=private-key=./auditor-key.pem \
@@ -77,12 +86,15 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
    * Example
        * ScalarDL Ledger
+
          ```console
          $ ls -l /keys/
          total 0
          lrwxrwxrwx 1 root root 18 Jun 27 03:12 private-key -> ..data/private-key
          ```
+
        * ScalarDL Auditor
+
          ```console
          $ ls -l /keys/
          total 0
@@ -101,6 +113,7 @@ You can mount emptyDir to Scalar product pods by using the following keys in you
   * `auditor.extraVolumes` / `auditor.extraVolumeMounts` (ScalarDL Auditor)
 
 * Example (ScalarDB Server)
+
   ```yaml
   scalardb:
     extraVolumes:

--- a/docs/3.10/helm-charts/use-secret-for-credentials.md
+++ b/docs/3.10/helm-charts/use-secret-for-credentials.md
@@ -3,6 +3,7 @@
 You can pass credentials like **username** or **password** as environment variables via a `Secret` resource in Kubernetes. The docker images for previous versions of Scalar products use the `dockerize` command for templating properties files. The docker images for the latest versions of Scalar products get values directly from environment variables.
 
 Note: You cannot use the following environment variable names in your custom values file since these are used in the Scalar Helm Chart internal.
+
 ```console
 HELM_SCALAR_DB_CONTACT_POINTS
 HELM_SCALAR_DB_CONTACT_PORT
@@ -31,6 +32,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
    * Example
        * ScalarDB Server
            * ScalarDB Server 3.7 or earlier (Go template syntax)
+
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -39,7 +41,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
                   ...
              ```
+
            * ScalarDB Server 3.8 or later (Apache Commons Text syntax)
+
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -48,7 +52,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password=${env:SCALAR_DB_PASSWORD}
                   ...
              ```
+
        * ScalarDB Cluster
+
          ```yaml
          scalardbCluster:
            scalardbClusterNodeProperties: |
@@ -57,7 +63,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password=${env:SCALAR_DB_PASSWORD}
              ...
          ```
+
        * ScalarDL Ledger (Go template syntax)
+
           ```yaml
           ledger:
             ledgerProperties: |
@@ -66,7 +74,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
               scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
               ...
           ```
+
        * ScalarDL Auditor (Go template syntax)
+
          ```yaml
          auditor:
            auditorProperties: |
@@ -75,7 +85,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+
        * ScalarDL Schema Loader (Go template syntax)
+
          ```yaml
          schemaLoading:
            databaseProperties: |
@@ -88,6 +100,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 1. Create a `Secret` resource that includes credentials.  
    You need to specify the environment variable name as keys of the `Secret`.
    * Example
+
      ```console
      kubectl create secret generic scalardb-credentials-secret \
        --from-literal=SCALAR_DB_USERNAME=postgres \
@@ -103,26 +116,35 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
      * `schemaLoading.secretName` (ScalarDL Schema Loader)
    * Example
      * ScalarDB Server
+
        ```yaml
        scalardb:
          secretName: "scalardb-credentials-secret"
        ```
+
      * ScalarDB Cluster
+
        ```yaml
        scalardbCluster:
          secretName: "scalardb-cluster-credentials-secret"
        ```
+
      * ScalarDL Ledger
+
        ```yaml
        ledger:
          secretName: "ledger-credentials-secret"
        ```
+
      * ScalarDL Auditor
+
        ```yaml
        auditor:
          secretName: "auditor-credentials-secret"
        ```
+
      * ScalarDL Schema Loader
+
        ```yaml
        schemaLoading:
          secretName: "schema-loader-ledger-credentials-secret"
@@ -134,6 +156,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 
    * Example
        * Custom values file
+
          ```yaml
          scalardb:
            databaseProperties: |
@@ -142,7 +165,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              scalar.db.storage=jdbc
          ```
+
        * Properties file in containers
+       
          ```properties
          scalar.db.contact_points=jdbc:postgresql://postgresql-scalardb.default.svc.cluster.local:5432/postgres
          scalar.db.username=postgres

--- a/docs/3.5/helm-charts/ReleaseFlow.md
+++ b/docs/3.5/helm-charts/ReleaseFlow.md
@@ -1,22 +1,28 @@
 # Release Flow
 
 ## Requirements
+
 | Name | Version | Mandatory | link |
 |:------|:-------|:----------|:------|
 | Helm | 3.2.1 or latest | no | https://helm.sh/docs/intro/install/ |
 
 ## Release
+
 * You create a branch (`prepare-release-*`).
 * You make sure to create the tag from the previous version of the target version.
+
 ``` console
 $ git checkout -b prepare-release-v3.0.2  refs/tags/scalardl-3.0.1
 ```
 
 * You need to set the `version` of the `Chart.yaml` of each `helm-charts` to the version to be released.
+
 ``` yaml
 version: 3.0.2
 ```
+
 * Pushing commits to a remote repository.
+
 ``` console
 $ git push origin prepare-release-v3.0.2
 ```

--- a/docs/3.5/helm-charts/configure-custom-values-envoy.md
+++ b/docs/3.5/helm-charts/configure-custom-values-envoy.md
@@ -9,6 +9,7 @@ The Scalar Envoy chart is used via other charts (scalardb, scalardl, and scalard
 For example, if you want to configure the Scalar Envoy for ScalarDB Server, you can configure some Scalar Envoy configurations in the custom values file of ScalarDB as follows.
 
 * Example (scalardb-custom-values.yaml)
+
   ```yaml
   envoy:
     configurationsForScalarEnvoy: 

--- a/docs/3.5/helm-charts/getting-started-logging.md
+++ b/docs/3.5/helm-charts/getting-started-logging.md
@@ -47,11 +47,13 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 2. Deploy `loki-stack`
 
 1. Add the `grafana` helm repository.
+
    ```console
    helm repo add grafana https://grafana.github.io/helm-charts
    ```
 
 1. Deploy the `loki-stack` helm chart.
+
    ```console
    helm install scalar-logging-loki grafana/loki-stack -n monitoring -f scalar-loki-stack-custom-values.yaml
    ```
@@ -59,6 +61,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 3. Add a Loki data source in the Grafana configuration
 
 1. Add a configuration of the Loki data source in the `scalar-prometheus-custom-values.yaml` file.
+
    ```yaml
    grafana:
      additionalDataSources:
@@ -72,6 +75,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
    ```
 
 1. Apply the configuration (upgrade the deployment of `kube-prometheus-stack`).
+
    ```console
    helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -86,6 +90,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 5. Delete the `loki-stack` helm chart
 
 1. Uninstall `loki-stack`.
+
    ```console
    helm uninstall scalar-logging-loki -n monitoring
    ```

--- a/docs/3.5/helm-charts/getting-started-monitoring.md
+++ b/docs/3.5/helm-charts/getting-started-monitoring.md
@@ -45,6 +45,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * `grafana.service.type` to `LoadBalancer`
        * `grafana.service.port` to `3000`
    * Example
+
      ```yaml
      alertmanager:
      
@@ -68,6 +69,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
      
      ...
      ```
+
    * Note:
        * If you want to customize the Prometheus Operator deployment using Helm Charts, you need to set the following configuration for monitoring Scalar products.
            * The `serviceMonitorSelectorNilUsesHelmValues` and `ruleSelectorNilUsesHelmValues` must be set to `false` (`true` by default) to make Prometheus Operator detects `ServiceMonitor` and `PrometheusRule` of Scalar products.
@@ -75,23 +77,26 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 ## Step 3. Deploy `kube-prometheus-stack`
 
 1. Add the `prometheus-community` helm repository.
+
    ```console
    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
    ```
 
 1. Create a namespace `monitoring` on the Kubernetes.
+
    ```console
    kubectl create namespace monitoring
    ```
 
 1. Deploy the `kube-prometheus-stack`.
+
    ```console
    helm install scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
 
 ## Step 4. Deploy (or Upgrade) Scalar products using Helm Charts
 
-* Note: 
+* Note:
    * The following explains the minimum steps. If you want to know more details about the deployment of ScalarDB and ScalarDL, please refer to the following documents.
        * [Getting Started with Helm Charts (ScalarDB Server)](./getting-started-scalardb.md)
        * [Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)](./getting-started-scalardl-ledger.md)
@@ -104,6 +109,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * `*.serviceMonitor.enabled`
    * Sample configuration files
        * ScalarDB (scalardb-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -121,7 +127,9 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            serviceMonitor:
              enabled: true
          ```
+
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -139,7 +147,9 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            serviceMonitor:
              enabled: true
          ```
+
        * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -161,23 +171,31 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 1. Deploy (or Upgrade) Scalar products using Helm Charts with the above custom values file.
    * Examples
        * ScalarDB
+
          ```console
          helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
+
        * ScalarDL Ledger
+
          ```console
          helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
+
        * ScalarDL Auditor
+
          ```console
          helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
@@ -187,15 +205,19 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 ### If you use minikube
 
 1. To expose each service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
+
    ```console
    minikube tunnel
    ```
 
    After running the `minikube tunnel` command, you can see the EXTERNAL-IP of each service resource as `127.0.0.1`.
+
    ```console
    kubectl get svc -n monitoring scalar-monitoring-kube-pro-prometheus scalar-monitoring-kube-pro-alertmanager scalar-monitoring-grafana
    ```
+
    [Command execution result]
+
    ```console
    NAME                                      TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
    scalar-monitoring-kube-pro-prometheus     LoadBalancer   10.98.11.12    127.0.0.1     9090:30550/TCP   26m
@@ -205,24 +227,33 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 
 1. Access each Dashboard.
    * Prometheus
+
      ```console
      http://localhost:9090/
      ```
+
    * Alertmanager
+
      ```console
      http://localhost:9093/
      ```
+
    * Grafana
+
      ```console
      http://localhost:3000/
      ```
+
        * Note:
            * You can see the user and password of Grafana as follows.
                * user
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-user}' | base64 -d
                  ```
+
                * password
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```
@@ -236,18 +267,22 @@ If you use a Kubernetes cluster other than minikube, you need to access the Load
 After completing the Monitoring tests on the Kubernetes cluster, remove all resources.
 
 1. Terminate the `minikube tunnel` command. (If you use minikube)
+
    ```console
    Ctrl + C
    ```
 
 1. Uninstall `kube-prometheus-stack`.
+
    ```console
    helm uninstall scalar-monitoring -n monitoring
    ```
 
 1. Delete minikube. (Optional / If you use minikube)
+
    ```console
    minikube delete --all
    ```
+
    * Note:
        * If you deploy the ScalarDB or ScalarDL, you need to remove them before deleting minikube.

--- a/docs/3.5/helm-charts/getting-started-scalar-helm-charts.md
+++ b/docs/3.5/helm-charts/getting-started-scalar-helm-charts.md
@@ -28,15 +28,19 @@ First, you need to install the following tools used in this guide.
 ## Step 2. Start minikube with docker driver (Optional / If you use minikube)
 
 1. Start minikube.
+
    ```console
    minikube start
    ```
 
 1. Check the status of the minikube and pods.
+
    ```console
    kubectl get pod -A
    ```
+
    [Command execution result]
+
    ```console
    NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
    kube-system   coredns-64897985d-lbsfr            1/1     Running   1 (20h ago)   21h
@@ -47,9 +51,10 @@ First, you need to install the following tools used in this guide.
    kube-system   kube-scheduler-minikube            1/1     Running   1 (20h ago)   21h
    kube-system   storage-provisioner                1/1     Running   2 (19s ago)   21h
    ```
+
    If the minikube starts properly, you can see some pods are **Running** in the kube-system namespace.
 
-## Step 3. 
+## Step 3.
 
 After the Kubernetes cluster starts, you can try each Scalar Helm Charts on it. Please refer to the following documents for more details.
 

--- a/docs/3.5/helm-charts/getting-started-scalar-manager.md
+++ b/docs/3.5/helm-charts/getting-started-scalar-manager.md
@@ -64,6 +64,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 1. Upgrade the `kube-prometheus-stack` to allow Grafana to be embedded
 
 1. Add or revise this value to the custom values file (e.g. scalar-prometheus-custom-values.yaml) of the `kube-prometheus-stack`
+
    ```yaml
    grafana:
      grafana.ini:
@@ -73,6 +74,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
    ```
 
 1. Upgrade the Helm installation
+
    ```console
    helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -82,6 +84,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 1. Get the sample file [scalar-manager-custom-values.yaml](./conf/scalar-manager-custom-values.yaml) for `scalar-manager`.
 
 1. Add the targets that you would like to manage. For example, if we want to manage a ledger cluster, then we can add the values as follows.
+
    ```yaml
    scalarManager:
      targets:
@@ -89,21 +92,25 @@ We will deploy the following components on a Kubernetes cluster as follows.
          adminSrv: _scalardl-admin._tcp.scalardl-headless.default.svc.cluster.local
          databaseType: cassandra
    ```
+
    Note: the `adminSrv` is the DNS Service URL that returns SRV record of pods. Kubernetes creates this URL for the named port of the headless service of the Scalar product. The format is `_{port name}._{protocol}.{service name}.{namespace}.svc.{cluster domain name}`
 
 1. Set the Grafana URL. For example, if your Grafana of the `kube-prometheus-stack` is exposed in `localhost:3000`, then we can set it as follows.
+
    ```yaml
    scalarManager:
      grafanaUrl: "http://localhost:3000"
    ```
 
 1. Set the refresh interval that Scalar Manager checks the status of the products. The default value is `30` seconds, but we can change it like:
+
    ```yaml
    scalarManager:
      refreshInterval: 60 # one minute
    ```
 
 1. Set the service type to access Scalar Manager. The default value is `ClusterIP`, but if we access using the `minikube tunnel` command or some load balancer, we can set it as `LoadBalancer`.
+
    ```yaml
    service:
      type: LoadBalancer
@@ -112,11 +119,13 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 3. Deploy `scalar-manager`
 
 1. Create a secret resource `reg-docker-secrets` to pull the Scalar Manager container image from GitHub Packages.
+
    ```console
    kubectl create secret docker-registry reg-docker-secrets --docker-server=ghcr.io --docker-username=<github-username> --docker-password=<github-personal-access-token>
    ```
 
 1. Deploy the `scalar-manager` Helm Chart.
+
    ```console
    helm install scalar-manager scalar-labs/scalar-manager -f scalar-manager-custom-values.yaml
    ```
@@ -126,6 +135,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ### If you use minikube
 
 1. To expose Scalar Manager's service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
+
    ```console
    minikube tunnel
    ```
@@ -138,6 +148,7 @@ If you use a Kubernetes cluster other than minikube, you need to access the Load
 
 ## Step 5. Delete Scalar Manager
 1. Uninstall `scalar-manager`
+
    ```console
    helm uninstall scalar-manager
    ```

--- a/docs/3.5/helm-charts/getting-started-scalardb.md
+++ b/docs/3.5/helm-charts/getting-started-scalardb.md
@@ -44,11 +44,13 @@ ScalarDB uses some kind of database system as a backend database. In this docume
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL.
+
    ```console
    helm install postgresql-scalardb bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -56,10 +58,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL container is running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                    READY   STATUS    RESTARTS   AGE
    postgresql-scalardb-0   1/1     Running   0          2m42s
@@ -68,19 +73,23 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 ## Step 3. Deploy ScalarDB Server on the Kubernetes cluster using Helm Charts
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDB container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -89,12 +98,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
 
    Please refer to the following documents for more details.
-   
+
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 1. Create a custom values file for ScalarDB Server (scalardb-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -118,7 +128,9 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -144,6 +156,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
 
 1. Create a Secret resource that includes a username and password for PostgreSQL.
+
    ```console
    kubectl create secret generic scalardb-credentials-secret \
      --from-literal=SCALAR_DB_POSTGRES_USERNAME=postgres \
@@ -151,15 +164,19 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Deploy ScalarDB Server.
+
    ```console
    helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
    ```
 
 1. Check if the ScalarDB Server pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                              READY   STATUS    RESTARTS   AGE
    postgresql-scalardb-0             1/1     Running   0          9m48s
@@ -170,13 +187,17 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    scalardb-envoy-84c475f77b-n74tk   1/1     Running   0          6s
    scalardb-envoy-84c475f77b-zbrwz   1/1     Running   0          6s
    ```
+
    If the ScalarDB Server Pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDB Server services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
    kubernetes               ClusterIP   10.96.0.1        <none>        443/TCP     47d
@@ -187,20 +208,25 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    scalardb-headless        ClusterIP   None             <none>        60051/TCP   41s
    scalardb-metrics         ClusterIP   10.108.188.10    <none>        8080/TCP    41s
    ```
+
    If the ScalarDB Server services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardb-headless` has no CLUSTER-IP.)  
 
 ## Step 4. Start a Client container
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    kubectl run scalardb-client --image eclipse-temurin:8 --command sleep inf
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardb-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardb-client   1/1     Running   0          23s
@@ -211,66 +237,86 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 The following explains the minimum steps. If you want to know more details about ScalarDB, please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardb-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git and curl commands in the Client container.
+
    ```console
    apt update && apt install -y git curl
    ```
 
 1. Clone ScalarDB git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardb.git
    ```
 
 1. Change the directory to `scalardb/`.
+
    ```console
    cd scalardb/
    ```
+
    ```console
    pwd
    ```
+
    [Command execution result]
+
    ```console
    /scalardb
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.7.0 refs/tags/v3.7.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
+
    ```console
      master
    * v3.7.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use.
 
 1. Change the directory to `docs/getting-started/`.
+
    ```console
    cd docs/getting-started/
    ```
+
    ```console
    pwd
    ```
+
    [Command execution result]
+
    ```console
    /scalardb/docs/getting-started
    ```
 
 1. Download Schema Loader from [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardb/releases/download/v3.7.0/scalardb-schema-loader-3.7.0.jar
    ```
+
    You need to use the same version of ScalarDB and Schema Loader.
 
 1. Create a configuration file (scalardb.properties) to access ScalarDB Server on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > scalardb.properties
    scalar.db.contact_points=scalardb-envoy.default.svc.cluster.local
@@ -281,6 +327,7 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Create a JSON file (emoney-transaction.json) that defines DB Schema for the sample applications.
+
    ```console
    cat << 'EOF' > emoney-transaction.json
    {
@@ -300,37 +347,50 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Run Schema Loader (Create sample TABLE).
+
    ```console
    java -jar ./scalardb-schema-loader-3.7.0.jar --config ./scalardb.properties -f emoney-transaction.json --coordinator
    ```
 
 1. Run the sample applications.
    * Charge `1000` to `user1`:
+
      ```console
      ./gradlew run --args="-action charge -amount 1000 -to user1"
      ```
+
    * Charge `0` to `merchant1` (Just create an account for `merchant1`):
+
      ```console
      ./gradlew run --args="-action charge -amount 0 -to merchant1"
      ```
+
    * Pay `100` from `user1` to `merchant1`:
+
      ```console
      ./gradlew run --args="-action pay -amount 100 -from user1 -to merchant1"
      ```
+
    * Get the balance of `user1`:
+
      ```console
      ./gradlew run --args="-action getBalance -id user1"
      ```
+
    * Get the balance of `merchant1`:
+
      ```console
      ./gradlew run --args="-action getBalance -id merchant1"
      ```
 
 1. (Optional) You can see the inserted and modified (INSERT/UPDATE) data through the sample applications using the following command. (This command needs to run on your localhost, not on the Client container.)  
+
    ```console
    kubectl exec -it postgresql-scalardb-0 -- bash -c 'export PGPASSWORD=postgres && psql -U postgres -d postgres -c "SELECT * FROM emoney.account"'
    ```
+
    [Command execution result]
+
    ```sql
        id     | balance |                tx_id                 | tx_state | tx_version | tx_prepared_at | tx_committed_at |             before_tx_id             | before_tx_state | before_tx_version | before_tx_prepared_at | before_tx_committed_at | before_balance
    -----------+---------+--------------------------------------+----------+------------+----------------+-----------------+--------------------------------------+-----------------+-------------------+-----------------------+------------------------+----------------
@@ -338,6 +398,7 @@ The following explains the minimum steps. If you want to know more details about
     user1     |     900 | 65a90225-0846-4e97-b729-151f76f6ca2f |        3 |          2 |  1667361909634 |1667361909679    | 5520cba4-625a-4886-b81f-6089bf846d18 |               3 |                 1 |         1667361897283 |          1667361897317 |           1000
    (2 rows)
    ```
+
    * Note:
        * Usually, you need to access data (records) through ScalarDB. The above command is used to explain and confirm the working of the sample applications.
 
@@ -346,12 +407,14 @@ The following explains the minimum steps. If you want to know more details about
 After completing the ScalarDB Server tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDB Server and PostgreSQL.
+
    ```console
    helm uninstall scalardb postgresql-scalardb
    ```
 
 1. Remove the Client container.
-   ```
+
+   ```console
    kubectl delete pod scalardb-client --force --grace-period 0
    ```
 

--- a/docs/3.5/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/3.5/helm-charts/getting-started-scalardl-auditor.md
@@ -72,11 +72,13 @@ ScalarDL Ledger and Auditor use some kind of database system as a backend databa
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL for Ledger.
+
    ```console
    helm install postgresql-ledger bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -84,6 +86,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Deploy PostgreSQL for Auditor.
+
    ```console
    helm install postgresql-auditor bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -91,10 +94,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL containers are running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                   READY   STATUS    RESTARTS   AGE
    postgresql-auditor-0   1/1     Running   0          11s
@@ -106,6 +112,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 We will create some configuration files and key/certificate files locally. So, create a working directory for them.
 
 1. Create a working directory.
+
    ```console
    mkdir -p ~/scalardl-test/certs/
    ```
@@ -115,11 +122,13 @@ We will create some configuration files and key/certificate files locally. So, c
 Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
 1. Change the working directory to `~/scalardl-test/certs/` directory.
+
    ```console
    cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
@@ -143,6 +152,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Auditor information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/auditor.json
    {
@@ -166,6 +176,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Client information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
@@ -189,25 +200,31 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create key/certificate files for the Ledger.
+
    ```console
    cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Auditor.
+
    ```console
    cfssl selfsign "" ./auditor.json | cfssljson -bare auditor
    ```
 
 1. Create key/certificate files for the Client.
+
    ```console
    cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
+
    ```console
    ls -1
    ```
+
    [Command execution result]
+
    ```console
    auditor-key.pem
    auditor.csr
@@ -229,24 +246,29 @@ We will deploy two ScalarDL Schema Loader pods on the Kubernetes cluster using H
 The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Auditor in PostgreSQL.  
 
 1. Change the working directory to `~/scalardl-test/`.
+
    ```console
    cd ~/scalardl-test/
    ```
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -255,12 +277,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
    Please refer to the following documents for more details.
-   
+
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 1. Create a custom values file for ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -278,7 +301,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -299,6 +324,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 
 1. Create a custom values file for ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -316,7 +342,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -336,6 +364,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Ledger.
+
    ```console
    kubectl create secret generic ledger-credentials-secret \
      --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
@@ -343,6 +372,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Auditor.
+
    ```console
    kubectl create secret generic auditor-credentials-secret \
      --from-literal=SCALAR_DL_AUDITOR_POSTGRES_USERNAME=postgres \
@@ -350,20 +380,25 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    ```
 
 1. Deploy the ScalarDL Schema Loader for Ledger.
+
    ```console
    helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Deploy the ScalarDL Schema Loader for Auditor.
+
    ```console
    helm install schema-loader-auditor scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Schema Loader pods are deployed and completed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
    postgresql-auditor-0                         1/1     Running     0          2m56s
@@ -371,12 +406,14 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          6s
    schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          10s
    ```
+
    If the ScalarDL Schema Loader pods are **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
 ## Step 6. Deploy ScalarDL Ledger and Auditor on the Kubernetes cluster using Helm Charts
 
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -411,7 +448,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -448,6 +487,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 
 1. Create a custom values file for ScalarDL Auditor (scalardl-auditor-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -482,7 +522,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -519,30 +561,37 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
 1. Create secret resource `ledger-keys`.
+
    ```console
    kubectl create secret generic ledger-keys --from-file=certificate=./certs/ledger.pem --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Create secret resource `auditor-keys`.
+
    ```console
    kubectl create secret generic auditor-keys --from-file=certificate=./certs/auditor.pem --from-file=private-key=./certs/auditor-key.pem
    ```
 
 1. Deploy the ScalarDL Ledger.
+
    ```console
    helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Deploy the ScalarDL Auditor.
+
    ```console
    helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Ledger and Auditor pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
    postgresql-auditor-0                         1/1     Running     0          14m
@@ -562,13 +611,17 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          11m
    schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          11m
    ```
+
    If the ScalarDL Ledger and Auditor pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDL Ledger and Auditor services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                             TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
    kubernetes                       ClusterIP   10.96.0.1        <none>        443/TCP                         47d
@@ -585,6 +638,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    scalardl-ledger-headless         ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   61s
    scalardl-ledger-metrics          ClusterIP   10.99.122.106    <none>        8080/TCP                        61s
    ```
+
    If the ScalarDL Ledger and Auditor services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` and `scalardl-auditor-headless` have no CLUSTER-IP.)  
 
 ## Step 7. Start a Client container
@@ -592,11 +646,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
 
 1. Create secret resource `client-keys`.
-   ```
+
+   ```console
    kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
@@ -634,10 +690,13 @@ We will use certificate files in a Client container. So, we create a secret reso
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardl-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardl-client   1/1     Running   0          4s
@@ -652,65 +711,82 @@ The following explains the minimum steps. If you want to know more details about
 When you use Auditor, you need to register the certificate for the Ledger and Auditor before starting the client application. Ledger needs to register its certificate to Auditor, and Auditor needs to register its certificate to Ledger.
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardl-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git, curl and unzip commands in the Client container.
+
    ```console
    apt update && apt install -y git curl unzip
    ```
 
 1. Clone ScalarDL Java Client SDK git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change the directory to `scalardl-java-client-sdk/`.
+
    ```console
    cd scalardl-java-client-sdk/
    ```
+
    ```console
    pwd
    ```
-   [Command execution result]
-   ```console
 
+   [Command execution result]
+
+   ```console
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
+
    ```console
      master
    * v3.6.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
 1. Build the sample contracts.
+
    ```console
    ./gradlew assemble
    ```
 
 1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
+
    You need to use the same version of CLI tools and ScalarDL Ledger.
 
 1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
+
    ```console
    unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (ledger.as.client.properties) to register the certificate of Ledger to Auditor.
+
    ```console
    cat << 'EOF' > ledger.as.client.properties
    # Ledger
@@ -728,6 +804,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Create a configuration file (auditor.as.client.properties) to register the certificate of Auditor to Ledger.
+
    ```console
    cat << 'EOF' > auditor.as.client.properties
    # Ledger
@@ -745,6 +822,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > client.properties
    # Ledger
@@ -762,46 +840,57 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Register the certificate file of Ledger.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./ledger.as.client.properties
    ```
 
 1. Register the certificate file of Auditor.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./auditor.as.client.properties
    ```
 
 1. Register the certificate file of client.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./client.properties
    ```
 
 1. Register the sample contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Register the contract `ValdateLedger` to execute a validate request.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id validate-ledger --contract-binary-name com.scalar.dl.client.contract.ValidateLedger --contract-class-file ./build/classes/java/main/com/scalar/dl/client/contract/ValidateLedger.class
    ```
 
 1. Execute the contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
+
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    ```
+
    [Command execution result]
+
    ```console
    Contract result:
    {
@@ -812,23 +901,29 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
      }
    }
    ```
+
    * Reference information
       * If the asset data is not tampered with, the contract execution request (execute-contract command) returns `OK` as a result.
       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the contract execution request (execute-contract command) returns a value other than `OK`  (e.g. `INCONSISTENT_STATES`) as a result, like the following.  
         [Command execution result (If the asset data is tampered with)]
+
         ```console
         {
           "status_code" : "INCONSISTENT_STATES",
           "error_message" : "The results from Ledger and Auditor don't match"
         }
         ```
+
           * In this way, the ScalarDL can detect data tampering.
 
 1. Execute a validation request for the asset.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
+
    [Command execution result]
+
    ```console
    {
      "status_code" : "OK",
@@ -848,16 +943,19 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
      }
    }
    ```
+
    * Reference information
       * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
         [Command execution result (If the asset data is tampered with)]
+
         ```console
         {
           "status_code" : "INCONSISTENT_STATES",
           "error_message" : "The results from Ledger and Auditor don't match"
         }
         ```
+
           * In this way, the ScalarDL Ledger can detect data tampering.
 
 ## Step 9. Delete all resources
@@ -865,19 +963,23 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
 After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
+
    ```console
    helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger scalardl-auditor schema-loader-auditor postgresql-auditor
    ```
 
 1. Remove the Client container.
+
    ```
    kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
 1. Remove the working directory and sample files (configuration file, key, and certificate).
+
    ```console
    cd ~
    ```
+   
    ```console
    rm -rf ~/scalardl-test/
    ```

--- a/docs/3.5/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/3.5/helm-charts/getting-started-scalardl-ledger.md
@@ -54,11 +54,13 @@ ScalarDL Ledger uses some kind of database system as a backend database. In this
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL.
+
    ```console
    helm install postgresql-ledger bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -66,10 +68,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL container is running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                  READY   STATUS    RESTARTS   AGE
    postgresql-ledger-0   1/1     Running   0          11s
@@ -80,6 +85,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 We will create some configuration files and key/certificate files locally. So, create a working directory for them.
 
 1. Create a working directory.
+
    ```console
    mkdir -p ~/scalardl-test/certs/
    ```
@@ -89,11 +95,13 @@ We will create some configuration files and key/certificate files locally. So, c
 Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
 1. Change the working directory to `~/scalardl-test/certs/` directory.
+
    ```console
    cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
@@ -117,6 +125,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Client information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
@@ -140,20 +149,25 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create key/certificate files for the Ledger.
+
    ```console
    cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Client.
+
    ```console
    cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
+
    ```console
    ls -1
    ```
+
    [Command execution result]
+
    ```console
    client-key.pem
    client.csr
@@ -171,24 +185,29 @@ We will deploy a ScalarDL Schema Loader on the Kubernetes cluster using Helm Cha
 The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in PostgreSQL.  
 
 1. Change the working directory to `~/scalardl-test/`.
+
    ```console
    cd ~/scalardl-test/
    ```
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -203,6 +222,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 
 1. Create a custom values file for ScalarDL Schema Loader (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -221,6 +241,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      EOF
      ```
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -240,6 +261,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL.
+
    ```console
    kubectl create secret generic ledger-credentials-secret \
      --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
@@ -247,26 +269,32 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    ```
 
 1. Deploy the ScalarDL Schema Loader.
+
    ```console
    helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Schema Loader pod is deployed and completed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    postgresql-ledger-0                         1/1     Running     0          11m
    schema-loader-ledger-schema-loading-46rcr   0/1     Completed   0          3s
    ```
+
    If the ScalarDL Schema Loader pod is **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
 ## Step 6. Deploy ScalarDL Ledger on the Kubernetes cluster using Helm Charts
 
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -300,7 +328,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -336,20 +366,25 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
 
 1. Create secret resource `ledger-keys`.
+
    ```console
    kubectl create secret generic ledger-keys --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Deploy the ScalarDL Ledger.
+
    ```console
    helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Ledger pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    postgresql-ledger-0                         1/1     Running     0          14m
@@ -361,13 +396,17 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    scalardl-ledger-ledger-9bdf7f8bd-9tw5x      1/1     Running     0          52s
    schema-loader-ledger-schema-loading-46rcr   0/1     Completed   0          3m38s
    ```
+
    If the ScalarDL Ledger pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDL Ledger services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
    kubernetes                      ClusterIP   10.96.0.1        <none>        443/TCP                         47d
@@ -378,6 +417,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    scalardl-ledger-headless        ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   83s
    scalardl-ledger-metrics         ClusterIP   10.98.4.217      <none>        8080/TCP                        83s
    ```
+
    If the ScalarDL Ledger services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` has no CLUSTER-IP.)  
 
 ## Step 7. Start a Client container
@@ -385,11 +425,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
 
 1. Create secret resource `client-keys`.
-   ```
+
+   ```console
    kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
@@ -415,10 +457,13 @@ We will use certificate files in a Client container. So, we create a secret reso
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardl-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardl-client   1/1     Running   0          11s
@@ -429,65 +474,81 @@ We will use certificate files in a Client container. So, we create a secret reso
 The following explains the minimum steps. If you want to know more details about ScalarDL and the contract, please refer to the [Getting Started with ScalarDL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md).
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardl-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git, curl and unzip commands in the Client container.
+
    ```console
    apt update && apt install -y git curl unzip
    ```
 
 1. Clone ScalarDL Java Client SDK git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change the directory to `scalardl-java-client-sdk/`.
+
    ```console
    cd scalardl-java-client-sdk/
    ```
+
    ```console
    pwd
    ```
-   [Command execution result]
-   ```console
 
+   [Command execution result]
+
+   ```console
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
    ```console
      master
    * v3.6.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
 1. Build the sample contracts.
+
    ```console
    ./gradlew assemble
    ```
 
 1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
+
    You need to use the same version of CLI tools and ScalarDL Ledger.
 
 1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
+
    ```console
    unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > client.properties
    scalar.dl.client.server.host=scalardl-ledger-envoy.default.svc.cluster.local
@@ -503,26 +564,32 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Register the sample contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Execute the contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    ```
+
    [Command execution result]
+
    ```console
    Contract result:
    {
@@ -535,10 +602,13 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Execute a validation request for the asset.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
+
    [Command execution result]
+
    ```console
    {
      "status_code" : "OK",
@@ -552,10 +622,12 @@ The following explains the minimum steps. If you want to know more details about
      "Auditor" : null
    }
    ```
+
    * Reference information
        * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
        * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
          [Command execution result (If the asset data is tampered with)]
+
          ```console
          {
            "status_code" : "INVALID_OUTPUT",
@@ -569,6 +641,7 @@ The following explains the minimum steps. If you want to know more details about
            "Auditor" : null
          }
          ```
+
            * In this way, the ScalarDL Ledger can detect data tampering.
 
 ## Step 9. Delete all resources
@@ -576,19 +649,23 @@ The following explains the minimum steps. If you want to know more details about
 After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
+
    ```console
    helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger
    ```
 
 1. Remove the Client container.
+
    ```
    kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
 1. Remove the working directory and sample files (configuration file, key, and certificate).
+
    ```console
    cd ~
    ```
+   
    ```console
    rm -rf ~/scalardl-test/
    ```

--- a/docs/3.5/helm-charts/how-to-deploy-scalar-products.md
+++ b/docs/3.5/helm-charts/how-to-deploy-scalar-products.md
@@ -15,6 +15,7 @@ You must install the helm command to use Scalar Helm Charts. Please install the 
 ```console
 helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
 ```
+
 ```console
 helm repo update scalar-labs
 ```

--- a/docs/3.5/helm-charts/how-to-deploy-scalardb-cluster.md
+++ b/docs/3.5/helm-charts/how-to-deploy-scalardb-cluster.md
@@ -31,6 +31,7 @@ If you use ScalarDB Cluster with `direct-kubernetes` mode, you must:
 This method is necessary because the ScalarDB Cluster client library with `direct-kubernetes` mode runs the Kubernetes API from inside of your application pods to get information about the ScalarDB Cluster pods.
 
 * Role
+
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -42,7 +43,9 @@ This method is necessary because the ScalarDB Cluster client library with `direc
       resources: ["endpoints"]
       verbs: ["get", "watch", "list"]
   ```
+
 * RoleBinding
+
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
@@ -57,7 +60,9 @@ This method is necessary because the ScalarDB Cluster client library with `direc
     name: scalardb-cluster-role
     apiGroup: rbac.authorization.k8s.io
   ```
+
 * ServiceAccount
+
   ```yaml
   apiVersion: v1
   kind: ServiceAccount

--- a/docs/3.5/helm-charts/mount-files-or-volumes-on-scalar-pods.md
+++ b/docs/3.5/helm-charts/mount-files-or-volumes-on-scalar-pods.md
@@ -8,6 +8,7 @@ You must mount the key and certificate files to run ScalarDL Auditor.
 
 * Configuration example
     * ScalarDL Ledger
+
       ```yaml
       ledger:
         ledgerProperties: |
@@ -16,7 +17,9 @@ You must mount the key and certificate files to run ScalarDL Auditor.
           scalar.dl.ledger.auditor.enabled=true
           scalar.dl.ledger.proof.private_key_path=/keys/private-key
       ```
+
     * ScalarDL Auditor
+
       ```yaml
       auditor:
         auditorProperties: |
@@ -30,6 +33,7 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 1. Set `extraVolumes` and `extraVolumeMounts` in the custom values file using the same syntax of Kubernetes manifest. You need to specify the directory name to the key `mountPath`.
    * Example
         * ScalarDL Ledger
+
           ```yaml
           ledger:
             extraVolumes:
@@ -41,7 +45,9 @@ In this example, you need to mount a **private-key** and a **certificate** file 
                 mountPath: /keys
                 readOnly: true
           ```
+
        * ScalarDL Auditor
+
          ```yaml
          auditor:
             extraVolumes:
@@ -60,11 +66,14 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
    * Example
        * ScalarDL Ledger
+
          ```console
          kubectl create secret generic ledger-keys \
            --from-file=private-key=./ledger-key.pem
          ```
+
        * ScalarDL Auditor
+
          ```console
          kubectl create secret generic auditor-keys \
            --from-file=private-key=./auditor-key.pem \
@@ -77,12 +86,15 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
    * Example
        * ScalarDL Ledger
+
          ```console
          $ ls -l /keys/
          total 0
          lrwxrwxrwx 1 root root 18 Jun 27 03:12 private-key -> ..data/private-key
          ```
+
        * ScalarDL Auditor
+
          ```console
          $ ls -l /keys/
          total 0
@@ -101,6 +113,7 @@ You can mount emptyDir to Scalar product pods by using the following keys in you
   * `auditor.extraVolumes` / `auditor.extraVolumeMounts` (ScalarDL Auditor)
 
 * Example (ScalarDB Server)
+
   ```yaml
   scalardb:
     extraVolumes:

--- a/docs/3.5/helm-charts/use-secret-for-credentials.md
+++ b/docs/3.5/helm-charts/use-secret-for-credentials.md
@@ -3,6 +3,7 @@
 You can pass credentials like **username** or **password** as environment variables via a `Secret` resource in Kubernetes. The docker images for previous versions of Scalar products use the `dockerize` command for templating properties files. The docker images for the latest versions of Scalar products get values directly from environment variables.
 
 Note: You cannot use the following environment variable names in your custom values file since these are used in the Scalar Helm Chart internal.
+
 ```console
 HELM_SCALAR_DB_CONTACT_POINTS
 HELM_SCALAR_DB_CONTACT_PORT
@@ -31,6 +32,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
    * Example
        * ScalarDB Server
            * ScalarDB Server 3.7 or earlier (Go template syntax)
+
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -39,7 +41,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
                   ...
              ```
+
            * ScalarDB Server 3.8 or later (Apache Commons Text syntax)
+
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -48,7 +52,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password=${env:SCALAR_DB_PASSWORD}
                   ...
              ```
+
        * ScalarDB Cluster
+
          ```yaml
          scalardbCluster:
            scalardbClusterNodeProperties: |
@@ -57,7 +63,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password=${env:SCALAR_DB_PASSWORD}
              ...
          ```
+
        * ScalarDL Ledger (Go template syntax)
+
           ```yaml
           ledger:
             ledgerProperties: |
@@ -66,7 +74,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
               scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
               ...
           ```
+
        * ScalarDL Auditor (Go template syntax)
+
          ```yaml
          auditor:
            auditorProperties: |
@@ -75,7 +85,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+
        * ScalarDL Schema Loader (Go template syntax)
+
          ```yaml
          schemaLoading:
            databaseProperties: |
@@ -88,6 +100,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 1. Create a `Secret` resource that includes credentials.  
    You need to specify the environment variable name as keys of the `Secret`.
    * Example
+
      ```console
      kubectl create secret generic scalardb-credentials-secret \
        --from-literal=SCALAR_DB_USERNAME=postgres \
@@ -103,26 +116,35 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
      * `schemaLoading.secretName` (ScalarDL Schema Loader)
    * Example
      * ScalarDB Server
+
        ```yaml
        scalardb:
          secretName: "scalardb-credentials-secret"
        ```
+
      * ScalarDB Cluster
+
        ```yaml
        scalardbCluster:
          secretName: "scalardb-cluster-credentials-secret"
        ```
+
      * ScalarDL Ledger
+
        ```yaml
        ledger:
          secretName: "ledger-credentials-secret"
        ```
+
      * ScalarDL Auditor
+
        ```yaml
        auditor:
          secretName: "auditor-credentials-secret"
        ```
+
      * ScalarDL Schema Loader
+
        ```yaml
        schemaLoading:
          secretName: "schema-loader-ledger-credentials-secret"
@@ -134,6 +156,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 
    * Example
        * Custom values file
+
          ```yaml
          scalardb:
            databaseProperties: |
@@ -142,7 +165,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              scalar.db.storage=jdbc
          ```
+
        * Properties file in containers
+       
          ```properties
          scalar.db.contact_points=jdbc:postgresql://postgresql-scalardb.default.svc.cluster.local:5432/postgres
          scalar.db.username=postgres

--- a/docs/3.6/helm-charts/ReleaseFlow.md
+++ b/docs/3.6/helm-charts/ReleaseFlow.md
@@ -1,22 +1,28 @@
 # Release Flow
 
 ## Requirements
+
 | Name | Version | Mandatory | link |
 |:------|:-------|:----------|:------|
 | Helm | 3.2.1 or latest | no | https://helm.sh/docs/intro/install/ |
 
 ## Release
+
 * You create a branch (`prepare-release-*`).
 * You make sure to create the tag from the previous version of the target version.
+
 ``` console
 $ git checkout -b prepare-release-v3.0.2  refs/tags/scalardl-3.0.1
 ```
 
 * You need to set the `version` of the `Chart.yaml` of each `helm-charts` to the version to be released.
+
 ``` yaml
 version: 3.0.2
 ```
+
 * Pushing commits to a remote repository.
+
 ``` console
 $ git push origin prepare-release-v3.0.2
 ```

--- a/docs/3.6/helm-charts/configure-custom-values-envoy.md
+++ b/docs/3.6/helm-charts/configure-custom-values-envoy.md
@@ -9,6 +9,7 @@ The Scalar Envoy chart is used via other charts (scalardb, scalardl, and scalard
 For example, if you want to configure the Scalar Envoy for ScalarDB Server, you can configure some Scalar Envoy configurations in the custom values file of ScalarDB as follows.
 
 * Example (scalardb-custom-values.yaml)
+
   ```yaml
   envoy:
     configurationsForScalarEnvoy: 

--- a/docs/3.6/helm-charts/getting-started-logging.md
+++ b/docs/3.6/helm-charts/getting-started-logging.md
@@ -47,11 +47,13 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 2. Deploy `loki-stack`
 
 1. Add the `grafana` helm repository.
+
    ```console
    helm repo add grafana https://grafana.github.io/helm-charts
    ```
 
 1. Deploy the `loki-stack` helm chart.
+
    ```console
    helm install scalar-logging-loki grafana/loki-stack -n monitoring -f scalar-loki-stack-custom-values.yaml
    ```
@@ -59,6 +61,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 3. Add a Loki data source in the Grafana configuration
 
 1. Add a configuration of the Loki data source in the `scalar-prometheus-custom-values.yaml` file.
+
    ```yaml
    grafana:
      additionalDataSources:
@@ -72,6 +75,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
    ```
 
 1. Apply the configuration (upgrade the deployment of `kube-prometheus-stack`).
+
    ```console
    helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -86,6 +90,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 5. Delete the `loki-stack` helm chart
 
 1. Uninstall `loki-stack`.
+
    ```console
    helm uninstall scalar-logging-loki -n monitoring
    ```

--- a/docs/3.6/helm-charts/getting-started-monitoring.md
+++ b/docs/3.6/helm-charts/getting-started-monitoring.md
@@ -45,6 +45,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * `grafana.service.type` to `LoadBalancer`
        * `grafana.service.port` to `3000`
    * Example
+
      ```yaml
      alertmanager:
      
@@ -68,6 +69,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
      
      ...
      ```
+
    * Note:
        * If you want to customize the Prometheus Operator deployment using Helm Charts, you need to set the following configuration for monitoring Scalar products.
            * The `serviceMonitorSelectorNilUsesHelmValues` and `ruleSelectorNilUsesHelmValues` must be set to `false` (`true` by default) to make Prometheus Operator detects `ServiceMonitor` and `PrometheusRule` of Scalar products.
@@ -75,23 +77,26 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 ## Step 3. Deploy `kube-prometheus-stack`
 
 1. Add the `prometheus-community` helm repository.
+
    ```console
    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
    ```
 
 1. Create a namespace `monitoring` on the Kubernetes.
+
    ```console
    kubectl create namespace monitoring
    ```
 
 1. Deploy the `kube-prometheus-stack`.
+
    ```console
    helm install scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
 
 ## Step 4. Deploy (or Upgrade) Scalar products using Helm Charts
 
-* Note: 
+* Note:
    * The following explains the minimum steps. If you want to know more details about the deployment of ScalarDB and ScalarDL, please refer to the following documents.
        * [Getting Started with Helm Charts (ScalarDB Server)](./getting-started-scalardb.md)
        * [Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)](./getting-started-scalardl-ledger.md)
@@ -104,6 +109,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * `*.serviceMonitor.enabled`
    * Sample configuration files
        * ScalarDB (scalardb-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -121,7 +127,9 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            serviceMonitor:
              enabled: true
          ```
+
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -139,7 +147,9 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            serviceMonitor:
              enabled: true
          ```
+
        * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -161,23 +171,31 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 1. Deploy (or Upgrade) Scalar products using Helm Charts with the above custom values file.
    * Examples
        * ScalarDB
+
          ```console
          helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
+
        * ScalarDL Ledger
+
          ```console
          helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
+
        * ScalarDL Auditor
+
          ```console
          helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
@@ -187,15 +205,19 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 ### If you use minikube
 
 1. To expose each service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
+
    ```console
    minikube tunnel
    ```
 
    After running the `minikube tunnel` command, you can see the EXTERNAL-IP of each service resource as `127.0.0.1`.
+
    ```console
    kubectl get svc -n monitoring scalar-monitoring-kube-pro-prometheus scalar-monitoring-kube-pro-alertmanager scalar-monitoring-grafana
    ```
+
    [Command execution result]
+
    ```console
    NAME                                      TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
    scalar-monitoring-kube-pro-prometheus     LoadBalancer   10.98.11.12    127.0.0.1     9090:30550/TCP   26m
@@ -205,24 +227,33 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 
 1. Access each Dashboard.
    * Prometheus
+
      ```console
      http://localhost:9090/
      ```
+
    * Alertmanager
+
      ```console
      http://localhost:9093/
      ```
+
    * Grafana
+
      ```console
      http://localhost:3000/
      ```
+
        * Note:
            * You can see the user and password of Grafana as follows.
                * user
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-user}' | base64 -d
                  ```
+
                * password
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```
@@ -236,18 +267,22 @@ If you use a Kubernetes cluster other than minikube, you need to access the Load
 After completing the Monitoring tests on the Kubernetes cluster, remove all resources.
 
 1. Terminate the `minikube tunnel` command. (If you use minikube)
+
    ```console
    Ctrl + C
    ```
 
 1. Uninstall `kube-prometheus-stack`.
+
    ```console
    helm uninstall scalar-monitoring -n monitoring
    ```
 
 1. Delete minikube. (Optional / If you use minikube)
+
    ```console
    minikube delete --all
    ```
+
    * Note:
        * If you deploy the ScalarDB or ScalarDL, you need to remove them before deleting minikube.

--- a/docs/3.6/helm-charts/getting-started-scalar-helm-charts.md
+++ b/docs/3.6/helm-charts/getting-started-scalar-helm-charts.md
@@ -28,15 +28,19 @@ First, you need to install the following tools used in this guide.
 ## Step 2. Start minikube with docker driver (Optional / If you use minikube)
 
 1. Start minikube.
+
    ```console
    minikube start
    ```
 
 1. Check the status of the minikube and pods.
+
    ```console
    kubectl get pod -A
    ```
+
    [Command execution result]
+
    ```console
    NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
    kube-system   coredns-64897985d-lbsfr            1/1     Running   1 (20h ago)   21h
@@ -47,9 +51,10 @@ First, you need to install the following tools used in this guide.
    kube-system   kube-scheduler-minikube            1/1     Running   1 (20h ago)   21h
    kube-system   storage-provisioner                1/1     Running   2 (19s ago)   21h
    ```
+
    If the minikube starts properly, you can see some pods are **Running** in the kube-system namespace.
 
-## Step 3. 
+## Step 3.
 
 After the Kubernetes cluster starts, you can try each Scalar Helm Charts on it. Please refer to the following documents for more details.
 

--- a/docs/3.6/helm-charts/getting-started-scalar-manager.md
+++ b/docs/3.6/helm-charts/getting-started-scalar-manager.md
@@ -64,6 +64,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 1. Upgrade the `kube-prometheus-stack` to allow Grafana to be embedded
 
 1. Add or revise this value to the custom values file (e.g. scalar-prometheus-custom-values.yaml) of the `kube-prometheus-stack`
+
    ```yaml
    grafana:
      grafana.ini:
@@ -73,6 +74,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
    ```
 
 1. Upgrade the Helm installation
+
    ```console
    helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -82,6 +84,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 1. Get the sample file [scalar-manager-custom-values.yaml](./conf/scalar-manager-custom-values.yaml) for `scalar-manager`.
 
 1. Add the targets that you would like to manage. For example, if we want to manage a ledger cluster, then we can add the values as follows.
+
    ```yaml
    scalarManager:
      targets:
@@ -89,21 +92,25 @@ We will deploy the following components on a Kubernetes cluster as follows.
          adminSrv: _scalardl-admin._tcp.scalardl-headless.default.svc.cluster.local
          databaseType: cassandra
    ```
+
    Note: the `adminSrv` is the DNS Service URL that returns SRV record of pods. Kubernetes creates this URL for the named port of the headless service of the Scalar product. The format is `_{port name}._{protocol}.{service name}.{namespace}.svc.{cluster domain name}`
 
 1. Set the Grafana URL. For example, if your Grafana of the `kube-prometheus-stack` is exposed in `localhost:3000`, then we can set it as follows.
+
    ```yaml
    scalarManager:
      grafanaUrl: "http://localhost:3000"
    ```
 
 1. Set the refresh interval that Scalar Manager checks the status of the products. The default value is `30` seconds, but we can change it like:
+
    ```yaml
    scalarManager:
      refreshInterval: 60 # one minute
    ```
 
 1. Set the service type to access Scalar Manager. The default value is `ClusterIP`, but if we access using the `minikube tunnel` command or some load balancer, we can set it as `LoadBalancer`.
+
    ```yaml
    service:
      type: LoadBalancer
@@ -112,11 +119,13 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 3. Deploy `scalar-manager`
 
 1. Create a secret resource `reg-docker-secrets` to pull the Scalar Manager container image from GitHub Packages.
+
    ```console
    kubectl create secret docker-registry reg-docker-secrets --docker-server=ghcr.io --docker-username=<github-username> --docker-password=<github-personal-access-token>
    ```
 
 1. Deploy the `scalar-manager` Helm Chart.
+
    ```console
    helm install scalar-manager scalar-labs/scalar-manager -f scalar-manager-custom-values.yaml
    ```
@@ -126,6 +135,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ### If you use minikube
 
 1. To expose Scalar Manager's service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
+
    ```console
    minikube tunnel
    ```
@@ -138,6 +148,7 @@ If you use a Kubernetes cluster other than minikube, you need to access the Load
 
 ## Step 5. Delete Scalar Manager
 1. Uninstall `scalar-manager`
+
    ```console
    helm uninstall scalar-manager
    ```

--- a/docs/3.6/helm-charts/getting-started-scalardb.md
+++ b/docs/3.6/helm-charts/getting-started-scalardb.md
@@ -44,11 +44,13 @@ ScalarDB uses some kind of database system as a backend database. In this docume
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL.
+
    ```console
    helm install postgresql-scalardb bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -56,10 +58,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL container is running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                    READY   STATUS    RESTARTS   AGE
    postgresql-scalardb-0   1/1     Running   0          2m42s
@@ -68,19 +73,23 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 ## Step 3. Deploy ScalarDB Server on the Kubernetes cluster using Helm Charts
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDB container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -89,12 +98,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
 
    Please refer to the following documents for more details.
-   
+
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 1. Create a custom values file for ScalarDB Server (scalardb-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -118,7 +128,9 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -144,6 +156,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
 
 1. Create a Secret resource that includes a username and password for PostgreSQL.
+
    ```console
    kubectl create secret generic scalardb-credentials-secret \
      --from-literal=SCALAR_DB_POSTGRES_USERNAME=postgres \
@@ -151,15 +164,19 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Deploy ScalarDB Server.
+
    ```console
    helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
    ```
 
 1. Check if the ScalarDB Server pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                              READY   STATUS    RESTARTS   AGE
    postgresql-scalardb-0             1/1     Running   0          9m48s
@@ -170,13 +187,17 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    scalardb-envoy-84c475f77b-n74tk   1/1     Running   0          6s
    scalardb-envoy-84c475f77b-zbrwz   1/1     Running   0          6s
    ```
+
    If the ScalarDB Server Pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDB Server services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
    kubernetes               ClusterIP   10.96.0.1        <none>        443/TCP     47d
@@ -187,20 +208,25 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    scalardb-headless        ClusterIP   None             <none>        60051/TCP   41s
    scalardb-metrics         ClusterIP   10.108.188.10    <none>        8080/TCP    41s
    ```
+
    If the ScalarDB Server services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardb-headless` has no CLUSTER-IP.)  
 
 ## Step 4. Start a Client container
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    kubectl run scalardb-client --image eclipse-temurin:8 --command sleep inf
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardb-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardb-client   1/1     Running   0          23s
@@ -211,66 +237,86 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 The following explains the minimum steps. If you want to know more details about ScalarDB, please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardb-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git and curl commands in the Client container.
+
    ```console
    apt update && apt install -y git curl
    ```
 
 1. Clone ScalarDB git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardb.git
    ```
 
 1. Change the directory to `scalardb/`.
+
    ```console
    cd scalardb/
    ```
+
    ```console
    pwd
    ```
+
    [Command execution result]
+
    ```console
    /scalardb
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.7.0 refs/tags/v3.7.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
+
    ```console
      master
    * v3.7.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use.
 
 1. Change the directory to `docs/getting-started/`.
+
    ```console
    cd docs/getting-started/
    ```
+
    ```console
    pwd
    ```
+
    [Command execution result]
+
    ```console
    /scalardb/docs/getting-started
    ```
 
 1. Download Schema Loader from [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardb/releases/download/v3.7.0/scalardb-schema-loader-3.7.0.jar
    ```
+
    You need to use the same version of ScalarDB and Schema Loader.
 
 1. Create a configuration file (scalardb.properties) to access ScalarDB Server on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > scalardb.properties
    scalar.db.contact_points=scalardb-envoy.default.svc.cluster.local
@@ -281,6 +327,7 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Create a JSON file (emoney-transaction.json) that defines DB Schema for the sample applications.
+
    ```console
    cat << 'EOF' > emoney-transaction.json
    {
@@ -300,37 +347,50 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Run Schema Loader (Create sample TABLE).
+
    ```console
    java -jar ./scalardb-schema-loader-3.7.0.jar --config ./scalardb.properties -f emoney-transaction.json --coordinator
    ```
 
 1. Run the sample applications.
    * Charge `1000` to `user1`:
+
      ```console
      ./gradlew run --args="-action charge -amount 1000 -to user1"
      ```
+
    * Charge `0` to `merchant1` (Just create an account for `merchant1`):
+
      ```console
      ./gradlew run --args="-action charge -amount 0 -to merchant1"
      ```
+
    * Pay `100` from `user1` to `merchant1`:
+
      ```console
      ./gradlew run --args="-action pay -amount 100 -from user1 -to merchant1"
      ```
+
    * Get the balance of `user1`:
+
      ```console
      ./gradlew run --args="-action getBalance -id user1"
      ```
+
    * Get the balance of `merchant1`:
+
      ```console
      ./gradlew run --args="-action getBalance -id merchant1"
      ```
 
 1. (Optional) You can see the inserted and modified (INSERT/UPDATE) data through the sample applications using the following command. (This command needs to run on your localhost, not on the Client container.)  
+
    ```console
    kubectl exec -it postgresql-scalardb-0 -- bash -c 'export PGPASSWORD=postgres && psql -U postgres -d postgres -c "SELECT * FROM emoney.account"'
    ```
+
    [Command execution result]
+
    ```sql
        id     | balance |                tx_id                 | tx_state | tx_version | tx_prepared_at | tx_committed_at |             before_tx_id             | before_tx_state | before_tx_version | before_tx_prepared_at | before_tx_committed_at | before_balance
    -----------+---------+--------------------------------------+----------+------------+----------------+-----------------+--------------------------------------+-----------------+-------------------+-----------------------+------------------------+----------------
@@ -338,6 +398,7 @@ The following explains the minimum steps. If you want to know more details about
     user1     |     900 | 65a90225-0846-4e97-b729-151f76f6ca2f |        3 |          2 |  1667361909634 |1667361909679    | 5520cba4-625a-4886-b81f-6089bf846d18 |               3 |                 1 |         1667361897283 |          1667361897317 |           1000
    (2 rows)
    ```
+
    * Note:
        * Usually, you need to access data (records) through ScalarDB. The above command is used to explain and confirm the working of the sample applications.
 
@@ -346,12 +407,14 @@ The following explains the minimum steps. If you want to know more details about
 After completing the ScalarDB Server tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDB Server and PostgreSQL.
+
    ```console
    helm uninstall scalardb postgresql-scalardb
    ```
 
 1. Remove the Client container.
-   ```
+
+   ```console
    kubectl delete pod scalardb-client --force --grace-period 0
    ```
 

--- a/docs/3.6/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/3.6/helm-charts/getting-started-scalardl-auditor.md
@@ -72,11 +72,13 @@ ScalarDL Ledger and Auditor use some kind of database system as a backend databa
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL for Ledger.
+
    ```console
    helm install postgresql-ledger bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -84,6 +86,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Deploy PostgreSQL for Auditor.
+
    ```console
    helm install postgresql-auditor bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -91,10 +94,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL containers are running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                   READY   STATUS    RESTARTS   AGE
    postgresql-auditor-0   1/1     Running   0          11s
@@ -106,6 +112,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 We will create some configuration files and key/certificate files locally. So, create a working directory for them.
 
 1. Create a working directory.
+
    ```console
    mkdir -p ~/scalardl-test/certs/
    ```
@@ -115,11 +122,13 @@ We will create some configuration files and key/certificate files locally. So, c
 Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
 1. Change the working directory to `~/scalardl-test/certs/` directory.
+
    ```console
    cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
@@ -143,6 +152,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Auditor information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/auditor.json
    {
@@ -166,6 +176,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Client information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
@@ -189,25 +200,31 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create key/certificate files for the Ledger.
+
    ```console
    cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Auditor.
+
    ```console
    cfssl selfsign "" ./auditor.json | cfssljson -bare auditor
    ```
 
 1. Create key/certificate files for the Client.
+
    ```console
    cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
+
    ```console
    ls -1
    ```
+
    [Command execution result]
+
    ```console
    auditor-key.pem
    auditor.csr
@@ -229,24 +246,29 @@ We will deploy two ScalarDL Schema Loader pods on the Kubernetes cluster using H
 The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Auditor in PostgreSQL.  
 
 1. Change the working directory to `~/scalardl-test/`.
+
    ```console
    cd ~/scalardl-test/
    ```
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -255,12 +277,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
    Please refer to the following documents for more details.
-   
+
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 1. Create a custom values file for ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -278,7 +301,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -299,6 +324,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 
 1. Create a custom values file for ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -316,7 +342,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -336,6 +364,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Ledger.
+
    ```console
    kubectl create secret generic ledger-credentials-secret \
      --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
@@ -343,6 +372,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Auditor.
+
    ```console
    kubectl create secret generic auditor-credentials-secret \
      --from-literal=SCALAR_DL_AUDITOR_POSTGRES_USERNAME=postgres \
@@ -350,20 +380,25 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    ```
 
 1. Deploy the ScalarDL Schema Loader for Ledger.
+
    ```console
    helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Deploy the ScalarDL Schema Loader for Auditor.
+
    ```console
    helm install schema-loader-auditor scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Schema Loader pods are deployed and completed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
    postgresql-auditor-0                         1/1     Running     0          2m56s
@@ -371,12 +406,14 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          6s
    schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          10s
    ```
+
    If the ScalarDL Schema Loader pods are **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
 ## Step 6. Deploy ScalarDL Ledger and Auditor on the Kubernetes cluster using Helm Charts
 
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -411,7 +448,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -448,6 +487,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 
 1. Create a custom values file for ScalarDL Auditor (scalardl-auditor-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -482,7 +522,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -519,30 +561,37 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
 1. Create secret resource `ledger-keys`.
+
    ```console
    kubectl create secret generic ledger-keys --from-file=certificate=./certs/ledger.pem --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Create secret resource `auditor-keys`.
+
    ```console
    kubectl create secret generic auditor-keys --from-file=certificate=./certs/auditor.pem --from-file=private-key=./certs/auditor-key.pem
    ```
 
 1. Deploy the ScalarDL Ledger.
+
    ```console
    helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Deploy the ScalarDL Auditor.
+
    ```console
    helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Ledger and Auditor pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
    postgresql-auditor-0                         1/1     Running     0          14m
@@ -562,13 +611,17 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          11m
    schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          11m
    ```
+
    If the ScalarDL Ledger and Auditor pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDL Ledger and Auditor services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                             TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
    kubernetes                       ClusterIP   10.96.0.1        <none>        443/TCP                         47d
@@ -585,6 +638,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    scalardl-ledger-headless         ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   61s
    scalardl-ledger-metrics          ClusterIP   10.99.122.106    <none>        8080/TCP                        61s
    ```
+
    If the ScalarDL Ledger and Auditor services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` and `scalardl-auditor-headless` have no CLUSTER-IP.)  
 
 ## Step 7. Start a Client container
@@ -592,11 +646,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
 
 1. Create secret resource `client-keys`.
-   ```
+
+   ```console
    kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
@@ -634,10 +690,13 @@ We will use certificate files in a Client container. So, we create a secret reso
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardl-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardl-client   1/1     Running   0          4s
@@ -652,65 +711,82 @@ The following explains the minimum steps. If you want to know more details about
 When you use Auditor, you need to register the certificate for the Ledger and Auditor before starting the client application. Ledger needs to register its certificate to Auditor, and Auditor needs to register its certificate to Ledger.
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardl-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git, curl and unzip commands in the Client container.
+
    ```console
    apt update && apt install -y git curl unzip
    ```
 
 1. Clone ScalarDL Java Client SDK git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change the directory to `scalardl-java-client-sdk/`.
+
    ```console
    cd scalardl-java-client-sdk/
    ```
+
    ```console
    pwd
    ```
-   [Command execution result]
-   ```console
 
+   [Command execution result]
+
+   ```console
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
+
    ```console
      master
    * v3.6.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
 1. Build the sample contracts.
+
    ```console
    ./gradlew assemble
    ```
 
 1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
+
    You need to use the same version of CLI tools and ScalarDL Ledger.
 
 1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
+
    ```console
    unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (ledger.as.client.properties) to register the certificate of Ledger to Auditor.
+
    ```console
    cat << 'EOF' > ledger.as.client.properties
    # Ledger
@@ -728,6 +804,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Create a configuration file (auditor.as.client.properties) to register the certificate of Auditor to Ledger.
+
    ```console
    cat << 'EOF' > auditor.as.client.properties
    # Ledger
@@ -745,6 +822,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > client.properties
    # Ledger
@@ -762,46 +840,57 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Register the certificate file of Ledger.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./ledger.as.client.properties
    ```
 
 1. Register the certificate file of Auditor.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./auditor.as.client.properties
    ```
 
 1. Register the certificate file of client.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./client.properties
    ```
 
 1. Register the sample contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Register the contract `ValdateLedger` to execute a validate request.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id validate-ledger --contract-binary-name com.scalar.dl.client.contract.ValidateLedger --contract-class-file ./build/classes/java/main/com/scalar/dl/client/contract/ValidateLedger.class
    ```
 
 1. Execute the contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
+
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    ```
+
    [Command execution result]
+
    ```console
    Contract result:
    {
@@ -812,23 +901,29 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
      }
    }
    ```
+
    * Reference information
       * If the asset data is not tampered with, the contract execution request (execute-contract command) returns `OK` as a result.
       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the contract execution request (execute-contract command) returns a value other than `OK`  (e.g. `INCONSISTENT_STATES`) as a result, like the following.  
         [Command execution result (If the asset data is tampered with)]
+
         ```console
         {
           "status_code" : "INCONSISTENT_STATES",
           "error_message" : "The results from Ledger and Auditor don't match"
         }
         ```
+
           * In this way, the ScalarDL can detect data tampering.
 
 1. Execute a validation request for the asset.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
+
    [Command execution result]
+
    ```console
    {
      "status_code" : "OK",
@@ -848,16 +943,19 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
      }
    }
    ```
+
    * Reference information
       * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
         [Command execution result (If the asset data is tampered with)]
+
         ```console
         {
           "status_code" : "INCONSISTENT_STATES",
           "error_message" : "The results from Ledger and Auditor don't match"
         }
         ```
+
           * In this way, the ScalarDL Ledger can detect data tampering.
 
 ## Step 9. Delete all resources
@@ -865,19 +963,23 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
 After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
+
    ```console
    helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger scalardl-auditor schema-loader-auditor postgresql-auditor
    ```
 
 1. Remove the Client container.
+
    ```
    kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
 1. Remove the working directory and sample files (configuration file, key, and certificate).
+
    ```console
    cd ~
    ```
+   
    ```console
    rm -rf ~/scalardl-test/
    ```

--- a/docs/3.6/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/3.6/helm-charts/getting-started-scalardl-ledger.md
@@ -54,11 +54,13 @@ ScalarDL Ledger uses some kind of database system as a backend database. In this
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL.
+
    ```console
    helm install postgresql-ledger bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -66,10 +68,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL container is running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                  READY   STATUS    RESTARTS   AGE
    postgresql-ledger-0   1/1     Running   0          11s
@@ -80,6 +85,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 We will create some configuration files and key/certificate files locally. So, create a working directory for them.
 
 1. Create a working directory.
+
    ```console
    mkdir -p ~/scalardl-test/certs/
    ```
@@ -89,11 +95,13 @@ We will create some configuration files and key/certificate files locally. So, c
 Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
 1. Change the working directory to `~/scalardl-test/certs/` directory.
+
    ```console
    cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
@@ -117,6 +125,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Client information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
@@ -140,20 +149,25 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create key/certificate files for the Ledger.
+
    ```console
    cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Client.
+
    ```console
    cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
+
    ```console
    ls -1
    ```
+
    [Command execution result]
+
    ```console
    client-key.pem
    client.csr
@@ -171,24 +185,29 @@ We will deploy a ScalarDL Schema Loader on the Kubernetes cluster using Helm Cha
 The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in PostgreSQL.  
 
 1. Change the working directory to `~/scalardl-test/`.
+
    ```console
    cd ~/scalardl-test/
    ```
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -203,6 +222,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 
 1. Create a custom values file for ScalarDL Schema Loader (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -221,6 +241,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      EOF
      ```
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -240,6 +261,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL.
+
    ```console
    kubectl create secret generic ledger-credentials-secret \
      --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
@@ -247,26 +269,32 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    ```
 
 1. Deploy the ScalarDL Schema Loader.
+
    ```console
    helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Schema Loader pod is deployed and completed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    postgresql-ledger-0                         1/1     Running     0          11m
    schema-loader-ledger-schema-loading-46rcr   0/1     Completed   0          3s
    ```
+
    If the ScalarDL Schema Loader pod is **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
 ## Step 6. Deploy ScalarDL Ledger on the Kubernetes cluster using Helm Charts
 
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -300,7 +328,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -336,20 +366,25 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
 
 1. Create secret resource `ledger-keys`.
+
    ```console
    kubectl create secret generic ledger-keys --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Deploy the ScalarDL Ledger.
+
    ```console
    helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Ledger pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    postgresql-ledger-0                         1/1     Running     0          14m
@@ -361,13 +396,17 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    scalardl-ledger-ledger-9bdf7f8bd-9tw5x      1/1     Running     0          52s
    schema-loader-ledger-schema-loading-46rcr   0/1     Completed   0          3m38s
    ```
+
    If the ScalarDL Ledger pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDL Ledger services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
    kubernetes                      ClusterIP   10.96.0.1        <none>        443/TCP                         47d
@@ -378,6 +417,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    scalardl-ledger-headless        ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   83s
    scalardl-ledger-metrics         ClusterIP   10.98.4.217      <none>        8080/TCP                        83s
    ```
+
    If the ScalarDL Ledger services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` has no CLUSTER-IP.)  
 
 ## Step 7. Start a Client container
@@ -385,11 +425,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
 
 1. Create secret resource `client-keys`.
-   ```
+
+   ```console
    kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
@@ -415,10 +457,13 @@ We will use certificate files in a Client container. So, we create a secret reso
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardl-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardl-client   1/1     Running   0          11s
@@ -429,65 +474,81 @@ We will use certificate files in a Client container. So, we create a secret reso
 The following explains the minimum steps. If you want to know more details about ScalarDL and the contract, please refer to the [Getting Started with ScalarDL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md).
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardl-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git, curl and unzip commands in the Client container.
+
    ```console
    apt update && apt install -y git curl unzip
    ```
 
 1. Clone ScalarDL Java Client SDK git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change the directory to `scalardl-java-client-sdk/`.
+
    ```console
    cd scalardl-java-client-sdk/
    ```
+
    ```console
    pwd
    ```
-   [Command execution result]
-   ```console
 
+   [Command execution result]
+
+   ```console
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
    ```console
      master
    * v3.6.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
 1. Build the sample contracts.
+
    ```console
    ./gradlew assemble
    ```
 
 1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
+
    You need to use the same version of CLI tools and ScalarDL Ledger.
 
 1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
+
    ```console
    unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > client.properties
    scalar.dl.client.server.host=scalardl-ledger-envoy.default.svc.cluster.local
@@ -503,26 +564,32 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Register the sample contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Execute the contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    ```
+
    [Command execution result]
+
    ```console
    Contract result:
    {
@@ -535,10 +602,13 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Execute a validation request for the asset.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
+
    [Command execution result]
+
    ```console
    {
      "status_code" : "OK",
@@ -552,10 +622,12 @@ The following explains the minimum steps. If you want to know more details about
      "Auditor" : null
    }
    ```
+
    * Reference information
        * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
        * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
          [Command execution result (If the asset data is tampered with)]
+
          ```console
          {
            "status_code" : "INVALID_OUTPUT",
@@ -569,6 +641,7 @@ The following explains the minimum steps. If you want to know more details about
            "Auditor" : null
          }
          ```
+
            * In this way, the ScalarDL Ledger can detect data tampering.
 
 ## Step 9. Delete all resources
@@ -576,19 +649,23 @@ The following explains the minimum steps. If you want to know more details about
 After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
+
    ```console
    helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger
    ```
 
 1. Remove the Client container.
+
    ```
    kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
 1. Remove the working directory and sample files (configuration file, key, and certificate).
+
    ```console
    cd ~
    ```
+   
    ```console
    rm -rf ~/scalardl-test/
    ```

--- a/docs/3.6/helm-charts/how-to-deploy-scalar-products.md
+++ b/docs/3.6/helm-charts/how-to-deploy-scalar-products.md
@@ -15,6 +15,7 @@ You must install the helm command to use Scalar Helm Charts. Please install the 
 ```console
 helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
 ```
+
 ```console
 helm repo update scalar-labs
 ```

--- a/docs/3.6/helm-charts/how-to-deploy-scalardb-cluster.md
+++ b/docs/3.6/helm-charts/how-to-deploy-scalardb-cluster.md
@@ -31,6 +31,7 @@ If you use ScalarDB Cluster with `direct-kubernetes` mode, you must:
 This method is necessary because the ScalarDB Cluster client library with `direct-kubernetes` mode runs the Kubernetes API from inside of your application pods to get information about the ScalarDB Cluster pods.
 
 * Role
+
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -42,7 +43,9 @@ This method is necessary because the ScalarDB Cluster client library with `direc
       resources: ["endpoints"]
       verbs: ["get", "watch", "list"]
   ```
+
 * RoleBinding
+
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
@@ -57,7 +60,9 @@ This method is necessary because the ScalarDB Cluster client library with `direc
     name: scalardb-cluster-role
     apiGroup: rbac.authorization.k8s.io
   ```
+
 * ServiceAccount
+
   ```yaml
   apiVersion: v1
   kind: ServiceAccount

--- a/docs/3.6/helm-charts/mount-files-or-volumes-on-scalar-pods.md
+++ b/docs/3.6/helm-charts/mount-files-or-volumes-on-scalar-pods.md
@@ -8,6 +8,7 @@ You must mount the key and certificate files to run ScalarDL Auditor.
 
 * Configuration example
     * ScalarDL Ledger
+
       ```yaml
       ledger:
         ledgerProperties: |
@@ -16,7 +17,9 @@ You must mount the key and certificate files to run ScalarDL Auditor.
           scalar.dl.ledger.auditor.enabled=true
           scalar.dl.ledger.proof.private_key_path=/keys/private-key
       ```
+
     * ScalarDL Auditor
+
       ```yaml
       auditor:
         auditorProperties: |
@@ -30,6 +33,7 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 1. Set `extraVolumes` and `extraVolumeMounts` in the custom values file using the same syntax of Kubernetes manifest. You need to specify the directory name to the key `mountPath`.
    * Example
         * ScalarDL Ledger
+
           ```yaml
           ledger:
             extraVolumes:
@@ -41,7 +45,9 @@ In this example, you need to mount a **private-key** and a **certificate** file 
                 mountPath: /keys
                 readOnly: true
           ```
+
        * ScalarDL Auditor
+
          ```yaml
          auditor:
             extraVolumes:
@@ -60,11 +66,14 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
    * Example
        * ScalarDL Ledger
+
          ```console
          kubectl create secret generic ledger-keys \
            --from-file=private-key=./ledger-key.pem
          ```
+
        * ScalarDL Auditor
+
          ```console
          kubectl create secret generic auditor-keys \
            --from-file=private-key=./auditor-key.pem \
@@ -77,12 +86,15 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
    * Example
        * ScalarDL Ledger
+
          ```console
          $ ls -l /keys/
          total 0
          lrwxrwxrwx 1 root root 18 Jun 27 03:12 private-key -> ..data/private-key
          ```
+
        * ScalarDL Auditor
+
          ```console
          $ ls -l /keys/
          total 0
@@ -101,6 +113,7 @@ You can mount emptyDir to Scalar product pods by using the following keys in you
   * `auditor.extraVolumes` / `auditor.extraVolumeMounts` (ScalarDL Auditor)
 
 * Example (ScalarDB Server)
+
   ```yaml
   scalardb:
     extraVolumes:

--- a/docs/3.6/helm-charts/use-secret-for-credentials.md
+++ b/docs/3.6/helm-charts/use-secret-for-credentials.md
@@ -3,6 +3,7 @@
 You can pass credentials like **username** or **password** as environment variables via a `Secret` resource in Kubernetes. The docker images for previous versions of Scalar products use the `dockerize` command for templating properties files. The docker images for the latest versions of Scalar products get values directly from environment variables.
 
 Note: You cannot use the following environment variable names in your custom values file since these are used in the Scalar Helm Chart internal.
+
 ```console
 HELM_SCALAR_DB_CONTACT_POINTS
 HELM_SCALAR_DB_CONTACT_PORT
@@ -31,6 +32,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
    * Example
        * ScalarDB Server
            * ScalarDB Server 3.7 or earlier (Go template syntax)
+
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -39,7 +41,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
                   ...
              ```
+
            * ScalarDB Server 3.8 or later (Apache Commons Text syntax)
+
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -48,7 +52,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password=${env:SCALAR_DB_PASSWORD}
                   ...
              ```
+
        * ScalarDB Cluster
+
          ```yaml
          scalardbCluster:
            scalardbClusterNodeProperties: |
@@ -57,7 +63,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password=${env:SCALAR_DB_PASSWORD}
              ...
          ```
+
        * ScalarDL Ledger (Go template syntax)
+
           ```yaml
           ledger:
             ledgerProperties: |
@@ -66,7 +74,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
               scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
               ...
           ```
+
        * ScalarDL Auditor (Go template syntax)
+
          ```yaml
          auditor:
            auditorProperties: |
@@ -75,7 +85,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+
        * ScalarDL Schema Loader (Go template syntax)
+
          ```yaml
          schemaLoading:
            databaseProperties: |
@@ -88,6 +100,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 1. Create a `Secret` resource that includes credentials.  
    You need to specify the environment variable name as keys of the `Secret`.
    * Example
+
      ```console
      kubectl create secret generic scalardb-credentials-secret \
        --from-literal=SCALAR_DB_USERNAME=postgres \
@@ -103,26 +116,35 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
      * `schemaLoading.secretName` (ScalarDL Schema Loader)
    * Example
      * ScalarDB Server
+
        ```yaml
        scalardb:
          secretName: "scalardb-credentials-secret"
        ```
+
      * ScalarDB Cluster
+
        ```yaml
        scalardbCluster:
          secretName: "scalardb-cluster-credentials-secret"
        ```
+
      * ScalarDL Ledger
+
        ```yaml
        ledger:
          secretName: "ledger-credentials-secret"
        ```
+
      * ScalarDL Auditor
+
        ```yaml
        auditor:
          secretName: "auditor-credentials-secret"
        ```
+
      * ScalarDL Schema Loader
+
        ```yaml
        schemaLoading:
          secretName: "schema-loader-ledger-credentials-secret"
@@ -134,6 +156,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 
    * Example
        * Custom values file
+
          ```yaml
          scalardb:
            databaseProperties: |
@@ -142,7 +165,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              scalar.db.storage=jdbc
          ```
+
        * Properties file in containers
+       
          ```properties
          scalar.db.contact_points=jdbc:postgresql://postgresql-scalardb.default.svc.cluster.local:5432/postgres
          scalar.db.username=postgres

--- a/docs/3.7/helm-charts/ReleaseFlow.md
+++ b/docs/3.7/helm-charts/ReleaseFlow.md
@@ -1,22 +1,28 @@
 # Release Flow
 
 ## Requirements
+
 | Name | Version | Mandatory | link |
 |:------|:-------|:----------|:------|
 | Helm | 3.2.1 or latest | no | https://helm.sh/docs/intro/install/ |
 
 ## Release
+
 * You create a branch (`prepare-release-*`).
 * You make sure to create the tag from the previous version of the target version.
+
 ``` console
 $ git checkout -b prepare-release-v3.0.2  refs/tags/scalardl-3.0.1
 ```
 
 * You need to set the `version` of the `Chart.yaml` of each `helm-charts` to the version to be released.
+
 ``` yaml
 version: 3.0.2
 ```
+
 * Pushing commits to a remote repository.
+
 ``` console
 $ git push origin prepare-release-v3.0.2
 ```

--- a/docs/3.7/helm-charts/configure-custom-values-envoy.md
+++ b/docs/3.7/helm-charts/configure-custom-values-envoy.md
@@ -9,6 +9,7 @@ The Scalar Envoy chart is used via other charts (scalardb, scalardl, and scalard
 For example, if you want to configure the Scalar Envoy for ScalarDB Server, you can configure some Scalar Envoy configurations in the custom values file of ScalarDB as follows.
 
 * Example (scalardb-custom-values.yaml)
+
   ```yaml
   envoy:
     configurationsForScalarEnvoy: 

--- a/docs/3.7/helm-charts/getting-started-logging.md
+++ b/docs/3.7/helm-charts/getting-started-logging.md
@@ -47,11 +47,13 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 2. Deploy `loki-stack`
 
 1. Add the `grafana` helm repository.
+
    ```console
    helm repo add grafana https://grafana.github.io/helm-charts
    ```
 
 1. Deploy the `loki-stack` helm chart.
+
    ```console
    helm install scalar-logging-loki grafana/loki-stack -n monitoring -f scalar-loki-stack-custom-values.yaml
    ```
@@ -59,6 +61,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 3. Add a Loki data source in the Grafana configuration
 
 1. Add a configuration of the Loki data source in the `scalar-prometheus-custom-values.yaml` file.
+
    ```yaml
    grafana:
      additionalDataSources:
@@ -72,6 +75,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
    ```
 
 1. Apply the configuration (upgrade the deployment of `kube-prometheus-stack`).
+
    ```console
    helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -86,6 +90,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 5. Delete the `loki-stack` helm chart
 
 1. Uninstall `loki-stack`.
+
    ```console
    helm uninstall scalar-logging-loki -n monitoring
    ```

--- a/docs/3.7/helm-charts/getting-started-monitoring.md
+++ b/docs/3.7/helm-charts/getting-started-monitoring.md
@@ -45,6 +45,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * `grafana.service.type` to `LoadBalancer`
        * `grafana.service.port` to `3000`
    * Example
+
      ```yaml
      alertmanager:
      
@@ -68,6 +69,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
      
      ...
      ```
+
    * Note:
        * If you want to customize the Prometheus Operator deployment using Helm Charts, you need to set the following configuration for monitoring Scalar products.
            * The `serviceMonitorSelectorNilUsesHelmValues` and `ruleSelectorNilUsesHelmValues` must be set to `false` (`true` by default) to make Prometheus Operator detects `ServiceMonitor` and `PrometheusRule` of Scalar products.
@@ -75,23 +77,26 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 ## Step 3. Deploy `kube-prometheus-stack`
 
 1. Add the `prometheus-community` helm repository.
+
    ```console
    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
    ```
 
 1. Create a namespace `monitoring` on the Kubernetes.
+
    ```console
    kubectl create namespace monitoring
    ```
 
 1. Deploy the `kube-prometheus-stack`.
+
    ```console
    helm install scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
 
 ## Step 4. Deploy (or Upgrade) Scalar products using Helm Charts
 
-* Note: 
+* Note:
    * The following explains the minimum steps. If you want to know more details about the deployment of ScalarDB and ScalarDL, please refer to the following documents.
        * [Getting Started with Helm Charts (ScalarDB Server)](./getting-started-scalardb.md)
        * [Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)](./getting-started-scalardl-ledger.md)
@@ -104,6 +109,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * `*.serviceMonitor.enabled`
    * Sample configuration files
        * ScalarDB (scalardb-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -121,7 +127,9 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            serviceMonitor:
              enabled: true
          ```
+
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -139,7 +147,9 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            serviceMonitor:
              enabled: true
          ```
+
        * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -161,23 +171,31 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 1. Deploy (or Upgrade) Scalar products using Helm Charts with the above custom values file.
    * Examples
        * ScalarDB
+
          ```console
          helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
+
        * ScalarDL Ledger
+
          ```console
          helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
+
        * ScalarDL Auditor
+
          ```console
          helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
@@ -187,15 +205,19 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 ### If you use minikube
 
 1. To expose each service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
+
    ```console
    minikube tunnel
    ```
 
    After running the `minikube tunnel` command, you can see the EXTERNAL-IP of each service resource as `127.0.0.1`.
+
    ```console
    kubectl get svc -n monitoring scalar-monitoring-kube-pro-prometheus scalar-monitoring-kube-pro-alertmanager scalar-monitoring-grafana
    ```
+
    [Command execution result]
+
    ```console
    NAME                                      TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
    scalar-monitoring-kube-pro-prometheus     LoadBalancer   10.98.11.12    127.0.0.1     9090:30550/TCP   26m
@@ -205,24 +227,33 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 
 1. Access each Dashboard.
    * Prometheus
+
      ```console
      http://localhost:9090/
      ```
+
    * Alertmanager
+
      ```console
      http://localhost:9093/
      ```
+
    * Grafana
+
      ```console
      http://localhost:3000/
      ```
+
        * Note:
            * You can see the user and password of Grafana as follows.
                * user
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-user}' | base64 -d
                  ```
+
                * password
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```
@@ -236,18 +267,22 @@ If you use a Kubernetes cluster other than minikube, you need to access the Load
 After completing the Monitoring tests on the Kubernetes cluster, remove all resources.
 
 1. Terminate the `minikube tunnel` command. (If you use minikube)
+
    ```console
    Ctrl + C
    ```
 
 1. Uninstall `kube-prometheus-stack`.
+
    ```console
    helm uninstall scalar-monitoring -n monitoring
    ```
 
 1. Delete minikube. (Optional / If you use minikube)
+
    ```console
    minikube delete --all
    ```
+
    * Note:
        * If you deploy the ScalarDB or ScalarDL, you need to remove them before deleting minikube.

--- a/docs/3.7/helm-charts/getting-started-scalar-helm-charts.md
+++ b/docs/3.7/helm-charts/getting-started-scalar-helm-charts.md
@@ -28,15 +28,19 @@ First, you need to install the following tools used in this guide.
 ## Step 2. Start minikube with docker driver (Optional / If you use minikube)
 
 1. Start minikube.
+
    ```console
    minikube start
    ```
 
 1. Check the status of the minikube and pods.
+
    ```console
    kubectl get pod -A
    ```
+
    [Command execution result]
+
    ```console
    NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
    kube-system   coredns-64897985d-lbsfr            1/1     Running   1 (20h ago)   21h
@@ -47,9 +51,10 @@ First, you need to install the following tools used in this guide.
    kube-system   kube-scheduler-minikube            1/1     Running   1 (20h ago)   21h
    kube-system   storage-provisioner                1/1     Running   2 (19s ago)   21h
    ```
+
    If the minikube starts properly, you can see some pods are **Running** in the kube-system namespace.
 
-## Step 3. 
+## Step 3.
 
 After the Kubernetes cluster starts, you can try each Scalar Helm Charts on it. Please refer to the following documents for more details.
 

--- a/docs/3.7/helm-charts/getting-started-scalar-manager.md
+++ b/docs/3.7/helm-charts/getting-started-scalar-manager.md
@@ -64,6 +64,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 1. Upgrade the `kube-prometheus-stack` to allow Grafana to be embedded
 
 1. Add or revise this value to the custom values file (e.g. scalar-prometheus-custom-values.yaml) of the `kube-prometheus-stack`
+
    ```yaml
    grafana:
      grafana.ini:
@@ -73,6 +74,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
    ```
 
 1. Upgrade the Helm installation
+
    ```console
    helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -82,6 +84,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 1. Get the sample file [scalar-manager-custom-values.yaml](./conf/scalar-manager-custom-values.yaml) for `scalar-manager`.
 
 1. Add the targets that you would like to manage. For example, if we want to manage a ledger cluster, then we can add the values as follows.
+
    ```yaml
    scalarManager:
      targets:
@@ -89,21 +92,25 @@ We will deploy the following components on a Kubernetes cluster as follows.
          adminSrv: _scalardl-admin._tcp.scalardl-headless.default.svc.cluster.local
          databaseType: cassandra
    ```
+
    Note: the `adminSrv` is the DNS Service URL that returns SRV record of pods. Kubernetes creates this URL for the named port of the headless service of the Scalar product. The format is `_{port name}._{protocol}.{service name}.{namespace}.svc.{cluster domain name}`
 
 1. Set the Grafana URL. For example, if your Grafana of the `kube-prometheus-stack` is exposed in `localhost:3000`, then we can set it as follows.
+
    ```yaml
    scalarManager:
      grafanaUrl: "http://localhost:3000"
    ```
 
 1. Set the refresh interval that Scalar Manager checks the status of the products. The default value is `30` seconds, but we can change it like:
+
    ```yaml
    scalarManager:
      refreshInterval: 60 # one minute
    ```
 
 1. Set the service type to access Scalar Manager. The default value is `ClusterIP`, but if we access using the `minikube tunnel` command or some load balancer, we can set it as `LoadBalancer`.
+
    ```yaml
    service:
      type: LoadBalancer
@@ -112,11 +119,13 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 3. Deploy `scalar-manager`
 
 1. Create a secret resource `reg-docker-secrets` to pull the Scalar Manager container image from GitHub Packages.
+
    ```console
    kubectl create secret docker-registry reg-docker-secrets --docker-server=ghcr.io --docker-username=<github-username> --docker-password=<github-personal-access-token>
    ```
 
 1. Deploy the `scalar-manager` Helm Chart.
+
    ```console
    helm install scalar-manager scalar-labs/scalar-manager -f scalar-manager-custom-values.yaml
    ```
@@ -126,6 +135,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ### If you use minikube
 
 1. To expose Scalar Manager's service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
+
    ```console
    minikube tunnel
    ```
@@ -138,6 +148,7 @@ If you use a Kubernetes cluster other than minikube, you need to access the Load
 
 ## Step 5. Delete Scalar Manager
 1. Uninstall `scalar-manager`
+
    ```console
    helm uninstall scalar-manager
    ```

--- a/docs/3.7/helm-charts/getting-started-scalardb.md
+++ b/docs/3.7/helm-charts/getting-started-scalardb.md
@@ -44,11 +44,13 @@ ScalarDB uses some kind of database system as a backend database. In this docume
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL.
+
    ```console
    helm install postgresql-scalardb bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -56,10 +58,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL container is running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                    READY   STATUS    RESTARTS   AGE
    postgresql-scalardb-0   1/1     Running   0          2m42s
@@ -68,19 +73,23 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 ## Step 3. Deploy ScalarDB Server on the Kubernetes cluster using Helm Charts
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDB container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -89,12 +98,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
 
    Please refer to the following documents for more details.
-   
+
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 1. Create a custom values file for ScalarDB Server (scalardb-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -118,7 +128,9 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -144,6 +156,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
 
 1. Create a Secret resource that includes a username and password for PostgreSQL.
+
    ```console
    kubectl create secret generic scalardb-credentials-secret \
      --from-literal=SCALAR_DB_POSTGRES_USERNAME=postgres \
@@ -151,15 +164,19 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Deploy ScalarDB Server.
+
    ```console
    helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
    ```
 
 1. Check if the ScalarDB Server pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                              READY   STATUS    RESTARTS   AGE
    postgresql-scalardb-0             1/1     Running   0          9m48s
@@ -170,13 +187,17 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    scalardb-envoy-84c475f77b-n74tk   1/1     Running   0          6s
    scalardb-envoy-84c475f77b-zbrwz   1/1     Running   0          6s
    ```
+
    If the ScalarDB Server Pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDB Server services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
    kubernetes               ClusterIP   10.96.0.1        <none>        443/TCP     47d
@@ -187,20 +208,25 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    scalardb-headless        ClusterIP   None             <none>        60051/TCP   41s
    scalardb-metrics         ClusterIP   10.108.188.10    <none>        8080/TCP    41s
    ```
+
    If the ScalarDB Server services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardb-headless` has no CLUSTER-IP.)  
 
 ## Step 4. Start a Client container
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    kubectl run scalardb-client --image eclipse-temurin:8 --command sleep inf
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardb-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardb-client   1/1     Running   0          23s
@@ -211,66 +237,86 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 The following explains the minimum steps. If you want to know more details about ScalarDB, please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardb-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git and curl commands in the Client container.
+
    ```console
    apt update && apt install -y git curl
    ```
 
 1. Clone ScalarDB git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardb.git
    ```
 
 1. Change the directory to `scalardb/`.
+
    ```console
    cd scalardb/
    ```
+
    ```console
    pwd
    ```
+
    [Command execution result]
+
    ```console
    /scalardb
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.7.0 refs/tags/v3.7.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
+
    ```console
      master
    * v3.7.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use.
 
 1. Change the directory to `docs/getting-started/`.
+
    ```console
    cd docs/getting-started/
    ```
+
    ```console
    pwd
    ```
+
    [Command execution result]
+
    ```console
    /scalardb/docs/getting-started
    ```
 
 1. Download Schema Loader from [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardb/releases/download/v3.7.0/scalardb-schema-loader-3.7.0.jar
    ```
+
    You need to use the same version of ScalarDB and Schema Loader.
 
 1. Create a configuration file (scalardb.properties) to access ScalarDB Server on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > scalardb.properties
    scalar.db.contact_points=scalardb-envoy.default.svc.cluster.local
@@ -281,6 +327,7 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Create a JSON file (emoney-transaction.json) that defines DB Schema for the sample applications.
+
    ```console
    cat << 'EOF' > emoney-transaction.json
    {
@@ -300,37 +347,50 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Run Schema Loader (Create sample TABLE).
+
    ```console
    java -jar ./scalardb-schema-loader-3.7.0.jar --config ./scalardb.properties -f emoney-transaction.json --coordinator
    ```
 
 1. Run the sample applications.
    * Charge `1000` to `user1`:
+
      ```console
      ./gradlew run --args="-action charge -amount 1000 -to user1"
      ```
+
    * Charge `0` to `merchant1` (Just create an account for `merchant1`):
+
      ```console
      ./gradlew run --args="-action charge -amount 0 -to merchant1"
      ```
+
    * Pay `100` from `user1` to `merchant1`:
+
      ```console
      ./gradlew run --args="-action pay -amount 100 -from user1 -to merchant1"
      ```
+
    * Get the balance of `user1`:
+
      ```console
      ./gradlew run --args="-action getBalance -id user1"
      ```
+
    * Get the balance of `merchant1`:
+
      ```console
      ./gradlew run --args="-action getBalance -id merchant1"
      ```
 
 1. (Optional) You can see the inserted and modified (INSERT/UPDATE) data through the sample applications using the following command. (This command needs to run on your localhost, not on the Client container.)  
+
    ```console
    kubectl exec -it postgresql-scalardb-0 -- bash -c 'export PGPASSWORD=postgres && psql -U postgres -d postgres -c "SELECT * FROM emoney.account"'
    ```
+
    [Command execution result]
+
    ```sql
        id     | balance |                tx_id                 | tx_state | tx_version | tx_prepared_at | tx_committed_at |             before_tx_id             | before_tx_state | before_tx_version | before_tx_prepared_at | before_tx_committed_at | before_balance
    -----------+---------+--------------------------------------+----------+------------+----------------+-----------------+--------------------------------------+-----------------+-------------------+-----------------------+------------------------+----------------
@@ -338,6 +398,7 @@ The following explains the minimum steps. If you want to know more details about
     user1     |     900 | 65a90225-0846-4e97-b729-151f76f6ca2f |        3 |          2 |  1667361909634 |1667361909679    | 5520cba4-625a-4886-b81f-6089bf846d18 |               3 |                 1 |         1667361897283 |          1667361897317 |           1000
    (2 rows)
    ```
+
    * Note:
        * Usually, you need to access data (records) through ScalarDB. The above command is used to explain and confirm the working of the sample applications.
 
@@ -346,12 +407,14 @@ The following explains the minimum steps. If you want to know more details about
 After completing the ScalarDB Server tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDB Server and PostgreSQL.
+
    ```console
    helm uninstall scalardb postgresql-scalardb
    ```
 
 1. Remove the Client container.
-   ```
+
+   ```console
    kubectl delete pod scalardb-client --force --grace-period 0
    ```
 

--- a/docs/3.7/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/3.7/helm-charts/getting-started-scalardl-auditor.md
@@ -72,11 +72,13 @@ ScalarDL Ledger and Auditor use some kind of database system as a backend databa
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL for Ledger.
+
    ```console
    helm install postgresql-ledger bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -84,6 +86,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Deploy PostgreSQL for Auditor.
+
    ```console
    helm install postgresql-auditor bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -91,10 +94,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL containers are running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                   READY   STATUS    RESTARTS   AGE
    postgresql-auditor-0   1/1     Running   0          11s
@@ -106,6 +112,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 We will create some configuration files and key/certificate files locally. So, create a working directory for them.
 
 1. Create a working directory.
+
    ```console
    mkdir -p ~/scalardl-test/certs/
    ```
@@ -115,11 +122,13 @@ We will create some configuration files and key/certificate files locally. So, c
 Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
 1. Change the working directory to `~/scalardl-test/certs/` directory.
+
    ```console
    cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
@@ -143,6 +152,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Auditor information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/auditor.json
    {
@@ -166,6 +176,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Client information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
@@ -189,25 +200,31 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create key/certificate files for the Ledger.
+
    ```console
    cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Auditor.
+
    ```console
    cfssl selfsign "" ./auditor.json | cfssljson -bare auditor
    ```
 
 1. Create key/certificate files for the Client.
+
    ```console
    cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
+
    ```console
    ls -1
    ```
+
    [Command execution result]
+
    ```console
    auditor-key.pem
    auditor.csr
@@ -229,24 +246,29 @@ We will deploy two ScalarDL Schema Loader pods on the Kubernetes cluster using H
 The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Auditor in PostgreSQL.  
 
 1. Change the working directory to `~/scalardl-test/`.
+
    ```console
    cd ~/scalardl-test/
    ```
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -255,12 +277,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
    Please refer to the following documents for more details.
-   
+
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 1. Create a custom values file for ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -278,7 +301,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -299,6 +324,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 
 1. Create a custom values file for ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -316,7 +342,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -336,6 +364,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Ledger.
+
    ```console
    kubectl create secret generic ledger-credentials-secret \
      --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
@@ -343,6 +372,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Auditor.
+
    ```console
    kubectl create secret generic auditor-credentials-secret \
      --from-literal=SCALAR_DL_AUDITOR_POSTGRES_USERNAME=postgres \
@@ -350,20 +380,25 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    ```
 
 1. Deploy the ScalarDL Schema Loader for Ledger.
+
    ```console
    helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Deploy the ScalarDL Schema Loader for Auditor.
+
    ```console
    helm install schema-loader-auditor scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Schema Loader pods are deployed and completed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
    postgresql-auditor-0                         1/1     Running     0          2m56s
@@ -371,12 +406,14 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          6s
    schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          10s
    ```
+
    If the ScalarDL Schema Loader pods are **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
 ## Step 6. Deploy ScalarDL Ledger and Auditor on the Kubernetes cluster using Helm Charts
 
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -411,7 +448,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -448,6 +487,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 
 1. Create a custom values file for ScalarDL Auditor (scalardl-auditor-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -482,7 +522,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -519,30 +561,37 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
 1. Create secret resource `ledger-keys`.
+
    ```console
    kubectl create secret generic ledger-keys --from-file=certificate=./certs/ledger.pem --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Create secret resource `auditor-keys`.
+
    ```console
    kubectl create secret generic auditor-keys --from-file=certificate=./certs/auditor.pem --from-file=private-key=./certs/auditor-key.pem
    ```
 
 1. Deploy the ScalarDL Ledger.
+
    ```console
    helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Deploy the ScalarDL Auditor.
+
    ```console
    helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Ledger and Auditor pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
    postgresql-auditor-0                         1/1     Running     0          14m
@@ -562,13 +611,17 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          11m
    schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          11m
    ```
+
    If the ScalarDL Ledger and Auditor pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDL Ledger and Auditor services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                             TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
    kubernetes                       ClusterIP   10.96.0.1        <none>        443/TCP                         47d
@@ -585,6 +638,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    scalardl-ledger-headless         ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   61s
    scalardl-ledger-metrics          ClusterIP   10.99.122.106    <none>        8080/TCP                        61s
    ```
+
    If the ScalarDL Ledger and Auditor services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` and `scalardl-auditor-headless` have no CLUSTER-IP.)  
 
 ## Step 7. Start a Client container
@@ -592,11 +646,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
 
 1. Create secret resource `client-keys`.
-   ```
+
+   ```console
    kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
@@ -634,10 +690,13 @@ We will use certificate files in a Client container. So, we create a secret reso
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardl-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardl-client   1/1     Running   0          4s
@@ -652,65 +711,82 @@ The following explains the minimum steps. If you want to know more details about
 When you use Auditor, you need to register the certificate for the Ledger and Auditor before starting the client application. Ledger needs to register its certificate to Auditor, and Auditor needs to register its certificate to Ledger.
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardl-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git, curl and unzip commands in the Client container.
+
    ```console
    apt update && apt install -y git curl unzip
    ```
 
 1. Clone ScalarDL Java Client SDK git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change the directory to `scalardl-java-client-sdk/`.
+
    ```console
    cd scalardl-java-client-sdk/
    ```
+
    ```console
    pwd
    ```
-   [Command execution result]
-   ```console
 
+   [Command execution result]
+
+   ```console
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
+
    ```console
      master
    * v3.6.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
 1. Build the sample contracts.
+
    ```console
    ./gradlew assemble
    ```
 
 1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
+
    You need to use the same version of CLI tools and ScalarDL Ledger.
 
 1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
+
    ```console
    unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (ledger.as.client.properties) to register the certificate of Ledger to Auditor.
+
    ```console
    cat << 'EOF' > ledger.as.client.properties
    # Ledger
@@ -728,6 +804,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Create a configuration file (auditor.as.client.properties) to register the certificate of Auditor to Ledger.
+
    ```console
    cat << 'EOF' > auditor.as.client.properties
    # Ledger
@@ -745,6 +822,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > client.properties
    # Ledger
@@ -762,46 +840,57 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Register the certificate file of Ledger.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./ledger.as.client.properties
    ```
 
 1. Register the certificate file of Auditor.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./auditor.as.client.properties
    ```
 
 1. Register the certificate file of client.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./client.properties
    ```
 
 1. Register the sample contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Register the contract `ValdateLedger` to execute a validate request.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id validate-ledger --contract-binary-name com.scalar.dl.client.contract.ValidateLedger --contract-class-file ./build/classes/java/main/com/scalar/dl/client/contract/ValidateLedger.class
    ```
 
 1. Execute the contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
+
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    ```
+
    [Command execution result]
+
    ```console
    Contract result:
    {
@@ -812,23 +901,29 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
      }
    }
    ```
+
    * Reference information
       * If the asset data is not tampered with, the contract execution request (execute-contract command) returns `OK` as a result.
       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the contract execution request (execute-contract command) returns a value other than `OK`  (e.g. `INCONSISTENT_STATES`) as a result, like the following.  
         [Command execution result (If the asset data is tampered with)]
+
         ```console
         {
           "status_code" : "INCONSISTENT_STATES",
           "error_message" : "The results from Ledger and Auditor don't match"
         }
         ```
+
           * In this way, the ScalarDL can detect data tampering.
 
 1. Execute a validation request for the asset.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
+
    [Command execution result]
+
    ```console
    {
      "status_code" : "OK",
@@ -848,16 +943,19 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
      }
    }
    ```
+
    * Reference information
       * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
         [Command execution result (If the asset data is tampered with)]
+
         ```console
         {
           "status_code" : "INCONSISTENT_STATES",
           "error_message" : "The results from Ledger and Auditor don't match"
         }
         ```
+
           * In this way, the ScalarDL Ledger can detect data tampering.
 
 ## Step 9. Delete all resources
@@ -865,19 +963,23 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
 After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
+
    ```console
    helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger scalardl-auditor schema-loader-auditor postgresql-auditor
    ```
 
 1. Remove the Client container.
+
    ```
    kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
 1. Remove the working directory and sample files (configuration file, key, and certificate).
+
    ```console
    cd ~
    ```
+   
    ```console
    rm -rf ~/scalardl-test/
    ```

--- a/docs/3.7/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/3.7/helm-charts/getting-started-scalardl-ledger.md
@@ -54,11 +54,13 @@ ScalarDL Ledger uses some kind of database system as a backend database. In this
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL.
+
    ```console
    helm install postgresql-ledger bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -66,10 +68,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL container is running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                  READY   STATUS    RESTARTS   AGE
    postgresql-ledger-0   1/1     Running   0          11s
@@ -80,6 +85,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 We will create some configuration files and key/certificate files locally. So, create a working directory for them.
 
 1. Create a working directory.
+
    ```console
    mkdir -p ~/scalardl-test/certs/
    ```
@@ -89,11 +95,13 @@ We will create some configuration files and key/certificate files locally. So, c
 Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
 1. Change the working directory to `~/scalardl-test/certs/` directory.
+
    ```console
    cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
@@ -117,6 +125,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Client information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
@@ -140,20 +149,25 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create key/certificate files for the Ledger.
+
    ```console
    cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Client.
+
    ```console
    cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
+
    ```console
    ls -1
    ```
+
    [Command execution result]
+
    ```console
    client-key.pem
    client.csr
@@ -171,24 +185,29 @@ We will deploy a ScalarDL Schema Loader on the Kubernetes cluster using Helm Cha
 The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in PostgreSQL.  
 
 1. Change the working directory to `~/scalardl-test/`.
+
    ```console
    cd ~/scalardl-test/
    ```
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -203,6 +222,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 
 1. Create a custom values file for ScalarDL Schema Loader (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -221,6 +241,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      EOF
      ```
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -240,6 +261,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL.
+
    ```console
    kubectl create secret generic ledger-credentials-secret \
      --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
@@ -247,26 +269,32 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    ```
 
 1. Deploy the ScalarDL Schema Loader.
+
    ```console
    helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Schema Loader pod is deployed and completed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    postgresql-ledger-0                         1/1     Running     0          11m
    schema-loader-ledger-schema-loading-46rcr   0/1     Completed   0          3s
    ```
+
    If the ScalarDL Schema Loader pod is **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
 ## Step 6. Deploy ScalarDL Ledger on the Kubernetes cluster using Helm Charts
 
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -300,7 +328,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -336,20 +366,25 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
 
 1. Create secret resource `ledger-keys`.
+
    ```console
    kubectl create secret generic ledger-keys --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Deploy the ScalarDL Ledger.
+
    ```console
    helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Ledger pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    postgresql-ledger-0                         1/1     Running     0          14m
@@ -361,13 +396,17 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    scalardl-ledger-ledger-9bdf7f8bd-9tw5x      1/1     Running     0          52s
    schema-loader-ledger-schema-loading-46rcr   0/1     Completed   0          3m38s
    ```
+
    If the ScalarDL Ledger pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDL Ledger services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
    kubernetes                      ClusterIP   10.96.0.1        <none>        443/TCP                         47d
@@ -378,6 +417,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    scalardl-ledger-headless        ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   83s
    scalardl-ledger-metrics         ClusterIP   10.98.4.217      <none>        8080/TCP                        83s
    ```
+
    If the ScalarDL Ledger services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` has no CLUSTER-IP.)  
 
 ## Step 7. Start a Client container
@@ -385,11 +425,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
 
 1. Create secret resource `client-keys`.
-   ```
+
+   ```console
    kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
@@ -415,10 +457,13 @@ We will use certificate files in a Client container. So, we create a secret reso
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardl-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardl-client   1/1     Running   0          11s
@@ -429,65 +474,81 @@ We will use certificate files in a Client container. So, we create a secret reso
 The following explains the minimum steps. If you want to know more details about ScalarDL and the contract, please refer to the [Getting Started with ScalarDL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md).
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardl-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git, curl and unzip commands in the Client container.
+
    ```console
    apt update && apt install -y git curl unzip
    ```
 
 1. Clone ScalarDL Java Client SDK git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change the directory to `scalardl-java-client-sdk/`.
+
    ```console
    cd scalardl-java-client-sdk/
    ```
+
    ```console
    pwd
    ```
-   [Command execution result]
-   ```console
 
+   [Command execution result]
+
+   ```console
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
    ```console
      master
    * v3.6.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
 1. Build the sample contracts.
+
    ```console
    ./gradlew assemble
    ```
 
 1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
+
    You need to use the same version of CLI tools and ScalarDL Ledger.
 
 1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
+
    ```console
    unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > client.properties
    scalar.dl.client.server.host=scalardl-ledger-envoy.default.svc.cluster.local
@@ -503,26 +564,32 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Register the sample contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Execute the contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    ```
+
    [Command execution result]
+
    ```console
    Contract result:
    {
@@ -535,10 +602,13 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Execute a validation request for the asset.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
+
    [Command execution result]
+
    ```console
    {
      "status_code" : "OK",
@@ -552,10 +622,12 @@ The following explains the minimum steps. If you want to know more details about
      "Auditor" : null
    }
    ```
+
    * Reference information
        * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
        * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
          [Command execution result (If the asset data is tampered with)]
+
          ```console
          {
            "status_code" : "INVALID_OUTPUT",
@@ -569,6 +641,7 @@ The following explains the minimum steps. If you want to know more details about
            "Auditor" : null
          }
          ```
+
            * In this way, the ScalarDL Ledger can detect data tampering.
 
 ## Step 9. Delete all resources
@@ -576,19 +649,23 @@ The following explains the minimum steps. If you want to know more details about
 After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
+
    ```console
    helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger
    ```
 
 1. Remove the Client container.
+
    ```
    kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
 1. Remove the working directory and sample files (configuration file, key, and certificate).
+
    ```console
    cd ~
    ```
+   
    ```console
    rm -rf ~/scalardl-test/
    ```

--- a/docs/3.7/helm-charts/how-to-deploy-scalar-products.md
+++ b/docs/3.7/helm-charts/how-to-deploy-scalar-products.md
@@ -15,6 +15,7 @@ You must install the helm command to use Scalar Helm Charts. Please install the 
 ```console
 helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
 ```
+
 ```console
 helm repo update scalar-labs
 ```

--- a/docs/3.7/helm-charts/how-to-deploy-scalardb-cluster.md
+++ b/docs/3.7/helm-charts/how-to-deploy-scalardb-cluster.md
@@ -31,6 +31,7 @@ If you use ScalarDB Cluster with `direct-kubernetes` mode, you must:
 This method is necessary because the ScalarDB Cluster client library with `direct-kubernetes` mode runs the Kubernetes API from inside of your application pods to get information about the ScalarDB Cluster pods.
 
 * Role
+
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -42,7 +43,9 @@ This method is necessary because the ScalarDB Cluster client library with `direc
       resources: ["endpoints"]
       verbs: ["get", "watch", "list"]
   ```
+
 * RoleBinding
+
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
@@ -57,7 +60,9 @@ This method is necessary because the ScalarDB Cluster client library with `direc
     name: scalardb-cluster-role
     apiGroup: rbac.authorization.k8s.io
   ```
+
 * ServiceAccount
+
   ```yaml
   apiVersion: v1
   kind: ServiceAccount

--- a/docs/3.7/helm-charts/mount-files-or-volumes-on-scalar-pods.md
+++ b/docs/3.7/helm-charts/mount-files-or-volumes-on-scalar-pods.md
@@ -8,6 +8,7 @@ You must mount the key and certificate files to run ScalarDL Auditor.
 
 * Configuration example
     * ScalarDL Ledger
+
       ```yaml
       ledger:
         ledgerProperties: |
@@ -16,7 +17,9 @@ You must mount the key and certificate files to run ScalarDL Auditor.
           scalar.dl.ledger.auditor.enabled=true
           scalar.dl.ledger.proof.private_key_path=/keys/private-key
       ```
+
     * ScalarDL Auditor
+
       ```yaml
       auditor:
         auditorProperties: |
@@ -30,6 +33,7 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 1. Set `extraVolumes` and `extraVolumeMounts` in the custom values file using the same syntax of Kubernetes manifest. You need to specify the directory name to the key `mountPath`.
    * Example
         * ScalarDL Ledger
+
           ```yaml
           ledger:
             extraVolumes:
@@ -41,7 +45,9 @@ In this example, you need to mount a **private-key** and a **certificate** file 
                 mountPath: /keys
                 readOnly: true
           ```
+
        * ScalarDL Auditor
+
          ```yaml
          auditor:
             extraVolumes:
@@ -60,11 +66,14 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
    * Example
        * ScalarDL Ledger
+
          ```console
          kubectl create secret generic ledger-keys \
            --from-file=private-key=./ledger-key.pem
          ```
+
        * ScalarDL Auditor
+
          ```console
          kubectl create secret generic auditor-keys \
            --from-file=private-key=./auditor-key.pem \
@@ -77,12 +86,15 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
    * Example
        * ScalarDL Ledger
+
          ```console
          $ ls -l /keys/
          total 0
          lrwxrwxrwx 1 root root 18 Jun 27 03:12 private-key -> ..data/private-key
          ```
+
        * ScalarDL Auditor
+
          ```console
          $ ls -l /keys/
          total 0
@@ -101,6 +113,7 @@ You can mount emptyDir to Scalar product pods by using the following keys in you
   * `auditor.extraVolumes` / `auditor.extraVolumeMounts` (ScalarDL Auditor)
 
 * Example (ScalarDB Server)
+
   ```yaml
   scalardb:
     extraVolumes:

--- a/docs/3.7/helm-charts/use-secret-for-credentials.md
+++ b/docs/3.7/helm-charts/use-secret-for-credentials.md
@@ -3,6 +3,7 @@
 You can pass credentials like **username** or **password** as environment variables via a `Secret` resource in Kubernetes. The docker images for previous versions of Scalar products use the `dockerize` command for templating properties files. The docker images for the latest versions of Scalar products get values directly from environment variables.
 
 Note: You cannot use the following environment variable names in your custom values file since these are used in the Scalar Helm Chart internal.
+
 ```console
 HELM_SCALAR_DB_CONTACT_POINTS
 HELM_SCALAR_DB_CONTACT_PORT
@@ -31,6 +32,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
    * Example
        * ScalarDB Server
            * ScalarDB Server 3.7 or earlier (Go template syntax)
+
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -39,7 +41,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
                   ...
              ```
+
            * ScalarDB Server 3.8 or later (Apache Commons Text syntax)
+
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -48,7 +52,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password=${env:SCALAR_DB_PASSWORD}
                   ...
              ```
+
        * ScalarDB Cluster
+
          ```yaml
          scalardbCluster:
            scalardbClusterNodeProperties: |
@@ -57,7 +63,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password=${env:SCALAR_DB_PASSWORD}
              ...
          ```
+
        * ScalarDL Ledger (Go template syntax)
+
           ```yaml
           ledger:
             ledgerProperties: |
@@ -66,7 +74,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
               scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
               ...
           ```
+
        * ScalarDL Auditor (Go template syntax)
+
          ```yaml
          auditor:
            auditorProperties: |
@@ -75,7 +85,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+
        * ScalarDL Schema Loader (Go template syntax)
+
          ```yaml
          schemaLoading:
            databaseProperties: |
@@ -88,6 +100,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 1. Create a `Secret` resource that includes credentials.  
    You need to specify the environment variable name as keys of the `Secret`.
    * Example
+
      ```console
      kubectl create secret generic scalardb-credentials-secret \
        --from-literal=SCALAR_DB_USERNAME=postgres \
@@ -103,26 +116,35 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
      * `schemaLoading.secretName` (ScalarDL Schema Loader)
    * Example
      * ScalarDB Server
+
        ```yaml
        scalardb:
          secretName: "scalardb-credentials-secret"
        ```
+
      * ScalarDB Cluster
+
        ```yaml
        scalardbCluster:
          secretName: "scalardb-cluster-credentials-secret"
        ```
+
      * ScalarDL Ledger
+
        ```yaml
        ledger:
          secretName: "ledger-credentials-secret"
        ```
+
      * ScalarDL Auditor
+
        ```yaml
        auditor:
          secretName: "auditor-credentials-secret"
        ```
+
      * ScalarDL Schema Loader
+
        ```yaml
        schemaLoading:
          secretName: "schema-loader-ledger-credentials-secret"
@@ -134,6 +156,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 
    * Example
        * Custom values file
+
          ```yaml
          scalardb:
            databaseProperties: |
@@ -142,7 +165,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              scalar.db.storage=jdbc
          ```
+
        * Properties file in containers
+       
          ```properties
          scalar.db.contact_points=jdbc:postgresql://postgresql-scalardb.default.svc.cluster.local:5432/postgres
          scalar.db.username=postgres

--- a/docs/3.8/helm-charts/ReleaseFlow.md
+++ b/docs/3.8/helm-charts/ReleaseFlow.md
@@ -1,22 +1,28 @@
 # Release Flow
 
 ## Requirements
+
 | Name | Version | Mandatory | link |
 |:------|:-------|:----------|:------|
 | Helm | 3.2.1 or latest | no | https://helm.sh/docs/intro/install/ |
 
 ## Release
+
 * You create a branch (`prepare-release-*`).
 * You make sure to create the tag from the previous version of the target version.
+
 ``` console
 $ git checkout -b prepare-release-v3.0.2  refs/tags/scalardl-3.0.1
 ```
 
 * You need to set the `version` of the `Chart.yaml` of each `helm-charts` to the version to be released.
+
 ``` yaml
 version: 3.0.2
 ```
+
 * Pushing commits to a remote repository.
+
 ``` console
 $ git push origin prepare-release-v3.0.2
 ```

--- a/docs/3.8/helm-charts/configure-custom-values-envoy.md
+++ b/docs/3.8/helm-charts/configure-custom-values-envoy.md
@@ -9,6 +9,7 @@ The Scalar Envoy chart is used via other charts (scalardb, scalardl, and scalard
 For example, if you want to configure the Scalar Envoy for ScalarDB Server, you can configure some Scalar Envoy configurations in the custom values file of ScalarDB as follows.
 
 * Example (scalardb-custom-values.yaml)
+
   ```yaml
   envoy:
     configurationsForScalarEnvoy: 

--- a/docs/3.8/helm-charts/getting-started-logging.md
+++ b/docs/3.8/helm-charts/getting-started-logging.md
@@ -47,11 +47,13 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 2. Deploy `loki-stack`
 
 1. Add the `grafana` helm repository.
+
    ```console
    helm repo add grafana https://grafana.github.io/helm-charts
    ```
 
 1. Deploy the `loki-stack` helm chart.
+
    ```console
    helm install scalar-logging-loki grafana/loki-stack -n monitoring -f scalar-loki-stack-custom-values.yaml
    ```
@@ -59,6 +61,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 3. Add a Loki data source in the Grafana configuration
 
 1. Add a configuration of the Loki data source in the `scalar-prometheus-custom-values.yaml` file.
+
    ```yaml
    grafana:
      additionalDataSources:
@@ -72,6 +75,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
    ```
 
 1. Apply the configuration (upgrade the deployment of `kube-prometheus-stack`).
+
    ```console
    helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -86,6 +90,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 5. Delete the `loki-stack` helm chart
 
 1. Uninstall `loki-stack`.
+
    ```console
    helm uninstall scalar-logging-loki -n monitoring
    ```

--- a/docs/3.8/helm-charts/getting-started-monitoring.md
+++ b/docs/3.8/helm-charts/getting-started-monitoring.md
@@ -45,6 +45,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * `grafana.service.type` to `LoadBalancer`
        * `grafana.service.port` to `3000`
    * Example
+
      ```yaml
      alertmanager:
      
@@ -68,6 +69,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
      
      ...
      ```
+
    * Note:
        * If you want to customize the Prometheus Operator deployment using Helm Charts, you need to set the following configuration for monitoring Scalar products.
            * The `serviceMonitorSelectorNilUsesHelmValues` and `ruleSelectorNilUsesHelmValues` must be set to `false` (`true` by default) to make Prometheus Operator detects `ServiceMonitor` and `PrometheusRule` of Scalar products.
@@ -75,23 +77,26 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 ## Step 3. Deploy `kube-prometheus-stack`
 
 1. Add the `prometheus-community` helm repository.
+
    ```console
    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
    ```
 
 1. Create a namespace `monitoring` on the Kubernetes.
+
    ```console
    kubectl create namespace monitoring
    ```
 
 1. Deploy the `kube-prometheus-stack`.
+
    ```console
    helm install scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
 
 ## Step 4. Deploy (or Upgrade) Scalar products using Helm Charts
 
-* Note: 
+* Note:
    * The following explains the minimum steps. If you want to know more details about the deployment of ScalarDB and ScalarDL, please refer to the following documents.
        * [Getting Started with Helm Charts (ScalarDB Server)](./getting-started-scalardb.md)
        * [Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)](./getting-started-scalardl-ledger.md)
@@ -104,6 +109,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * `*.serviceMonitor.enabled`
    * Sample configuration files
        * ScalarDB (scalardb-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -121,7 +127,9 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            serviceMonitor:
              enabled: true
          ```
+
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -139,7 +147,9 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            serviceMonitor:
              enabled: true
          ```
+
        * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -161,23 +171,31 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 1. Deploy (or Upgrade) Scalar products using Helm Charts with the above custom values file.
    * Examples
        * ScalarDB
+
          ```console
          helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
+
        * ScalarDL Ledger
+
          ```console
          helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
+
        * ScalarDL Auditor
+
          ```console
          helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
@@ -187,15 +205,19 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 ### If you use minikube
 
 1. To expose each service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
+
    ```console
    minikube tunnel
    ```
 
    After running the `minikube tunnel` command, you can see the EXTERNAL-IP of each service resource as `127.0.0.1`.
+
    ```console
    kubectl get svc -n monitoring scalar-monitoring-kube-pro-prometheus scalar-monitoring-kube-pro-alertmanager scalar-monitoring-grafana
    ```
+
    [Command execution result]
+
    ```console
    NAME                                      TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
    scalar-monitoring-kube-pro-prometheus     LoadBalancer   10.98.11.12    127.0.0.1     9090:30550/TCP   26m
@@ -205,24 +227,33 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 
 1. Access each Dashboard.
    * Prometheus
+
      ```console
      http://localhost:9090/
      ```
+
    * Alertmanager
+
      ```console
      http://localhost:9093/
      ```
+
    * Grafana
+
      ```console
      http://localhost:3000/
      ```
+
        * Note:
            * You can see the user and password of Grafana as follows.
                * user
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-user}' | base64 -d
                  ```
+
                * password
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```
@@ -236,18 +267,22 @@ If you use a Kubernetes cluster other than minikube, you need to access the Load
 After completing the Monitoring tests on the Kubernetes cluster, remove all resources.
 
 1. Terminate the `minikube tunnel` command. (If you use minikube)
+
    ```console
    Ctrl + C
    ```
 
 1. Uninstall `kube-prometheus-stack`.
+
    ```console
    helm uninstall scalar-monitoring -n monitoring
    ```
 
 1. Delete minikube. (Optional / If you use minikube)
+
    ```console
    minikube delete --all
    ```
+
    * Note:
        * If you deploy the ScalarDB or ScalarDL, you need to remove them before deleting minikube.

--- a/docs/3.8/helm-charts/getting-started-scalar-helm-charts.md
+++ b/docs/3.8/helm-charts/getting-started-scalar-helm-charts.md
@@ -28,15 +28,19 @@ First, you need to install the following tools used in this guide.
 ## Step 2. Start minikube with docker driver (Optional / If you use minikube)
 
 1. Start minikube.
+
    ```console
    minikube start
    ```
 
 1. Check the status of the minikube and pods.
+
    ```console
    kubectl get pod -A
    ```
+
    [Command execution result]
+
    ```console
    NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
    kube-system   coredns-64897985d-lbsfr            1/1     Running   1 (20h ago)   21h
@@ -47,9 +51,10 @@ First, you need to install the following tools used in this guide.
    kube-system   kube-scheduler-minikube            1/1     Running   1 (20h ago)   21h
    kube-system   storage-provisioner                1/1     Running   2 (19s ago)   21h
    ```
+
    If the minikube starts properly, you can see some pods are **Running** in the kube-system namespace.
 
-## Step 3. 
+## Step 3.
 
 After the Kubernetes cluster starts, you can try each Scalar Helm Charts on it. Please refer to the following documents for more details.
 

--- a/docs/3.8/helm-charts/getting-started-scalar-manager.md
+++ b/docs/3.8/helm-charts/getting-started-scalar-manager.md
@@ -64,6 +64,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 1. Upgrade the `kube-prometheus-stack` to allow Grafana to be embedded
 
 1. Add or revise this value to the custom values file (e.g. scalar-prometheus-custom-values.yaml) of the `kube-prometheus-stack`
+
    ```yaml
    grafana:
      grafana.ini:
@@ -73,6 +74,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
    ```
 
 1. Upgrade the Helm installation
+
    ```console
    helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -82,6 +84,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 1. Get the sample file [scalar-manager-custom-values.yaml](./conf/scalar-manager-custom-values.yaml) for `scalar-manager`.
 
 1. Add the targets that you would like to manage. For example, if we want to manage a ledger cluster, then we can add the values as follows.
+
    ```yaml
    scalarManager:
      targets:
@@ -89,21 +92,25 @@ We will deploy the following components on a Kubernetes cluster as follows.
          adminSrv: _scalardl-admin._tcp.scalardl-headless.default.svc.cluster.local
          databaseType: cassandra
    ```
+
    Note: the `adminSrv` is the DNS Service URL that returns SRV record of pods. Kubernetes creates this URL for the named port of the headless service of the Scalar product. The format is `_{port name}._{protocol}.{service name}.{namespace}.svc.{cluster domain name}`
 
 1. Set the Grafana URL. For example, if your Grafana of the `kube-prometheus-stack` is exposed in `localhost:3000`, then we can set it as follows.
+
    ```yaml
    scalarManager:
      grafanaUrl: "http://localhost:3000"
    ```
 
 1. Set the refresh interval that Scalar Manager checks the status of the products. The default value is `30` seconds, but we can change it like:
+
    ```yaml
    scalarManager:
      refreshInterval: 60 # one minute
    ```
 
 1. Set the service type to access Scalar Manager. The default value is `ClusterIP`, but if we access using the `minikube tunnel` command or some load balancer, we can set it as `LoadBalancer`.
+
    ```yaml
    service:
      type: LoadBalancer
@@ -112,11 +119,13 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 3. Deploy `scalar-manager`
 
 1. Create a secret resource `reg-docker-secrets` to pull the Scalar Manager container image from GitHub Packages.
+
    ```console
    kubectl create secret docker-registry reg-docker-secrets --docker-server=ghcr.io --docker-username=<github-username> --docker-password=<github-personal-access-token>
    ```
 
 1. Deploy the `scalar-manager` Helm Chart.
+
    ```console
    helm install scalar-manager scalar-labs/scalar-manager -f scalar-manager-custom-values.yaml
    ```
@@ -126,6 +135,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ### If you use minikube
 
 1. To expose Scalar Manager's service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
+
    ```console
    minikube tunnel
    ```
@@ -138,6 +148,7 @@ If you use a Kubernetes cluster other than minikube, you need to access the Load
 
 ## Step 5. Delete Scalar Manager
 1. Uninstall `scalar-manager`
+
    ```console
    helm uninstall scalar-manager
    ```

--- a/docs/3.8/helm-charts/getting-started-scalardb.md
+++ b/docs/3.8/helm-charts/getting-started-scalardb.md
@@ -44,11 +44,13 @@ ScalarDB uses some kind of database system as a backend database. In this docume
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL.
+
    ```console
    helm install postgresql-scalardb bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -56,10 +58,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL container is running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                    READY   STATUS    RESTARTS   AGE
    postgresql-scalardb-0   1/1     Running   0          2m42s
@@ -68,19 +73,23 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 ## Step 3. Deploy ScalarDB Server on the Kubernetes cluster using Helm Charts
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDB container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -89,12 +98,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
 
    Please refer to the following documents for more details.
-   
+
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 1. Create a custom values file for ScalarDB Server (scalardb-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -118,7 +128,9 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -144,6 +156,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
 
 1. Create a Secret resource that includes a username and password for PostgreSQL.
+
    ```console
    kubectl create secret generic scalardb-credentials-secret \
      --from-literal=SCALAR_DB_POSTGRES_USERNAME=postgres \
@@ -151,15 +164,19 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Deploy ScalarDB Server.
+
    ```console
    helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
    ```
 
 1. Check if the ScalarDB Server pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                              READY   STATUS    RESTARTS   AGE
    postgresql-scalardb-0             1/1     Running   0          9m48s
@@ -170,13 +187,17 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    scalardb-envoy-84c475f77b-n74tk   1/1     Running   0          6s
    scalardb-envoy-84c475f77b-zbrwz   1/1     Running   0          6s
    ```
+
    If the ScalarDB Server Pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDB Server services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
    kubernetes               ClusterIP   10.96.0.1        <none>        443/TCP     47d
@@ -187,20 +208,25 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    scalardb-headless        ClusterIP   None             <none>        60051/TCP   41s
    scalardb-metrics         ClusterIP   10.108.188.10    <none>        8080/TCP    41s
    ```
+
    If the ScalarDB Server services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardb-headless` has no CLUSTER-IP.)  
 
 ## Step 4. Start a Client container
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    kubectl run scalardb-client --image eclipse-temurin:8 --command sleep inf
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardb-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardb-client   1/1     Running   0          23s
@@ -211,66 +237,86 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 The following explains the minimum steps. If you want to know more details about ScalarDB, please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardb-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git and curl commands in the Client container.
+
    ```console
    apt update && apt install -y git curl
    ```
 
 1. Clone ScalarDB git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardb.git
    ```
 
 1. Change the directory to `scalardb/`.
+
    ```console
    cd scalardb/
    ```
+
    ```console
    pwd
    ```
+
    [Command execution result]
+
    ```console
    /scalardb
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.7.0 refs/tags/v3.7.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
+
    ```console
      master
    * v3.7.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use.
 
 1. Change the directory to `docs/getting-started/`.
+
    ```console
    cd docs/getting-started/
    ```
+
    ```console
    pwd
    ```
+
    [Command execution result]
+
    ```console
    /scalardb/docs/getting-started
    ```
 
 1. Download Schema Loader from [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardb/releases/download/v3.7.0/scalardb-schema-loader-3.7.0.jar
    ```
+
    You need to use the same version of ScalarDB and Schema Loader.
 
 1. Create a configuration file (scalardb.properties) to access ScalarDB Server on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > scalardb.properties
    scalar.db.contact_points=scalardb-envoy.default.svc.cluster.local
@@ -281,6 +327,7 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Create a JSON file (emoney-transaction.json) that defines DB Schema for the sample applications.
+
    ```console
    cat << 'EOF' > emoney-transaction.json
    {
@@ -300,37 +347,50 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Run Schema Loader (Create sample TABLE).
+
    ```console
    java -jar ./scalardb-schema-loader-3.7.0.jar --config ./scalardb.properties -f emoney-transaction.json --coordinator
    ```
 
 1. Run the sample applications.
    * Charge `1000` to `user1`:
+
      ```console
      ./gradlew run --args="-action charge -amount 1000 -to user1"
      ```
+
    * Charge `0` to `merchant1` (Just create an account for `merchant1`):
+
      ```console
      ./gradlew run --args="-action charge -amount 0 -to merchant1"
      ```
+
    * Pay `100` from `user1` to `merchant1`:
+
      ```console
      ./gradlew run --args="-action pay -amount 100 -from user1 -to merchant1"
      ```
+
    * Get the balance of `user1`:
+
      ```console
      ./gradlew run --args="-action getBalance -id user1"
      ```
+
    * Get the balance of `merchant1`:
+
      ```console
      ./gradlew run --args="-action getBalance -id merchant1"
      ```
 
 1. (Optional) You can see the inserted and modified (INSERT/UPDATE) data through the sample applications using the following command. (This command needs to run on your localhost, not on the Client container.)  
+
    ```console
    kubectl exec -it postgresql-scalardb-0 -- bash -c 'export PGPASSWORD=postgres && psql -U postgres -d postgres -c "SELECT * FROM emoney.account"'
    ```
+
    [Command execution result]
+
    ```sql
        id     | balance |                tx_id                 | tx_state | tx_version | tx_prepared_at | tx_committed_at |             before_tx_id             | before_tx_state | before_tx_version | before_tx_prepared_at | before_tx_committed_at | before_balance
    -----------+---------+--------------------------------------+----------+------------+----------------+-----------------+--------------------------------------+-----------------+-------------------+-----------------------+------------------------+----------------
@@ -338,6 +398,7 @@ The following explains the minimum steps. If you want to know more details about
     user1     |     900 | 65a90225-0846-4e97-b729-151f76f6ca2f |        3 |          2 |  1667361909634 |1667361909679    | 5520cba4-625a-4886-b81f-6089bf846d18 |               3 |                 1 |         1667361897283 |          1667361897317 |           1000
    (2 rows)
    ```
+
    * Note:
        * Usually, you need to access data (records) through ScalarDB. The above command is used to explain and confirm the working of the sample applications.
 
@@ -346,12 +407,14 @@ The following explains the minimum steps. If you want to know more details about
 After completing the ScalarDB Server tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDB Server and PostgreSQL.
+
    ```console
    helm uninstall scalardb postgresql-scalardb
    ```
 
 1. Remove the Client container.
-   ```
+
+   ```console
    kubectl delete pod scalardb-client --force --grace-period 0
    ```
 

--- a/docs/3.8/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/3.8/helm-charts/getting-started-scalardl-auditor.md
@@ -72,11 +72,13 @@ ScalarDL Ledger and Auditor use some kind of database system as a backend databa
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL for Ledger.
+
    ```console
    helm install postgresql-ledger bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -84,6 +86,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Deploy PostgreSQL for Auditor.
+
    ```console
    helm install postgresql-auditor bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -91,10 +94,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL containers are running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                   READY   STATUS    RESTARTS   AGE
    postgresql-auditor-0   1/1     Running   0          11s
@@ -106,6 +112,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 We will create some configuration files and key/certificate files locally. So, create a working directory for them.
 
 1. Create a working directory.
+
    ```console
    mkdir -p ~/scalardl-test/certs/
    ```
@@ -115,11 +122,13 @@ We will create some configuration files and key/certificate files locally. So, c
 Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
 1. Change the working directory to `~/scalardl-test/certs/` directory.
+
    ```console
    cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
@@ -143,6 +152,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Auditor information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/auditor.json
    {
@@ -166,6 +176,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Client information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
@@ -189,25 +200,31 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create key/certificate files for the Ledger.
+
    ```console
    cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Auditor.
+
    ```console
    cfssl selfsign "" ./auditor.json | cfssljson -bare auditor
    ```
 
 1. Create key/certificate files for the Client.
+
    ```console
    cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
+
    ```console
    ls -1
    ```
+
    [Command execution result]
+
    ```console
    auditor-key.pem
    auditor.csr
@@ -229,24 +246,29 @@ We will deploy two ScalarDL Schema Loader pods on the Kubernetes cluster using H
 The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Auditor in PostgreSQL.  
 
 1. Change the working directory to `~/scalardl-test/`.
+
    ```console
    cd ~/scalardl-test/
    ```
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -255,12 +277,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
    Please refer to the following documents for more details.
-   
+
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 1. Create a custom values file for ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -278,7 +301,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -299,6 +324,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 
 1. Create a custom values file for ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -316,7 +342,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -336,6 +364,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Ledger.
+
    ```console
    kubectl create secret generic ledger-credentials-secret \
      --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
@@ -343,6 +372,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Auditor.
+
    ```console
    kubectl create secret generic auditor-credentials-secret \
      --from-literal=SCALAR_DL_AUDITOR_POSTGRES_USERNAME=postgres \
@@ -350,20 +380,25 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    ```
 
 1. Deploy the ScalarDL Schema Loader for Ledger.
+
    ```console
    helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Deploy the ScalarDL Schema Loader for Auditor.
+
    ```console
    helm install schema-loader-auditor scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Schema Loader pods are deployed and completed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
    postgresql-auditor-0                         1/1     Running     0          2m56s
@@ -371,12 +406,14 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          6s
    schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          10s
    ```
+
    If the ScalarDL Schema Loader pods are **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
 ## Step 6. Deploy ScalarDL Ledger and Auditor on the Kubernetes cluster using Helm Charts
 
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -411,7 +448,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -448,6 +487,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 
 1. Create a custom values file for ScalarDL Auditor (scalardl-auditor-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -482,7 +522,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -519,30 +561,37 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
 1. Create secret resource `ledger-keys`.
+
    ```console
    kubectl create secret generic ledger-keys --from-file=certificate=./certs/ledger.pem --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Create secret resource `auditor-keys`.
+
    ```console
    kubectl create secret generic auditor-keys --from-file=certificate=./certs/auditor.pem --from-file=private-key=./certs/auditor-key.pem
    ```
 
 1. Deploy the ScalarDL Ledger.
+
    ```console
    helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Deploy the ScalarDL Auditor.
+
    ```console
    helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Ledger and Auditor pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
    postgresql-auditor-0                         1/1     Running     0          14m
@@ -562,13 +611,17 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          11m
    schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          11m
    ```
+
    If the ScalarDL Ledger and Auditor pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDL Ledger and Auditor services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                             TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
    kubernetes                       ClusterIP   10.96.0.1        <none>        443/TCP                         47d
@@ -585,6 +638,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    scalardl-ledger-headless         ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   61s
    scalardl-ledger-metrics          ClusterIP   10.99.122.106    <none>        8080/TCP                        61s
    ```
+
    If the ScalarDL Ledger and Auditor services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` and `scalardl-auditor-headless` have no CLUSTER-IP.)  
 
 ## Step 7. Start a Client container
@@ -592,11 +646,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
 
 1. Create secret resource `client-keys`.
-   ```
+
+   ```console
    kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
@@ -634,10 +690,13 @@ We will use certificate files in a Client container. So, we create a secret reso
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardl-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardl-client   1/1     Running   0          4s
@@ -652,65 +711,82 @@ The following explains the minimum steps. If you want to know more details about
 When you use Auditor, you need to register the certificate for the Ledger and Auditor before starting the client application. Ledger needs to register its certificate to Auditor, and Auditor needs to register its certificate to Ledger.
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardl-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git, curl and unzip commands in the Client container.
+
    ```console
    apt update && apt install -y git curl unzip
    ```
 
 1. Clone ScalarDL Java Client SDK git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change the directory to `scalardl-java-client-sdk/`.
+
    ```console
    cd scalardl-java-client-sdk/
    ```
+
    ```console
    pwd
    ```
-   [Command execution result]
-   ```console
 
+   [Command execution result]
+
+   ```console
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
+
    ```console
      master
    * v3.6.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
 1. Build the sample contracts.
+
    ```console
    ./gradlew assemble
    ```
 
 1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
+
    You need to use the same version of CLI tools and ScalarDL Ledger.
 
 1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
+
    ```console
    unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (ledger.as.client.properties) to register the certificate of Ledger to Auditor.
+
    ```console
    cat << 'EOF' > ledger.as.client.properties
    # Ledger
@@ -728,6 +804,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Create a configuration file (auditor.as.client.properties) to register the certificate of Auditor to Ledger.
+
    ```console
    cat << 'EOF' > auditor.as.client.properties
    # Ledger
@@ -745,6 +822,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > client.properties
    # Ledger
@@ -762,46 +840,57 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Register the certificate file of Ledger.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./ledger.as.client.properties
    ```
 
 1. Register the certificate file of Auditor.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./auditor.as.client.properties
    ```
 
 1. Register the certificate file of client.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./client.properties
    ```
 
 1. Register the sample contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Register the contract `ValdateLedger` to execute a validate request.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id validate-ledger --contract-binary-name com.scalar.dl.client.contract.ValidateLedger --contract-class-file ./build/classes/java/main/com/scalar/dl/client/contract/ValidateLedger.class
    ```
 
 1. Execute the contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
+
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    ```
+
    [Command execution result]
+
    ```console
    Contract result:
    {
@@ -812,23 +901,29 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
      }
    }
    ```
+
    * Reference information
       * If the asset data is not tampered with, the contract execution request (execute-contract command) returns `OK` as a result.
       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the contract execution request (execute-contract command) returns a value other than `OK`  (e.g. `INCONSISTENT_STATES`) as a result, like the following.  
         [Command execution result (If the asset data is tampered with)]
+
         ```console
         {
           "status_code" : "INCONSISTENT_STATES",
           "error_message" : "The results from Ledger and Auditor don't match"
         }
         ```
+
           * In this way, the ScalarDL can detect data tampering.
 
 1. Execute a validation request for the asset.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
+
    [Command execution result]
+
    ```console
    {
      "status_code" : "OK",
@@ -848,16 +943,19 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
      }
    }
    ```
+
    * Reference information
       * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
         [Command execution result (If the asset data is tampered with)]
+
         ```console
         {
           "status_code" : "INCONSISTENT_STATES",
           "error_message" : "The results from Ledger and Auditor don't match"
         }
         ```
+
           * In this way, the ScalarDL Ledger can detect data tampering.
 
 ## Step 9. Delete all resources
@@ -865,19 +963,23 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
 After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
+
    ```console
    helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger scalardl-auditor schema-loader-auditor postgresql-auditor
    ```
 
 1. Remove the Client container.
+
    ```
    kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
 1. Remove the working directory and sample files (configuration file, key, and certificate).
+
    ```console
    cd ~
    ```
+   
    ```console
    rm -rf ~/scalardl-test/
    ```

--- a/docs/3.8/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/3.8/helm-charts/getting-started-scalardl-ledger.md
@@ -54,11 +54,13 @@ ScalarDL Ledger uses some kind of database system as a backend database. In this
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL.
+
    ```console
    helm install postgresql-ledger bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -66,10 +68,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL container is running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                  READY   STATUS    RESTARTS   AGE
    postgresql-ledger-0   1/1     Running   0          11s
@@ -80,6 +85,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 We will create some configuration files and key/certificate files locally. So, create a working directory for them.
 
 1. Create a working directory.
+
    ```console
    mkdir -p ~/scalardl-test/certs/
    ```
@@ -89,11 +95,13 @@ We will create some configuration files and key/certificate files locally. So, c
 Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
 1. Change the working directory to `~/scalardl-test/certs/` directory.
+
    ```console
    cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
@@ -117,6 +125,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Client information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
@@ -140,20 +149,25 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create key/certificate files for the Ledger.
+
    ```console
    cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Client.
+
    ```console
    cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
+
    ```console
    ls -1
    ```
+
    [Command execution result]
+
    ```console
    client-key.pem
    client.csr
@@ -171,24 +185,29 @@ We will deploy a ScalarDL Schema Loader on the Kubernetes cluster using Helm Cha
 The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in PostgreSQL.  
 
 1. Change the working directory to `~/scalardl-test/`.
+
    ```console
    cd ~/scalardl-test/
    ```
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -203,6 +222,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 
 1. Create a custom values file for ScalarDL Schema Loader (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -221,6 +241,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      EOF
      ```
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -240,6 +261,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL.
+
    ```console
    kubectl create secret generic ledger-credentials-secret \
      --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
@@ -247,26 +269,32 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    ```
 
 1. Deploy the ScalarDL Schema Loader.
+
    ```console
    helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Schema Loader pod is deployed and completed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    postgresql-ledger-0                         1/1     Running     0          11m
    schema-loader-ledger-schema-loading-46rcr   0/1     Completed   0          3s
    ```
+
    If the ScalarDL Schema Loader pod is **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
 ## Step 6. Deploy ScalarDL Ledger on the Kubernetes cluster using Helm Charts
 
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -300,7 +328,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -336,20 +366,25 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
 
 1. Create secret resource `ledger-keys`.
+
    ```console
    kubectl create secret generic ledger-keys --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Deploy the ScalarDL Ledger.
+
    ```console
    helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Ledger pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    postgresql-ledger-0                         1/1     Running     0          14m
@@ -361,13 +396,17 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    scalardl-ledger-ledger-9bdf7f8bd-9tw5x      1/1     Running     0          52s
    schema-loader-ledger-schema-loading-46rcr   0/1     Completed   0          3m38s
    ```
+
    If the ScalarDL Ledger pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDL Ledger services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
    kubernetes                      ClusterIP   10.96.0.1        <none>        443/TCP                         47d
@@ -378,6 +417,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    scalardl-ledger-headless        ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   83s
    scalardl-ledger-metrics         ClusterIP   10.98.4.217      <none>        8080/TCP                        83s
    ```
+
    If the ScalarDL Ledger services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` has no CLUSTER-IP.)  
 
 ## Step 7. Start a Client container
@@ -385,11 +425,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
 
 1. Create secret resource `client-keys`.
-   ```
+
+   ```console
    kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
@@ -415,10 +457,13 @@ We will use certificate files in a Client container. So, we create a secret reso
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardl-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardl-client   1/1     Running   0          11s
@@ -429,65 +474,81 @@ We will use certificate files in a Client container. So, we create a secret reso
 The following explains the minimum steps. If you want to know more details about ScalarDL and the contract, please refer to the [Getting Started with ScalarDL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md).
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardl-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git, curl and unzip commands in the Client container.
+
    ```console
    apt update && apt install -y git curl unzip
    ```
 
 1. Clone ScalarDL Java Client SDK git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change the directory to `scalardl-java-client-sdk/`.
+
    ```console
    cd scalardl-java-client-sdk/
    ```
+
    ```console
    pwd
    ```
-   [Command execution result]
-   ```console
 
+   [Command execution result]
+
+   ```console
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
    ```console
      master
    * v3.6.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
 1. Build the sample contracts.
+
    ```console
    ./gradlew assemble
    ```
 
 1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
+
    You need to use the same version of CLI tools and ScalarDL Ledger.
 
 1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
+
    ```console
    unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > client.properties
    scalar.dl.client.server.host=scalardl-ledger-envoy.default.svc.cluster.local
@@ -503,26 +564,32 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Register the sample contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Execute the contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    ```
+
    [Command execution result]
+
    ```console
    Contract result:
    {
@@ -535,10 +602,13 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Execute a validation request for the asset.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
+
    [Command execution result]
+
    ```console
    {
      "status_code" : "OK",
@@ -552,10 +622,12 @@ The following explains the minimum steps. If you want to know more details about
      "Auditor" : null
    }
    ```
+
    * Reference information
        * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
        * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
          [Command execution result (If the asset data is tampered with)]
+
          ```console
          {
            "status_code" : "INVALID_OUTPUT",
@@ -569,6 +641,7 @@ The following explains the minimum steps. If you want to know more details about
            "Auditor" : null
          }
          ```
+
            * In this way, the ScalarDL Ledger can detect data tampering.
 
 ## Step 9. Delete all resources
@@ -576,19 +649,23 @@ The following explains the minimum steps. If you want to know more details about
 After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
+
    ```console
    helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger
    ```
 
 1. Remove the Client container.
+
    ```
    kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
 1. Remove the working directory and sample files (configuration file, key, and certificate).
+
    ```console
    cd ~
    ```
+   
    ```console
    rm -rf ~/scalardl-test/
    ```

--- a/docs/3.8/helm-charts/how-to-deploy-scalar-products.md
+++ b/docs/3.8/helm-charts/how-to-deploy-scalar-products.md
@@ -15,6 +15,7 @@ You must install the helm command to use Scalar Helm Charts. Please install the 
 ```console
 helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
 ```
+
 ```console
 helm repo update scalar-labs
 ```

--- a/docs/3.8/helm-charts/how-to-deploy-scalardb-cluster.md
+++ b/docs/3.8/helm-charts/how-to-deploy-scalardb-cluster.md
@@ -31,6 +31,7 @@ If you use ScalarDB Cluster with `direct-kubernetes` mode, you must:
 This method is necessary because the ScalarDB Cluster client library with `direct-kubernetes` mode runs the Kubernetes API from inside of your application pods to get information about the ScalarDB Cluster pods.
 
 * Role
+
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -42,7 +43,9 @@ This method is necessary because the ScalarDB Cluster client library with `direc
       resources: ["endpoints"]
       verbs: ["get", "watch", "list"]
   ```
+
 * RoleBinding
+
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
@@ -57,7 +60,9 @@ This method is necessary because the ScalarDB Cluster client library with `direc
     name: scalardb-cluster-role
     apiGroup: rbac.authorization.k8s.io
   ```
+
 * ServiceAccount
+
   ```yaml
   apiVersion: v1
   kind: ServiceAccount

--- a/docs/3.8/helm-charts/mount-files-or-volumes-on-scalar-pods.md
+++ b/docs/3.8/helm-charts/mount-files-or-volumes-on-scalar-pods.md
@@ -8,6 +8,7 @@ You must mount the key and certificate files to run ScalarDL Auditor.
 
 * Configuration example
     * ScalarDL Ledger
+
       ```yaml
       ledger:
         ledgerProperties: |
@@ -16,7 +17,9 @@ You must mount the key and certificate files to run ScalarDL Auditor.
           scalar.dl.ledger.auditor.enabled=true
           scalar.dl.ledger.proof.private_key_path=/keys/private-key
       ```
+
     * ScalarDL Auditor
+
       ```yaml
       auditor:
         auditorProperties: |
@@ -30,6 +33,7 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 1. Set `extraVolumes` and `extraVolumeMounts` in the custom values file using the same syntax of Kubernetes manifest. You need to specify the directory name to the key `mountPath`.
    * Example
         * ScalarDL Ledger
+
           ```yaml
           ledger:
             extraVolumes:
@@ -41,7 +45,9 @@ In this example, you need to mount a **private-key** and a **certificate** file 
                 mountPath: /keys
                 readOnly: true
           ```
+
        * ScalarDL Auditor
+
          ```yaml
          auditor:
             extraVolumes:
@@ -60,11 +66,14 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
    * Example
        * ScalarDL Ledger
+
          ```console
          kubectl create secret generic ledger-keys \
            --from-file=private-key=./ledger-key.pem
          ```
+
        * ScalarDL Auditor
+
          ```console
          kubectl create secret generic auditor-keys \
            --from-file=private-key=./auditor-key.pem \
@@ -77,12 +86,15 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
    * Example
        * ScalarDL Ledger
+
          ```console
          $ ls -l /keys/
          total 0
          lrwxrwxrwx 1 root root 18 Jun 27 03:12 private-key -> ..data/private-key
          ```
+
        * ScalarDL Auditor
+
          ```console
          $ ls -l /keys/
          total 0
@@ -101,6 +113,7 @@ You can mount emptyDir to Scalar product pods by using the following keys in you
   * `auditor.extraVolumes` / `auditor.extraVolumeMounts` (ScalarDL Auditor)
 
 * Example (ScalarDB Server)
+
   ```yaml
   scalardb:
     extraVolumes:

--- a/docs/3.8/helm-charts/use-secret-for-credentials.md
+++ b/docs/3.8/helm-charts/use-secret-for-credentials.md
@@ -3,6 +3,7 @@
 You can pass credentials like **username** or **password** as environment variables via a `Secret` resource in Kubernetes. The docker images for previous versions of Scalar products use the `dockerize` command for templating properties files. The docker images for the latest versions of Scalar products get values directly from environment variables.
 
 Note: You cannot use the following environment variable names in your custom values file since these are used in the Scalar Helm Chart internal.
+
 ```console
 HELM_SCALAR_DB_CONTACT_POINTS
 HELM_SCALAR_DB_CONTACT_PORT
@@ -31,6 +32,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
    * Example
        * ScalarDB Server
            * ScalarDB Server 3.7 or earlier (Go template syntax)
+
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -39,7 +41,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
                   ...
              ```
+
            * ScalarDB Server 3.8 or later (Apache Commons Text syntax)
+
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -48,7 +52,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password=${env:SCALAR_DB_PASSWORD}
                   ...
              ```
+
        * ScalarDB Cluster
+
          ```yaml
          scalardbCluster:
            scalardbClusterNodeProperties: |
@@ -57,7 +63,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password=${env:SCALAR_DB_PASSWORD}
              ...
          ```
+
        * ScalarDL Ledger (Go template syntax)
+
           ```yaml
           ledger:
             ledgerProperties: |
@@ -66,7 +74,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
               scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
               ...
           ```
+
        * ScalarDL Auditor (Go template syntax)
+
          ```yaml
          auditor:
            auditorProperties: |
@@ -75,7 +85,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+
        * ScalarDL Schema Loader (Go template syntax)
+
          ```yaml
          schemaLoading:
            databaseProperties: |
@@ -88,6 +100,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 1. Create a `Secret` resource that includes credentials.  
    You need to specify the environment variable name as keys of the `Secret`.
    * Example
+
      ```console
      kubectl create secret generic scalardb-credentials-secret \
        --from-literal=SCALAR_DB_USERNAME=postgres \
@@ -103,26 +116,35 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
      * `schemaLoading.secretName` (ScalarDL Schema Loader)
    * Example
      * ScalarDB Server
+
        ```yaml
        scalardb:
          secretName: "scalardb-credentials-secret"
        ```
+
      * ScalarDB Cluster
+
        ```yaml
        scalardbCluster:
          secretName: "scalardb-cluster-credentials-secret"
        ```
+
      * ScalarDL Ledger
+
        ```yaml
        ledger:
          secretName: "ledger-credentials-secret"
        ```
+
      * ScalarDL Auditor
+
        ```yaml
        auditor:
          secretName: "auditor-credentials-secret"
        ```
+
      * ScalarDL Schema Loader
+
        ```yaml
        schemaLoading:
          secretName: "schema-loader-ledger-credentials-secret"
@@ -134,6 +156,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 
    * Example
        * Custom values file
+
          ```yaml
          scalardb:
            databaseProperties: |
@@ -142,7 +165,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              scalar.db.storage=jdbc
          ```
+
        * Properties file in containers
+       
          ```properties
          scalar.db.contact_points=jdbc:postgresql://postgresql-scalardb.default.svc.cluster.local:5432/postgres
          scalar.db.username=postgres

--- a/docs/3.9/helm-charts/ReleaseFlow.md
+++ b/docs/3.9/helm-charts/ReleaseFlow.md
@@ -1,22 +1,28 @@
 # Release Flow
 
 ## Requirements
+
 | Name | Version | Mandatory | link |
 |:------|:-------|:----------|:------|
 | Helm | 3.2.1 or latest | no | https://helm.sh/docs/intro/install/ |
 
 ## Release
+
 * You create a branch (`prepare-release-*`).
 * You make sure to create the tag from the previous version of the target version.
+
 ``` console
 $ git checkout -b prepare-release-v3.0.2  refs/tags/scalardl-3.0.1
 ```
 
 * You need to set the `version` of the `Chart.yaml` of each `helm-charts` to the version to be released.
+
 ``` yaml
 version: 3.0.2
 ```
+
 * Pushing commits to a remote repository.
+
 ``` console
 $ git push origin prepare-release-v3.0.2
 ```

--- a/docs/3.9/helm-charts/configure-custom-values-envoy.md
+++ b/docs/3.9/helm-charts/configure-custom-values-envoy.md
@@ -9,6 +9,7 @@ The Scalar Envoy chart is used via other charts (scalardb, scalardl, and scalard
 For example, if you want to configure the Scalar Envoy for ScalarDB Server, you can configure some Scalar Envoy configurations in the custom values file of ScalarDB as follows.
 
 * Example (scalardb-custom-values.yaml)
+
   ```yaml
   envoy:
     configurationsForScalarEnvoy: 

--- a/docs/3.9/helm-charts/getting-started-logging.md
+++ b/docs/3.9/helm-charts/getting-started-logging.md
@@ -47,11 +47,13 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 2. Deploy `loki-stack`
 
 1. Add the `grafana` helm repository.
+
    ```console
    helm repo add grafana https://grafana.github.io/helm-charts
    ```
 
 1. Deploy the `loki-stack` helm chart.
+
    ```console
    helm install scalar-logging-loki grafana/loki-stack -n monitoring -f scalar-loki-stack-custom-values.yaml
    ```
@@ -59,6 +61,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 3. Add a Loki data source in the Grafana configuration
 
 1. Add a configuration of the Loki data source in the `scalar-prometheus-custom-values.yaml` file.
+
    ```yaml
    grafana:
      additionalDataSources:
@@ -72,6 +75,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
    ```
 
 1. Apply the configuration (upgrade the deployment of `kube-prometheus-stack`).
+
    ```console
    helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -86,6 +90,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 5. Delete the `loki-stack` helm chart
 
 1. Uninstall `loki-stack`.
+
    ```console
    helm uninstall scalar-logging-loki -n monitoring
    ```

--- a/docs/3.9/helm-charts/getting-started-monitoring.md
+++ b/docs/3.9/helm-charts/getting-started-monitoring.md
@@ -45,6 +45,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * `grafana.service.type` to `LoadBalancer`
        * `grafana.service.port` to `3000`
    * Example
+
      ```yaml
      alertmanager:
      
@@ -68,6 +69,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
      
      ...
      ```
+
    * Note:
        * If you want to customize the Prometheus Operator deployment using Helm Charts, you need to set the following configuration for monitoring Scalar products.
            * The `serviceMonitorSelectorNilUsesHelmValues` and `ruleSelectorNilUsesHelmValues` must be set to `false` (`true` by default) to make Prometheus Operator detects `ServiceMonitor` and `PrometheusRule` of Scalar products.
@@ -75,23 +77,26 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 ## Step 3. Deploy `kube-prometheus-stack`
 
 1. Add the `prometheus-community` helm repository.
+
    ```console
    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
    ```
 
 1. Create a namespace `monitoring` on the Kubernetes.
+
    ```console
    kubectl create namespace monitoring
    ```
 
 1. Deploy the `kube-prometheus-stack`.
+
    ```console
    helm install scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
 
 ## Step 4. Deploy (or Upgrade) Scalar products using Helm Charts
 
-* Note: 
+* Note:
    * The following explains the minimum steps. If you want to know more details about the deployment of ScalarDB and ScalarDL, please refer to the following documents.
        * [Getting Started with Helm Charts (ScalarDB Server)](./getting-started-scalardb.md)
        * [Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)](./getting-started-scalardl-ledger.md)
@@ -104,6 +109,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * `*.serviceMonitor.enabled`
    * Sample configuration files
        * ScalarDB (scalardb-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -121,7 +127,9 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            serviceMonitor:
              enabled: true
          ```
+
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -139,7 +147,9 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            serviceMonitor:
              enabled: true
          ```
+
        * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -161,23 +171,31 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 1. Deploy (or Upgrade) Scalar products using Helm Charts with the above custom values file.
    * Examples
        * ScalarDB
+
          ```console
          helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
+
        * ScalarDL Ledger
+
          ```console
          helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
+
        * ScalarDL Auditor
+
          ```console
          helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
@@ -187,15 +205,19 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 ### If you use minikube
 
 1. To expose each service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
+
    ```console
    minikube tunnel
    ```
 
    After running the `minikube tunnel` command, you can see the EXTERNAL-IP of each service resource as `127.0.0.1`.
+
    ```console
    kubectl get svc -n monitoring scalar-monitoring-kube-pro-prometheus scalar-monitoring-kube-pro-alertmanager scalar-monitoring-grafana
    ```
+
    [Command execution result]
+
    ```console
    NAME                                      TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
    scalar-monitoring-kube-pro-prometheus     LoadBalancer   10.98.11.12    127.0.0.1     9090:30550/TCP   26m
@@ -205,24 +227,33 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 
 1. Access each Dashboard.
    * Prometheus
+
      ```console
      http://localhost:9090/
      ```
+
    * Alertmanager
+
      ```console
      http://localhost:9093/
      ```
+
    * Grafana
+
      ```console
      http://localhost:3000/
      ```
+
        * Note:
            * You can see the user and password of Grafana as follows.
                * user
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-user}' | base64 -d
                  ```
+
                * password
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```
@@ -236,18 +267,22 @@ If you use a Kubernetes cluster other than minikube, you need to access the Load
 After completing the Monitoring tests on the Kubernetes cluster, remove all resources.
 
 1. Terminate the `minikube tunnel` command. (If you use minikube)
+
    ```console
    Ctrl + C
    ```
 
 1. Uninstall `kube-prometheus-stack`.
+
    ```console
    helm uninstall scalar-monitoring -n monitoring
    ```
 
 1. Delete minikube. (Optional / If you use minikube)
+
    ```console
    minikube delete --all
    ```
+
    * Note:
        * If you deploy the ScalarDB or ScalarDL, you need to remove them before deleting minikube.

--- a/docs/3.9/helm-charts/getting-started-scalar-helm-charts.md
+++ b/docs/3.9/helm-charts/getting-started-scalar-helm-charts.md
@@ -28,15 +28,19 @@ First, you need to install the following tools used in this guide.
 ## Step 2. Start minikube with docker driver (Optional / If you use minikube)
 
 1. Start minikube.
+
    ```console
    minikube start
    ```
 
 1. Check the status of the minikube and pods.
+
    ```console
    kubectl get pod -A
    ```
+
    [Command execution result]
+
    ```console
    NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
    kube-system   coredns-64897985d-lbsfr            1/1     Running   1 (20h ago)   21h
@@ -47,9 +51,10 @@ First, you need to install the following tools used in this guide.
    kube-system   kube-scheduler-minikube            1/1     Running   1 (20h ago)   21h
    kube-system   storage-provisioner                1/1     Running   2 (19s ago)   21h
    ```
+
    If the minikube starts properly, you can see some pods are **Running** in the kube-system namespace.
 
-## Step 3. 
+## Step 3.
 
 After the Kubernetes cluster starts, you can try each Scalar Helm Charts on it. Please refer to the following documents for more details.
 

--- a/docs/3.9/helm-charts/getting-started-scalar-manager.md
+++ b/docs/3.9/helm-charts/getting-started-scalar-manager.md
@@ -64,6 +64,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 1. Upgrade the `kube-prometheus-stack` to allow Grafana to be embedded
 
 1. Add or revise this value to the custom values file (e.g. scalar-prometheus-custom-values.yaml) of the `kube-prometheus-stack`
+
    ```yaml
    grafana:
      grafana.ini:
@@ -73,6 +74,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
    ```
 
 1. Upgrade the Helm installation
+
    ```console
    helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -82,6 +84,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 1. Get the sample file [scalar-manager-custom-values.yaml](./conf/scalar-manager-custom-values.yaml) for `scalar-manager`.
 
 1. Add the targets that you would like to manage. For example, if we want to manage a ledger cluster, then we can add the values as follows.
+
    ```yaml
    scalarManager:
      targets:
@@ -89,21 +92,25 @@ We will deploy the following components on a Kubernetes cluster as follows.
          adminSrv: _scalardl-admin._tcp.scalardl-headless.default.svc.cluster.local
          databaseType: cassandra
    ```
+
    Note: the `adminSrv` is the DNS Service URL that returns SRV record of pods. Kubernetes creates this URL for the named port of the headless service of the Scalar product. The format is `_{port name}._{protocol}.{service name}.{namespace}.svc.{cluster domain name}`
 
 1. Set the Grafana URL. For example, if your Grafana of the `kube-prometheus-stack` is exposed in `localhost:3000`, then we can set it as follows.
+
    ```yaml
    scalarManager:
      grafanaUrl: "http://localhost:3000"
    ```
 
 1. Set the refresh interval that Scalar Manager checks the status of the products. The default value is `30` seconds, but we can change it like:
+
    ```yaml
    scalarManager:
      refreshInterval: 60 # one minute
    ```
 
 1. Set the service type to access Scalar Manager. The default value is `ClusterIP`, but if we access using the `minikube tunnel` command or some load balancer, we can set it as `LoadBalancer`.
+
    ```yaml
    service:
      type: LoadBalancer
@@ -112,11 +119,13 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 3. Deploy `scalar-manager`
 
 1. Create a secret resource `reg-docker-secrets` to pull the Scalar Manager container image from GitHub Packages.
+
    ```console
    kubectl create secret docker-registry reg-docker-secrets --docker-server=ghcr.io --docker-username=<github-username> --docker-password=<github-personal-access-token>
    ```
 
 1. Deploy the `scalar-manager` Helm Chart.
+
    ```console
    helm install scalar-manager scalar-labs/scalar-manager -f scalar-manager-custom-values.yaml
    ```
@@ -126,6 +135,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ### If you use minikube
 
 1. To expose Scalar Manager's service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
+
    ```console
    minikube tunnel
    ```
@@ -138,6 +148,7 @@ If you use a Kubernetes cluster other than minikube, you need to access the Load
 
 ## Step 5. Delete Scalar Manager
 1. Uninstall `scalar-manager`
+
    ```console
    helm uninstall scalar-manager
    ```

--- a/docs/3.9/helm-charts/getting-started-scalardb.md
+++ b/docs/3.9/helm-charts/getting-started-scalardb.md
@@ -44,11 +44,13 @@ ScalarDB uses some kind of database system as a backend database. In this docume
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL.
+
    ```console
    helm install postgresql-scalardb bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -56,10 +58,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL container is running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                    READY   STATUS    RESTARTS   AGE
    postgresql-scalardb-0   1/1     Running   0          2m42s
@@ -68,19 +73,23 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 ## Step 3. Deploy ScalarDB Server on the Kubernetes cluster using Helm Charts
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDB container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -89,12 +98,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
 
    Please refer to the following documents for more details.
-   
+
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 1. Create a custom values file for ScalarDB Server (scalardb-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -118,7 +128,9 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -144,6 +156,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
 
 1. Create a Secret resource that includes a username and password for PostgreSQL.
+
    ```console
    kubectl create secret generic scalardb-credentials-secret \
      --from-literal=SCALAR_DB_POSTGRES_USERNAME=postgres \
@@ -151,15 +164,19 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Deploy ScalarDB Server.
+
    ```console
    helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
    ```
 
 1. Check if the ScalarDB Server pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                              READY   STATUS    RESTARTS   AGE
    postgresql-scalardb-0             1/1     Running   0          9m48s
@@ -170,13 +187,17 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    scalardb-envoy-84c475f77b-n74tk   1/1     Running   0          6s
    scalardb-envoy-84c475f77b-zbrwz   1/1     Running   0          6s
    ```
+
    If the ScalarDB Server Pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDB Server services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
    kubernetes               ClusterIP   10.96.0.1        <none>        443/TCP     47d
@@ -187,20 +208,25 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    scalardb-headless        ClusterIP   None             <none>        60051/TCP   41s
    scalardb-metrics         ClusterIP   10.108.188.10    <none>        8080/TCP    41s
    ```
+
    If the ScalarDB Server services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardb-headless` has no CLUSTER-IP.)  
 
 ## Step 4. Start a Client container
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    kubectl run scalardb-client --image eclipse-temurin:8 --command sleep inf
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardb-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardb-client   1/1     Running   0          23s
@@ -211,66 +237,86 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 The following explains the minimum steps. If you want to know more details about ScalarDB, please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardb-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git and curl commands in the Client container.
+
    ```console
    apt update && apt install -y git curl
    ```
 
 1. Clone ScalarDB git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardb.git
    ```
 
 1. Change the directory to `scalardb/`.
+
    ```console
    cd scalardb/
    ```
+
    ```console
    pwd
    ```
+
    [Command execution result]
+
    ```console
    /scalardb
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.7.0 refs/tags/v3.7.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
+
    ```console
      master
    * v3.7.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use.
 
 1. Change the directory to `docs/getting-started/`.
+
    ```console
    cd docs/getting-started/
    ```
+
    ```console
    pwd
    ```
+
    [Command execution result]
+
    ```console
    /scalardb/docs/getting-started
    ```
 
 1. Download Schema Loader from [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardb/releases/download/v3.7.0/scalardb-schema-loader-3.7.0.jar
    ```
+
    You need to use the same version of ScalarDB and Schema Loader.
 
 1. Create a configuration file (scalardb.properties) to access ScalarDB Server on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > scalardb.properties
    scalar.db.contact_points=scalardb-envoy.default.svc.cluster.local
@@ -281,6 +327,7 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Create a JSON file (emoney-transaction.json) that defines DB Schema for the sample applications.
+
    ```console
    cat << 'EOF' > emoney-transaction.json
    {
@@ -300,37 +347,50 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Run Schema Loader (Create sample TABLE).
+
    ```console
    java -jar ./scalardb-schema-loader-3.7.0.jar --config ./scalardb.properties -f emoney-transaction.json --coordinator
    ```
 
 1. Run the sample applications.
    * Charge `1000` to `user1`:
+
      ```console
      ./gradlew run --args="-action charge -amount 1000 -to user1"
      ```
+
    * Charge `0` to `merchant1` (Just create an account for `merchant1`):
+
      ```console
      ./gradlew run --args="-action charge -amount 0 -to merchant1"
      ```
+
    * Pay `100` from `user1` to `merchant1`:
+
      ```console
      ./gradlew run --args="-action pay -amount 100 -from user1 -to merchant1"
      ```
+
    * Get the balance of `user1`:
+
      ```console
      ./gradlew run --args="-action getBalance -id user1"
      ```
+
    * Get the balance of `merchant1`:
+
      ```console
      ./gradlew run --args="-action getBalance -id merchant1"
      ```
 
 1. (Optional) You can see the inserted and modified (INSERT/UPDATE) data through the sample applications using the following command. (This command needs to run on your localhost, not on the Client container.)  
+
    ```console
    kubectl exec -it postgresql-scalardb-0 -- bash -c 'export PGPASSWORD=postgres && psql -U postgres -d postgres -c "SELECT * FROM emoney.account"'
    ```
+
    [Command execution result]
+
    ```sql
        id     | balance |                tx_id                 | tx_state | tx_version | tx_prepared_at | tx_committed_at |             before_tx_id             | before_tx_state | before_tx_version | before_tx_prepared_at | before_tx_committed_at | before_balance
    -----------+---------+--------------------------------------+----------+------------+----------------+-----------------+--------------------------------------+-----------------+-------------------+-----------------------+------------------------+----------------
@@ -338,6 +398,7 @@ The following explains the minimum steps. If you want to know more details about
     user1     |     900 | 65a90225-0846-4e97-b729-151f76f6ca2f |        3 |          2 |  1667361909634 |1667361909679    | 5520cba4-625a-4886-b81f-6089bf846d18 |               3 |                 1 |         1667361897283 |          1667361897317 |           1000
    (2 rows)
    ```
+
    * Note:
        * Usually, you need to access data (records) through ScalarDB. The above command is used to explain and confirm the working of the sample applications.
 
@@ -346,12 +407,14 @@ The following explains the minimum steps. If you want to know more details about
 After completing the ScalarDB Server tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDB Server and PostgreSQL.
+
    ```console
    helm uninstall scalardb postgresql-scalardb
    ```
 
 1. Remove the Client container.
-   ```
+
+   ```console
    kubectl delete pod scalardb-client --force --grace-period 0
    ```
 

--- a/docs/3.9/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/3.9/helm-charts/getting-started-scalardl-auditor.md
@@ -72,11 +72,13 @@ ScalarDL Ledger and Auditor use some kind of database system as a backend databa
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL for Ledger.
+
    ```console
    helm install postgresql-ledger bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -84,6 +86,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Deploy PostgreSQL for Auditor.
+
    ```console
    helm install postgresql-auditor bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -91,10 +94,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL containers are running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                   READY   STATUS    RESTARTS   AGE
    postgresql-auditor-0   1/1     Running   0          11s
@@ -106,6 +112,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 We will create some configuration files and key/certificate files locally. So, create a working directory for them.
 
 1. Create a working directory.
+
    ```console
    mkdir -p ~/scalardl-test/certs/
    ```
@@ -115,11 +122,13 @@ We will create some configuration files and key/certificate files locally. So, c
 Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
 1. Change the working directory to `~/scalardl-test/certs/` directory.
+
    ```console
    cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
@@ -143,6 +152,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Auditor information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/auditor.json
    {
@@ -166,6 +176,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Client information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
@@ -189,25 +200,31 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create key/certificate files for the Ledger.
+
    ```console
    cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Auditor.
+
    ```console
    cfssl selfsign "" ./auditor.json | cfssljson -bare auditor
    ```
 
 1. Create key/certificate files for the Client.
+
    ```console
    cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
+
    ```console
    ls -1
    ```
+
    [Command execution result]
+
    ```console
    auditor-key.pem
    auditor.csr
@@ -229,24 +246,29 @@ We will deploy two ScalarDL Schema Loader pods on the Kubernetes cluster using H
 The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Auditor in PostgreSQL.  
 
 1. Change the working directory to `~/scalardl-test/`.
+
    ```console
    cd ~/scalardl-test/
    ```
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -255,12 +277,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
    Please refer to the following documents for more details.
-   
+
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 1. Create a custom values file for ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -278,7 +301,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -299,6 +324,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 
 1. Create a custom values file for ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -316,7 +342,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -336,6 +364,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Ledger.
+
    ```console
    kubectl create secret generic ledger-credentials-secret \
      --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
@@ -343,6 +372,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Auditor.
+
    ```console
    kubectl create secret generic auditor-credentials-secret \
      --from-literal=SCALAR_DL_AUDITOR_POSTGRES_USERNAME=postgres \
@@ -350,20 +380,25 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    ```
 
 1. Deploy the ScalarDL Schema Loader for Ledger.
+
    ```console
    helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Deploy the ScalarDL Schema Loader for Auditor.
+
    ```console
    helm install schema-loader-auditor scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Schema Loader pods are deployed and completed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
    postgresql-auditor-0                         1/1     Running     0          2m56s
@@ -371,12 +406,14 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          6s
    schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          10s
    ```
+
    If the ScalarDL Schema Loader pods are **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
 ## Step 6. Deploy ScalarDL Ledger and Auditor on the Kubernetes cluster using Helm Charts
 
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -411,7 +448,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -448,6 +487,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 
 1. Create a custom values file for ScalarDL Auditor (scalardl-auditor-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -482,7 +522,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -519,30 +561,37 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
 1. Create secret resource `ledger-keys`.
+
    ```console
    kubectl create secret generic ledger-keys --from-file=certificate=./certs/ledger.pem --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Create secret resource `auditor-keys`.
+
    ```console
    kubectl create secret generic auditor-keys --from-file=certificate=./certs/auditor.pem --from-file=private-key=./certs/auditor-key.pem
    ```
 
 1. Deploy the ScalarDL Ledger.
+
    ```console
    helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Deploy the ScalarDL Auditor.
+
    ```console
    helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Ledger and Auditor pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
    postgresql-auditor-0                         1/1     Running     0          14m
@@ -562,13 +611,17 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          11m
    schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          11m
    ```
+
    If the ScalarDL Ledger and Auditor pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDL Ledger and Auditor services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                             TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
    kubernetes                       ClusterIP   10.96.0.1        <none>        443/TCP                         47d
@@ -585,6 +638,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    scalardl-ledger-headless         ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   61s
    scalardl-ledger-metrics          ClusterIP   10.99.122.106    <none>        8080/TCP                        61s
    ```
+
    If the ScalarDL Ledger and Auditor services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` and `scalardl-auditor-headless` have no CLUSTER-IP.)  
 
 ## Step 7. Start a Client container
@@ -592,11 +646,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
 
 1. Create secret resource `client-keys`.
-   ```
+
+   ```console
    kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
@@ -634,10 +690,13 @@ We will use certificate files in a Client container. So, we create a secret reso
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardl-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardl-client   1/1     Running   0          4s
@@ -652,65 +711,82 @@ The following explains the minimum steps. If you want to know more details about
 When you use Auditor, you need to register the certificate for the Ledger and Auditor before starting the client application. Ledger needs to register its certificate to Auditor, and Auditor needs to register its certificate to Ledger.
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardl-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git, curl and unzip commands in the Client container.
+
    ```console
    apt update && apt install -y git curl unzip
    ```
 
 1. Clone ScalarDL Java Client SDK git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change the directory to `scalardl-java-client-sdk/`.
+
    ```console
    cd scalardl-java-client-sdk/
    ```
+
    ```console
    pwd
    ```
-   [Command execution result]
-   ```console
 
+   [Command execution result]
+
+   ```console
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
+
    ```console
      master
    * v3.6.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
 1. Build the sample contracts.
+
    ```console
    ./gradlew assemble
    ```
 
 1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
+
    You need to use the same version of CLI tools and ScalarDL Ledger.
 
 1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
+
    ```console
    unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (ledger.as.client.properties) to register the certificate of Ledger to Auditor.
+
    ```console
    cat << 'EOF' > ledger.as.client.properties
    # Ledger
@@ -728,6 +804,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Create a configuration file (auditor.as.client.properties) to register the certificate of Auditor to Ledger.
+
    ```console
    cat << 'EOF' > auditor.as.client.properties
    # Ledger
@@ -745,6 +822,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > client.properties
    # Ledger
@@ -762,46 +840,57 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Register the certificate file of Ledger.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./ledger.as.client.properties
    ```
 
 1. Register the certificate file of Auditor.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./auditor.as.client.properties
    ```
 
 1. Register the certificate file of client.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./client.properties
    ```
 
 1. Register the sample contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Register the contract `ValdateLedger` to execute a validate request.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id validate-ledger --contract-binary-name com.scalar.dl.client.contract.ValidateLedger --contract-class-file ./build/classes/java/main/com/scalar/dl/client/contract/ValidateLedger.class
    ```
 
 1. Execute the contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
+
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    ```
+
    [Command execution result]
+
    ```console
    Contract result:
    {
@@ -812,23 +901,29 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
      }
    }
    ```
+
    * Reference information
       * If the asset data is not tampered with, the contract execution request (execute-contract command) returns `OK` as a result.
       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the contract execution request (execute-contract command) returns a value other than `OK`  (e.g. `INCONSISTENT_STATES`) as a result, like the following.  
         [Command execution result (If the asset data is tampered with)]
+
         ```console
         {
           "status_code" : "INCONSISTENT_STATES",
           "error_message" : "The results from Ledger and Auditor don't match"
         }
         ```
+
           * In this way, the ScalarDL can detect data tampering.
 
 1. Execute a validation request for the asset.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
+
    [Command execution result]
+
    ```console
    {
      "status_code" : "OK",
@@ -848,16 +943,19 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
      }
    }
    ```
+
    * Reference information
       * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
         [Command execution result (If the asset data is tampered with)]
+
         ```console
         {
           "status_code" : "INCONSISTENT_STATES",
           "error_message" : "The results from Ledger and Auditor don't match"
         }
         ```
+
           * In this way, the ScalarDL Ledger can detect data tampering.
 
 ## Step 9. Delete all resources
@@ -865,19 +963,23 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
 After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
+
    ```console
    helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger scalardl-auditor schema-loader-auditor postgresql-auditor
    ```
 
 1. Remove the Client container.
+
    ```
    kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
 1. Remove the working directory and sample files (configuration file, key, and certificate).
+
    ```console
    cd ~
    ```
+   
    ```console
    rm -rf ~/scalardl-test/
    ```

--- a/docs/3.9/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/3.9/helm-charts/getting-started-scalardl-ledger.md
@@ -54,11 +54,13 @@ ScalarDL Ledger uses some kind of database system as a backend database. In this
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL.
+
    ```console
    helm install postgresql-ledger bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -66,10 +68,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL container is running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                  READY   STATUS    RESTARTS   AGE
    postgresql-ledger-0   1/1     Running   0          11s
@@ -80,6 +85,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 We will create some configuration files and key/certificate files locally. So, create a working directory for them.
 
 1. Create a working directory.
+
    ```console
    mkdir -p ~/scalardl-test/certs/
    ```
@@ -89,11 +95,13 @@ We will create some configuration files and key/certificate files locally. So, c
 Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
 1. Change the working directory to `~/scalardl-test/certs/` directory.
+
    ```console
    cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
@@ -117,6 +125,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Client information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
@@ -140,20 +149,25 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create key/certificate files for the Ledger.
+
    ```console
    cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Client.
+
    ```console
    cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
+
    ```console
    ls -1
    ```
+
    [Command execution result]
+
    ```console
    client-key.pem
    client.csr
@@ -171,24 +185,29 @@ We will deploy a ScalarDL Schema Loader on the Kubernetes cluster using Helm Cha
 The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in PostgreSQL.  
 
 1. Change the working directory to `~/scalardl-test/`.
+
    ```console
    cd ~/scalardl-test/
    ```
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -203,6 +222,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 
 1. Create a custom values file for ScalarDL Schema Loader (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -221,6 +241,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      EOF
      ```
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -240,6 +261,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL.
+
    ```console
    kubectl create secret generic ledger-credentials-secret \
      --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
@@ -247,26 +269,32 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    ```
 
 1. Deploy the ScalarDL Schema Loader.
+
    ```console
    helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Schema Loader pod is deployed and completed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    postgresql-ledger-0                         1/1     Running     0          11m
    schema-loader-ledger-schema-loading-46rcr   0/1     Completed   0          3s
    ```
+
    If the ScalarDL Schema Loader pod is **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
 ## Step 6. Deploy ScalarDL Ledger on the Kubernetes cluster using Helm Charts
 
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -300,7 +328,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -336,20 +366,25 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
 
 1. Create secret resource `ledger-keys`.
+
    ```console
    kubectl create secret generic ledger-keys --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Deploy the ScalarDL Ledger.
+
    ```console
    helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Ledger pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    postgresql-ledger-0                         1/1     Running     0          14m
@@ -361,13 +396,17 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    scalardl-ledger-ledger-9bdf7f8bd-9tw5x      1/1     Running     0          52s
    schema-loader-ledger-schema-loading-46rcr   0/1     Completed   0          3m38s
    ```
+
    If the ScalarDL Ledger pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDL Ledger services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
    kubernetes                      ClusterIP   10.96.0.1        <none>        443/TCP                         47d
@@ -378,6 +417,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    scalardl-ledger-headless        ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   83s
    scalardl-ledger-metrics         ClusterIP   10.98.4.217      <none>        8080/TCP                        83s
    ```
+
    If the ScalarDL Ledger services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` has no CLUSTER-IP.)  
 
 ## Step 7. Start a Client container
@@ -385,11 +425,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
 
 1. Create secret resource `client-keys`.
-   ```
+
+   ```console
    kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
@@ -415,10 +457,13 @@ We will use certificate files in a Client container. So, we create a secret reso
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardl-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardl-client   1/1     Running   0          11s
@@ -429,65 +474,81 @@ We will use certificate files in a Client container. So, we create a secret reso
 The following explains the minimum steps. If you want to know more details about ScalarDL and the contract, please refer to the [Getting Started with ScalarDL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md).
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardl-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git, curl and unzip commands in the Client container.
+
    ```console
    apt update && apt install -y git curl unzip
    ```
 
 1. Clone ScalarDL Java Client SDK git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change the directory to `scalardl-java-client-sdk/`.
+
    ```console
    cd scalardl-java-client-sdk/
    ```
+
    ```console
    pwd
    ```
-   [Command execution result]
-   ```console
 
+   [Command execution result]
+
+   ```console
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
    ```console
      master
    * v3.6.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
 1. Build the sample contracts.
+
    ```console
    ./gradlew assemble
    ```
 
 1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
+
    You need to use the same version of CLI tools and ScalarDL Ledger.
 
 1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
+
    ```console
    unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > client.properties
    scalar.dl.client.server.host=scalardl-ledger-envoy.default.svc.cluster.local
@@ -503,26 +564,32 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Register the sample contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Execute the contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    ```
+
    [Command execution result]
+
    ```console
    Contract result:
    {
@@ -535,10 +602,13 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Execute a validation request for the asset.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
+
    [Command execution result]
+
    ```console
    {
      "status_code" : "OK",
@@ -552,10 +622,12 @@ The following explains the minimum steps. If you want to know more details about
      "Auditor" : null
    }
    ```
+
    * Reference information
        * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
        * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
          [Command execution result (If the asset data is tampered with)]
+
          ```console
          {
            "status_code" : "INVALID_OUTPUT",
@@ -569,6 +641,7 @@ The following explains the minimum steps. If you want to know more details about
            "Auditor" : null
          }
          ```
+
            * In this way, the ScalarDL Ledger can detect data tampering.
 
 ## Step 9. Delete all resources
@@ -576,19 +649,23 @@ The following explains the minimum steps. If you want to know more details about
 After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
+
    ```console
    helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger
    ```
 
 1. Remove the Client container.
+
    ```
    kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
 1. Remove the working directory and sample files (configuration file, key, and certificate).
+
    ```console
    cd ~
    ```
+   
    ```console
    rm -rf ~/scalardl-test/
    ```

--- a/docs/3.9/helm-charts/how-to-deploy-scalar-products.md
+++ b/docs/3.9/helm-charts/how-to-deploy-scalar-products.md
@@ -15,6 +15,7 @@ You must install the helm command to use Scalar Helm Charts. Please install the 
 ```console
 helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
 ```
+
 ```console
 helm repo update scalar-labs
 ```

--- a/docs/3.9/helm-charts/how-to-deploy-scalardb-cluster.md
+++ b/docs/3.9/helm-charts/how-to-deploy-scalardb-cluster.md
@@ -31,6 +31,7 @@ If you use ScalarDB Cluster with `direct-kubernetes` mode, you must:
 This method is necessary because the ScalarDB Cluster client library with `direct-kubernetes` mode runs the Kubernetes API from inside of your application pods to get information about the ScalarDB Cluster pods.
 
 * Role
+
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -42,7 +43,9 @@ This method is necessary because the ScalarDB Cluster client library with `direc
       resources: ["endpoints"]
       verbs: ["get", "watch", "list"]
   ```
+
 * RoleBinding
+
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
@@ -57,7 +60,9 @@ This method is necessary because the ScalarDB Cluster client library with `direc
     name: scalardb-cluster-role
     apiGroup: rbac.authorization.k8s.io
   ```
+
 * ServiceAccount
+
   ```yaml
   apiVersion: v1
   kind: ServiceAccount

--- a/docs/3.9/helm-charts/mount-files-or-volumes-on-scalar-pods.md
+++ b/docs/3.9/helm-charts/mount-files-or-volumes-on-scalar-pods.md
@@ -8,6 +8,7 @@ You must mount the key and certificate files to run ScalarDL Auditor.
 
 * Configuration example
     * ScalarDL Ledger
+
       ```yaml
       ledger:
         ledgerProperties: |
@@ -16,7 +17,9 @@ You must mount the key and certificate files to run ScalarDL Auditor.
           scalar.dl.ledger.auditor.enabled=true
           scalar.dl.ledger.proof.private_key_path=/keys/private-key
       ```
+
     * ScalarDL Auditor
+
       ```yaml
       auditor:
         auditorProperties: |
@@ -30,6 +33,7 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 1. Set `extraVolumes` and `extraVolumeMounts` in the custom values file using the same syntax of Kubernetes manifest. You need to specify the directory name to the key `mountPath`.
    * Example
         * ScalarDL Ledger
+
           ```yaml
           ledger:
             extraVolumes:
@@ -41,7 +45,9 @@ In this example, you need to mount a **private-key** and a **certificate** file 
                 mountPath: /keys
                 readOnly: true
           ```
+
        * ScalarDL Auditor
+
          ```yaml
          auditor:
             extraVolumes:
@@ -60,11 +66,14 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
    * Example
        * ScalarDL Ledger
+
          ```console
          kubectl create secret generic ledger-keys \
            --from-file=private-key=./ledger-key.pem
          ```
+
        * ScalarDL Auditor
+
          ```console
          kubectl create secret generic auditor-keys \
            --from-file=private-key=./auditor-key.pem \
@@ -77,12 +86,15 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
    * Example
        * ScalarDL Ledger
+
          ```console
          $ ls -l /keys/
          total 0
          lrwxrwxrwx 1 root root 18 Jun 27 03:12 private-key -> ..data/private-key
          ```
+
        * ScalarDL Auditor
+
          ```console
          $ ls -l /keys/
          total 0
@@ -101,6 +113,7 @@ You can mount emptyDir to Scalar product pods by using the following keys in you
   * `auditor.extraVolumes` / `auditor.extraVolumeMounts` (ScalarDL Auditor)
 
 * Example (ScalarDB Server)
+
   ```yaml
   scalardb:
     extraVolumes:

--- a/docs/3.9/helm-charts/use-secret-for-credentials.md
+++ b/docs/3.9/helm-charts/use-secret-for-credentials.md
@@ -3,6 +3,7 @@
 You can pass credentials like **username** or **password** as environment variables via a `Secret` resource in Kubernetes. The docker images for previous versions of Scalar products use the `dockerize` command for templating properties files. The docker images for the latest versions of Scalar products get values directly from environment variables.
 
 Note: You cannot use the following environment variable names in your custom values file since these are used in the Scalar Helm Chart internal.
+
 ```console
 HELM_SCALAR_DB_CONTACT_POINTS
 HELM_SCALAR_DB_CONTACT_PORT
@@ -31,6 +32,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
    * Example
        * ScalarDB Server
            * ScalarDB Server 3.7 or earlier (Go template syntax)
+
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -39,7 +41,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
                   ...
              ```
+
            * ScalarDB Server 3.8 or later (Apache Commons Text syntax)
+
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -48,7 +52,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password=${env:SCALAR_DB_PASSWORD}
                   ...
              ```
+
        * ScalarDB Cluster
+
          ```yaml
          scalardbCluster:
            scalardbClusterNodeProperties: |
@@ -57,7 +63,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password=${env:SCALAR_DB_PASSWORD}
              ...
          ```
+
        * ScalarDL Ledger (Go template syntax)
+
           ```yaml
           ledger:
             ledgerProperties: |
@@ -66,7 +74,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
               scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
               ...
           ```
+
        * ScalarDL Auditor (Go template syntax)
+
          ```yaml
          auditor:
            auditorProperties: |
@@ -75,7 +85,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+
        * ScalarDL Schema Loader (Go template syntax)
+
          ```yaml
          schemaLoading:
            databaseProperties: |
@@ -88,6 +100,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 1. Create a `Secret` resource that includes credentials.  
    You need to specify the environment variable name as keys of the `Secret`.
    * Example
+
      ```console
      kubectl create secret generic scalardb-credentials-secret \
        --from-literal=SCALAR_DB_USERNAME=postgres \
@@ -103,26 +116,35 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
      * `schemaLoading.secretName` (ScalarDL Schema Loader)
    * Example
      * ScalarDB Server
+
        ```yaml
        scalardb:
          secretName: "scalardb-credentials-secret"
        ```
+
      * ScalarDB Cluster
+
        ```yaml
        scalardbCluster:
          secretName: "scalardb-cluster-credentials-secret"
        ```
+
      * ScalarDL Ledger
+
        ```yaml
        ledger:
          secretName: "ledger-credentials-secret"
        ```
+
      * ScalarDL Auditor
+
        ```yaml
        auditor:
          secretName: "auditor-credentials-secret"
        ```
+
      * ScalarDL Schema Loader
+
        ```yaml
        schemaLoading:
          secretName: "schema-loader-ledger-credentials-secret"
@@ -134,6 +156,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 
    * Example
        * Custom values file
+
          ```yaml
          scalardb:
            databaseProperties: |
@@ -142,7 +165,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              scalar.db.storage=jdbc
          ```
+
        * Properties file in containers
+       
          ```properties
          scalar.db.contact_points=jdbc:postgresql://postgresql-scalardb.default.svc.cluster.local:5432/postgres
          scalar.db.username=postgres

--- a/docs/latest/helm-charts/ReleaseFlow.md
+++ b/docs/latest/helm-charts/ReleaseFlow.md
@@ -1,22 +1,28 @@
 # Release Flow
 
 ## Requirements
+
 | Name | Version | Mandatory | link |
 |:------|:-------|:----------|:------|
 | Helm | 3.2.1 or latest | no | https://helm.sh/docs/intro/install/ |
 
 ## Release
+
 * You create a branch (`prepare-release-*`).
 * You make sure to create the tag from the previous version of the target version.
+
 ``` console
 $ git checkout -b prepare-release-v3.0.2  refs/tags/scalardl-3.0.1
 ```
 
 * You need to set the `version` of the `Chart.yaml` of each `helm-charts` to the version to be released.
+
 ``` yaml
 version: 3.0.2
 ```
+
 * Pushing commits to a remote repository.
+
 ``` console
 $ git push origin prepare-release-v3.0.2
 ```

--- a/docs/latest/helm-charts/configure-custom-values-envoy.md
+++ b/docs/latest/helm-charts/configure-custom-values-envoy.md
@@ -9,6 +9,7 @@ The Scalar Envoy chart is used via other charts (scalardb, scalardl, and scalard
 For example, if you want to configure the Scalar Envoy for ScalarDB Server, you can configure some Scalar Envoy configurations in the custom values file of ScalarDB as follows.
 
 * Example (scalardb-custom-values.yaml)
+
   ```yaml
   envoy:
     configurationsForScalarEnvoy: 

--- a/docs/latest/helm-charts/getting-started-logging.md
+++ b/docs/latest/helm-charts/getting-started-logging.md
@@ -47,11 +47,13 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 2. Deploy `loki-stack`
 
 1. Add the `grafana` helm repository.
+
    ```console
    helm repo add grafana https://grafana.github.io/helm-charts
    ```
 
 1. Deploy the `loki-stack` helm chart.
+
    ```console
    helm install scalar-logging-loki grafana/loki-stack -n monitoring -f scalar-loki-stack-custom-values.yaml
    ```
@@ -59,6 +61,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 3. Add a Loki data source in the Grafana configuration
 
 1. Add a configuration of the Loki data source in the `scalar-prometheus-custom-values.yaml` file.
+
    ```yaml
    grafana:
      additionalDataSources:
@@ -72,6 +75,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
    ```
 
 1. Apply the configuration (upgrade the deployment of `kube-prometheus-stack`).
+
    ```console
    helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -86,6 +90,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 5. Delete the `loki-stack` helm chart
 
 1. Uninstall `loki-stack`.
+
    ```console
    helm uninstall scalar-logging-loki -n monitoring
    ```

--- a/docs/latest/helm-charts/getting-started-monitoring.md
+++ b/docs/latest/helm-charts/getting-started-monitoring.md
@@ -45,6 +45,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * `grafana.service.type` to `LoadBalancer`
        * `grafana.service.port` to `3000`
    * Example
+
      ```yaml
      alertmanager:
      
@@ -68,6 +69,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
      
      ...
      ```
+
    * Note:
        * If you want to customize the Prometheus Operator deployment using Helm Charts, you need to set the following configuration for monitoring Scalar products.
            * The `serviceMonitorSelectorNilUsesHelmValues` and `ruleSelectorNilUsesHelmValues` must be set to `false` (`true` by default) to make Prometheus Operator detects `ServiceMonitor` and `PrometheusRule` of Scalar products.
@@ -75,23 +77,26 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 ## Step 3. Deploy `kube-prometheus-stack`
 
 1. Add the `prometheus-community` helm repository.
+
    ```console
    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
    ```
 
 1. Create a namespace `monitoring` on the Kubernetes.
+
    ```console
    kubectl create namespace monitoring
    ```
 
 1. Deploy the `kube-prometheus-stack`.
+
    ```console
    helm install scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
 
 ## Step 4. Deploy (or Upgrade) Scalar products using Helm Charts
 
-* Note: 
+* Note:
    * The following explains the minimum steps. If you want to know more details about the deployment of ScalarDB and ScalarDL, please refer to the following documents.
        * [Getting Started with Helm Charts (ScalarDB Server)](./getting-started-scalardb.md)
        * [Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)](./getting-started-scalardl-ledger.md)
@@ -104,6 +109,7 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
        * `*.serviceMonitor.enabled`
    * Sample configuration files
        * ScalarDB (scalardb-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -121,7 +127,9 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            serviceMonitor:
              enabled: true
          ```
+
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -139,7 +147,9 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
            serviceMonitor:
              enabled: true
          ```
+
        * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
          ```yaml
          envoy:
            prometheusRule:
@@ -161,23 +171,31 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 1. Deploy (or Upgrade) Scalar products using Helm Charts with the above custom values file.
    * Examples
        * ScalarDB
+
          ```console
          helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
          ```
+
        * ScalarDL Ledger
+
          ```console
          helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
          ```
+
        * ScalarDL Auditor
+
          ```console
          helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
+
          ```console
          helm upgrade scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
          ```
@@ -187,15 +205,19 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 ### If you use minikube
 
 1. To expose each service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
+
    ```console
    minikube tunnel
    ```
 
    After running the `minikube tunnel` command, you can see the EXTERNAL-IP of each service resource as `127.0.0.1`.
+
    ```console
    kubectl get svc -n monitoring scalar-monitoring-kube-pro-prometheus scalar-monitoring-kube-pro-alertmanager scalar-monitoring-grafana
    ```
+
    [Command execution result]
+
    ```console
    NAME                                      TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
    scalar-monitoring-kube-pro-prometheus     LoadBalancer   10.98.11.12    127.0.0.1     9090:30550/TCP   26m
@@ -205,24 +227,33 @@ First, you need to prepare a Kubernetes cluster. If you use a **minikube** envir
 
 1. Access each Dashboard.
    * Prometheus
+
      ```console
      http://localhost:9090/
      ```
+
    * Alertmanager
+
      ```console
      http://localhost:9093/
      ```
+
    * Grafana
+
      ```console
      http://localhost:3000/
      ```
+
        * Note:
            * You can see the user and password of Grafana as follows.
                * user
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-user}' | base64 -d
                  ```
+
                * password
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```
@@ -236,18 +267,22 @@ If you use a Kubernetes cluster other than minikube, you need to access the Load
 After completing the Monitoring tests on the Kubernetes cluster, remove all resources.
 
 1. Terminate the `minikube tunnel` command. (If you use minikube)
+
    ```console
    Ctrl + C
    ```
 
 1. Uninstall `kube-prometheus-stack`.
+
    ```console
    helm uninstall scalar-monitoring -n monitoring
    ```
 
 1. Delete minikube. (Optional / If you use minikube)
+
    ```console
    minikube delete --all
    ```
+
    * Note:
        * If you deploy the ScalarDB or ScalarDL, you need to remove them before deleting minikube.

--- a/docs/latest/helm-charts/getting-started-scalar-helm-charts.md
+++ b/docs/latest/helm-charts/getting-started-scalar-helm-charts.md
@@ -28,15 +28,19 @@ First, you need to install the following tools used in this guide.
 ## Step 2. Start minikube with docker driver (Optional / If you use minikube)
 
 1. Start minikube.
+
    ```console
    minikube start
    ```
 
 1. Check the status of the minikube and pods.
+
    ```console
    kubectl get pod -A
    ```
+
    [Command execution result]
+
    ```console
    NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
    kube-system   coredns-64897985d-lbsfr            1/1     Running   1 (20h ago)   21h
@@ -47,9 +51,10 @@ First, you need to install the following tools used in this guide.
    kube-system   kube-scheduler-minikube            1/1     Running   1 (20h ago)   21h
    kube-system   storage-provisioner                1/1     Running   2 (19s ago)   21h
    ```
+
    If the minikube starts properly, you can see some pods are **Running** in the kube-system namespace.
 
-## Step 3. 
+## Step 3.
 
 After the Kubernetes cluster starts, you can try each Scalar Helm Charts on it. Please refer to the following documents for more details.
 

--- a/docs/latest/helm-charts/getting-started-scalar-manager.md
+++ b/docs/latest/helm-charts/getting-started-scalar-manager.md
@@ -64,6 +64,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 1. Upgrade the `kube-prometheus-stack` to allow Grafana to be embedded
 
 1. Add or revise this value to the custom values file (e.g. scalar-prometheus-custom-values.yaml) of the `kube-prometheus-stack`
+
    ```yaml
    grafana:
      grafana.ini:
@@ -73,6 +74,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
    ```
 
 1. Upgrade the Helm installation
+
    ```console
    helm upgrade scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -82,6 +84,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 1. Get the sample file [scalar-manager-custom-values.yaml](./conf/scalar-manager-custom-values.yaml) for `scalar-manager`.
 
 1. Add the targets that you would like to manage. For example, if we want to manage a ledger cluster, then we can add the values as follows.
+
    ```yaml
    scalarManager:
      targets:
@@ -89,21 +92,25 @@ We will deploy the following components on a Kubernetes cluster as follows.
          adminSrv: _scalardl-admin._tcp.scalardl-headless.default.svc.cluster.local
          databaseType: cassandra
    ```
+
    Note: the `adminSrv` is the DNS Service URL that returns SRV record of pods. Kubernetes creates this URL for the named port of the headless service of the Scalar product. The format is `_{port name}._{protocol}.{service name}.{namespace}.svc.{cluster domain name}`
 
 1. Set the Grafana URL. For example, if your Grafana of the `kube-prometheus-stack` is exposed in `localhost:3000`, then we can set it as follows.
+
    ```yaml
    scalarManager:
      grafanaUrl: "http://localhost:3000"
    ```
 
 1. Set the refresh interval that Scalar Manager checks the status of the products. The default value is `30` seconds, but we can change it like:
+
    ```yaml
    scalarManager:
      refreshInterval: 60 # one minute
    ```
 
 1. Set the service type to access Scalar Manager. The default value is `ClusterIP`, but if we access using the `minikube tunnel` command or some load balancer, we can set it as `LoadBalancer`.
+
    ```yaml
    service:
      type: LoadBalancer
@@ -112,11 +119,13 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ## Step 3. Deploy `scalar-manager`
 
 1. Create a secret resource `reg-docker-secrets` to pull the Scalar Manager container image from GitHub Packages.
+
    ```console
    kubectl create secret docker-registry reg-docker-secrets --docker-server=ghcr.io --docker-username=<github-username> --docker-password=<github-personal-access-token>
    ```
 
 1. Deploy the `scalar-manager` Helm Chart.
+
    ```console
    helm install scalar-manager scalar-labs/scalar-manager -f scalar-manager-custom-values.yaml
    ```
@@ -126,6 +135,7 @@ We will deploy the following components on a Kubernetes cluster as follows.
 ### If you use minikube
 
 1. To expose Scalar Manager's service resource as your `localhost (127.0.0.1)`, open another terminal, and run the `minikube tunnel` command.
+
    ```console
    minikube tunnel
    ```
@@ -138,6 +148,7 @@ If you use a Kubernetes cluster other than minikube, you need to access the Load
 
 ## Step 5. Delete Scalar Manager
 1. Uninstall `scalar-manager`
+
    ```console
    helm uninstall scalar-manager
    ```

--- a/docs/latest/helm-charts/getting-started-scalardb.md
+++ b/docs/latest/helm-charts/getting-started-scalardb.md
@@ -44,11 +44,13 @@ ScalarDB uses some kind of database system as a backend database. In this docume
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL.
+
    ```console
    helm install postgresql-scalardb bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -56,10 +58,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL container is running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                    READY   STATUS    RESTARTS   AGE
    postgresql-scalardb-0   1/1     Running   0          2m42s
@@ -68,19 +73,23 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 ## Step 3. Deploy ScalarDB Server on the Kubernetes cluster using Helm Charts
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDB container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -89,12 +98,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
 
    Please refer to the following documents for more details.
-   
+
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 1. Create a custom values file for ScalarDB Server (scalardb-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -118,7 +128,9 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -144,6 +156,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
      ```
 
 1. Create a Secret resource that includes a username and password for PostgreSQL.
+
    ```console
    kubectl create secret generic scalardb-credentials-secret \
      --from-literal=SCALAR_DB_POSTGRES_USERNAME=postgres \
@@ -151,15 +164,19 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Deploy ScalarDB Server.
+
    ```console
    helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
    ```
 
 1. Check if the ScalarDB Server pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                              READY   STATUS    RESTARTS   AGE
    postgresql-scalardb-0             1/1     Running   0          9m48s
@@ -170,13 +187,17 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    scalardb-envoy-84c475f77b-n74tk   1/1     Running   0          6s
    scalardb-envoy-84c475f77b-zbrwz   1/1     Running   0          6s
    ```
+
    If the ScalarDB Server Pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDB Server services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
    kubernetes               ClusterIP   10.96.0.1        <none>        443/TCP     47d
@@ -187,20 +208,25 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    scalardb-headless        ClusterIP   None             <none>        60051/TCP   41s
    scalardb-metrics         ClusterIP   10.108.188.10    <none>        8080/TCP    41s
    ```
+
    If the ScalarDB Server services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardb-headless` has no CLUSTER-IP.)  
 
 ## Step 4. Start a Client container
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    kubectl run scalardb-client --image eclipse-temurin:8 --command sleep inf
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardb-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardb-client   1/1     Running   0          23s
@@ -211,66 +237,86 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 The following explains the minimum steps. If you want to know more details about ScalarDB, please refer to the [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardb-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git and curl commands in the Client container.
+
    ```console
    apt update && apt install -y git curl
    ```
 
 1. Clone ScalarDB git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardb.git
    ```
 
 1. Change the directory to `scalardb/`.
+
    ```console
    cd scalardb/
    ```
+
    ```console
    pwd
    ```
+
    [Command execution result]
+
    ```console
    /scalardb
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.7.0 refs/tags/v3.7.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
+
    ```console
      master
    * v3.7.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use.
 
 1. Change the directory to `docs/getting-started/`.
+
    ```console
    cd docs/getting-started/
    ```
+
    ```console
    pwd
    ```
+
    [Command execution result]
+
    ```console
    /scalardb/docs/getting-started
    ```
 
 1. Download Schema Loader from [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardb/releases/download/v3.7.0/scalardb-schema-loader-3.7.0.jar
    ```
+
    You need to use the same version of ScalarDB and Schema Loader.
 
 1. Create a configuration file (scalardb.properties) to access ScalarDB Server on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > scalardb.properties
    scalar.db.contact_points=scalardb-envoy.default.svc.cluster.local
@@ -281,6 +327,7 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Create a JSON file (emoney-transaction.json) that defines DB Schema for the sample applications.
+
    ```console
    cat << 'EOF' > emoney-transaction.json
    {
@@ -300,37 +347,50 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Run Schema Loader (Create sample TABLE).
+
    ```console
    java -jar ./scalardb-schema-loader-3.7.0.jar --config ./scalardb.properties -f emoney-transaction.json --coordinator
    ```
 
 1. Run the sample applications.
    * Charge `1000` to `user1`:
+
      ```console
      ./gradlew run --args="-action charge -amount 1000 -to user1"
      ```
+
    * Charge `0` to `merchant1` (Just create an account for `merchant1`):
+
      ```console
      ./gradlew run --args="-action charge -amount 0 -to merchant1"
      ```
+
    * Pay `100` from `user1` to `merchant1`:
+
      ```console
      ./gradlew run --args="-action pay -amount 100 -from user1 -to merchant1"
      ```
+
    * Get the balance of `user1`:
+
      ```console
      ./gradlew run --args="-action getBalance -id user1"
      ```
+
    * Get the balance of `merchant1`:
+
      ```console
      ./gradlew run --args="-action getBalance -id merchant1"
      ```
 
 1. (Optional) You can see the inserted and modified (INSERT/UPDATE) data through the sample applications using the following command. (This command needs to run on your localhost, not on the Client container.)  
+
    ```console
    kubectl exec -it postgresql-scalardb-0 -- bash -c 'export PGPASSWORD=postgres && psql -U postgres -d postgres -c "SELECT * FROM emoney.account"'
    ```
+
    [Command execution result]
+
    ```sql
        id     | balance |                tx_id                 | tx_state | tx_version | tx_prepared_at | tx_committed_at |             before_tx_id             | before_tx_state | before_tx_version | before_tx_prepared_at | before_tx_committed_at | before_balance
    -----------+---------+--------------------------------------+----------+------------+----------------+-----------------+--------------------------------------+-----------------+-------------------+-----------------------+------------------------+----------------
@@ -338,6 +398,7 @@ The following explains the minimum steps. If you want to know more details about
     user1     |     900 | 65a90225-0846-4e97-b729-151f76f6ca2f |        3 |          2 |  1667361909634 |1667361909679    | 5520cba4-625a-4886-b81f-6089bf846d18 |               3 |                 1 |         1667361897283 |          1667361897317 |           1000
    (2 rows)
    ```
+
    * Note:
        * Usually, you need to access data (records) through ScalarDB. The above command is used to explain and confirm the working of the sample applications.
 
@@ -346,12 +407,14 @@ The following explains the minimum steps. If you want to know more details about
 After completing the ScalarDB Server tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDB Server and PostgreSQL.
+
    ```console
    helm uninstall scalardb postgresql-scalardb
    ```
 
 1. Remove the Client container.
-   ```
+
+   ```console
    kubectl delete pod scalardb-client --force --grace-period 0
    ```
 

--- a/docs/latest/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/latest/helm-charts/getting-started-scalardl-auditor.md
@@ -72,11 +72,13 @@ ScalarDL Ledger and Auditor use some kind of database system as a backend databa
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL for Ledger.
+
    ```console
    helm install postgresql-ledger bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -84,6 +86,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Deploy PostgreSQL for Auditor.
+
    ```console
    helm install postgresql-auditor bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -91,10 +94,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL containers are running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                   READY   STATUS    RESTARTS   AGE
    postgresql-auditor-0   1/1     Running   0          11s
@@ -106,6 +112,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 We will create some configuration files and key/certificate files locally. So, create a working directory for them.
 
 1. Create a working directory.
+
    ```console
    mkdir -p ~/scalardl-test/certs/
    ```
@@ -115,11 +122,13 @@ We will create some configuration files and key/certificate files locally. So, c
 Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
 1. Change the working directory to `~/scalardl-test/certs/` directory.
+
    ```console
    cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
@@ -143,6 +152,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Auditor information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/auditor.json
    {
@@ -166,6 +176,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Client information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
@@ -189,25 +200,31 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create key/certificate files for the Ledger.
+
    ```console
    cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Auditor.
+
    ```console
    cfssl selfsign "" ./auditor.json | cfssljson -bare auditor
    ```
 
 1. Create key/certificate files for the Client.
+
    ```console
    cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
+
    ```console
    ls -1
    ```
+
    [Command execution result]
+
    ```console
    auditor-key.pem
    auditor.csr
@@ -229,24 +246,29 @@ We will deploy two ScalarDL Schema Loader pods on the Kubernetes cluster using H
 The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Auditor in PostgreSQL.  
 
 1. Change the working directory to `~/scalardl-test/`.
+
    ```console
    cd ~/scalardl-test/
    ```
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -255,12 +277,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
    Please refer to the following documents for more details.
-   
+
    * [How to install Scalar products through AWS Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AwsMarketplaceGuide.md)
    * [How to install Scalar products through Azure Marketplace](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/AzureMarketplaceGuide.md)
 
 1. Create a custom values file for ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -278,7 +301,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -299,6 +324,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 
 1. Create a custom values file for ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -316,7 +342,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -336,6 +364,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Ledger.
+
    ```console
    kubectl create secret generic ledger-credentials-secret \
      --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
@@ -343,6 +372,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Auditor.
+
    ```console
    kubectl create secret generic auditor-credentials-secret \
      --from-literal=SCALAR_DL_AUDITOR_POSTGRES_USERNAME=postgres \
@@ -350,20 +380,25 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    ```
 
 1. Deploy the ScalarDL Schema Loader for Ledger.
+
    ```console
    helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Deploy the ScalarDL Schema Loader for Auditor.
+
    ```console
    helm install schema-loader-auditor scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Schema Loader pods are deployed and completed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
    postgresql-auditor-0                         1/1     Running     0          2m56s
@@ -371,12 +406,14 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          6s
    schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          10s
    ```
+
    If the ScalarDL Schema Loader pods are **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
 ## Step 6. Deploy ScalarDL Ledger and Auditor on the Kubernetes cluster using Helm Charts
 
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -411,7 +448,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -448,6 +487,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 
 1. Create a custom values file for ScalarDL Auditor (scalardl-auditor-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -482,7 +522,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -519,30 +561,37 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
      ```
 
 1. Create secret resource `ledger-keys`.
+
    ```console
    kubectl create secret generic ledger-keys --from-file=certificate=./certs/ledger.pem --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Create secret resource `auditor-keys`.
+
    ```console
    kubectl create secret generic auditor-keys --from-file=certificate=./certs/auditor.pem --from-file=private-key=./certs/auditor-key.pem
    ```
 
 1. Deploy the ScalarDL Ledger.
+
    ```console
    helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Deploy the ScalarDL Auditor.
+
    ```console
    helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Ledger and Auditor pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                         READY   STATUS      RESTARTS   AGE
    postgresql-auditor-0                         1/1     Running     0          14m
@@ -562,13 +611,17 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    schema-loader-auditor-schema-loading-dvc5r   0/1     Completed   0          11m
    schema-loader-ledger-schema-loading-mtllb    0/1     Completed   0          11m
    ```
+
    If the ScalarDL Ledger and Auditor pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDL Ledger and Auditor services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                             TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
    kubernetes                       ClusterIP   10.96.0.1        <none>        443/TCP                         47d
@@ -585,6 +638,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
    scalardl-ledger-headless         ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   61s
    scalardl-ledger-metrics          ClusterIP   10.99.122.106    <none>        8080/TCP                        61s
    ```
+
    If the ScalarDL Ledger and Auditor services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` and `scalardl-auditor-headless` have no CLUSTER-IP.)  
 
 ## Step 7. Start a Client container
@@ -592,11 +646,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
 
 1. Create secret resource `client-keys`.
-   ```
+
+   ```console
    kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
@@ -634,10 +690,13 @@ We will use certificate files in a Client container. So, we create a secret reso
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardl-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardl-client   1/1     Running   0          4s
@@ -652,65 +711,82 @@ The following explains the minimum steps. If you want to know more details about
 When you use Auditor, you need to register the certificate for the Ledger and Auditor before starting the client application. Ledger needs to register its certificate to Auditor, and Auditor needs to register its certificate to Ledger.
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardl-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git, curl and unzip commands in the Client container.
+
    ```console
    apt update && apt install -y git curl unzip
    ```
 
 1. Clone ScalarDL Java Client SDK git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change the directory to `scalardl-java-client-sdk/`.
+
    ```console
    cd scalardl-java-client-sdk/
    ```
+
    ```console
    pwd
    ```
-   [Command execution result]
-   ```console
 
+   [Command execution result]
+
+   ```console
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
+
    ```console
      master
    * v3.6.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
 1. Build the sample contracts.
+
    ```console
    ./gradlew assemble
    ```
 
 1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
+
    You need to use the same version of CLI tools and ScalarDL Ledger.
 
 1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
+
    ```console
    unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (ledger.as.client.properties) to register the certificate of Ledger to Auditor.
+
    ```console
    cat << 'EOF' > ledger.as.client.properties
    # Ledger
@@ -728,6 +804,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Create a configuration file (auditor.as.client.properties) to register the certificate of Auditor to Ledger.
+
    ```console
    cat << 'EOF' > auditor.as.client.properties
    # Ledger
@@ -745,6 +822,7 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > client.properties
    # Ledger
@@ -762,46 +840,57 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
    ```
 
 1. Register the certificate file of Ledger.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./ledger.as.client.properties
    ```
 
 1. Register the certificate file of Auditor.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./auditor.as.client.properties
    ```
 
 1. Register the certificate file of client.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-cert --properties ./client.properties
    ```
 
 1. Register the sample contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Register the contract `ValdateLedger` to execute a validate request.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id validate-ledger --contract-binary-name com.scalar.dl.client.contract.ValidateLedger --contract-class-file ./build/classes/java/main/com/scalar/dl/client/contract/ValidateLedger.class
    ```
 
 1. Execute the contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
+
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    ```
+
    [Command execution result]
+
    ```console
    Contract result:
    {
@@ -812,23 +901,29 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
      }
    }
    ```
+
    * Reference information
       * If the asset data is not tampered with, the contract execution request (execute-contract command) returns `OK` as a result.
       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the contract execution request (execute-contract command) returns a value other than `OK`  (e.g. `INCONSISTENT_STATES`) as a result, like the following.  
         [Command execution result (If the asset data is tampered with)]
+
         ```console
         {
           "status_code" : "INCONSISTENT_STATES",
           "error_message" : "The results from Ledger and Auditor don't match"
         }
         ```
+
           * In this way, the ScalarDL can detect data tampering.
 
 1. Execute a validation request for the asset.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
+
    [Command execution result]
+
    ```console
    {
      "status_code" : "OK",
@@ -848,16 +943,19 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
      }
    }
    ```
+
    * Reference information
       * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
       * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
         [Command execution result (If the asset data is tampered with)]
+
         ```console
         {
           "status_code" : "INCONSISTENT_STATES",
           "error_message" : "The results from Ledger and Auditor don't match"
         }
         ```
+
           * In this way, the ScalarDL Ledger can detect data tampering.
 
 ## Step 9. Delete all resources
@@ -865,19 +963,23 @@ When you use Auditor, you need to register the certificate for the Ledger and Au
 After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
+
    ```console
    helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger scalardl-auditor schema-loader-auditor postgresql-auditor
    ```
 
 1. Remove the Client container.
+
    ```
    kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
 1. Remove the working directory and sample files (configuration file, key, and certificate).
+
    ```console
    cd ~
    ```
+   
    ```console
    rm -rf ~/scalardl-test/
    ```

--- a/docs/latest/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/latest/helm-charts/getting-started-scalardl-ledger.md
@@ -54,11 +54,13 @@ ScalarDL Ledger uses some kind of database system as a backend database. In this
 You can deploy PostgreSQL on the Kubernetes cluster as follows.
 
 1. Add the Bitnami helm repository.
+
    ```console
    helm repo add bitnami https://charts.bitnami.com/bitnami
    ```
 
 1. Deploy PostgreSQL.
+
    ```console
    helm install postgresql-ledger bitnami/postgresql \
      --set auth.postgresPassword=postgres \
@@ -66,10 +68,13 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
    ```
 
 1. Check if the PostgreSQL container is running.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                  READY   STATUS    RESTARTS   AGE
    postgresql-ledger-0   1/1     Running   0          11s
@@ -80,6 +85,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 We will create some configuration files and key/certificate files locally. So, create a working directory for them.
 
 1. Create a working directory.
+
    ```console
    mkdir -p ~/scalardl-test/certs/
    ```
@@ -89,11 +95,13 @@ We will create some configuration files and key/certificate files locally. So, c
 Note: In this guide, we will use self-sign certificates for the test. However, it is strongly recommended that these certificates NOT be used in production.
 
 1. Change the working directory to `~/scalardl-test/certs/` directory.
+
    ```console
    cd ~/scalardl-test/certs/
    ```
 
 1. Create a JSON file that includes Ledger information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/ledger.json
    {
@@ -117,6 +125,7 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create a JSON file that includes Client information.
+
    ```console
    cat << 'EOF' > ~/scalardl-test/certs/client.json
    {
@@ -140,20 +149,25 @@ Note: In this guide, we will use self-sign certificates for the test. However, i
    ```
 
 1. Create key/certificate files for the Ledger.
+
    ```console
    cfssl selfsign "" ./ledger.json | cfssljson -bare ledger
    ```
 
 1. Create key/certificate files for the Client.
+
    ```console
    cfssl selfsign "" ./client.json | cfssljson -bare client
    ```
 
 1. Confirm key/certificate files are created.
+
    ```console
    ls -1
    ```
+
    [Command execution result]
+
    ```console
    client-key.pem
    client.csr
@@ -171,24 +185,29 @@ We will deploy a ScalarDL Schema Loader on the Kubernetes cluster using Helm Cha
 The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in PostgreSQL.  
 
 1. Change the working directory to `~/scalardl-test/`.
+
    ```console
    cd ~/scalardl-test/
    ```
 
 1. Add the Scalar helm repository.
+
    ```console
    helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
    ```
 
 1. Create a secret resource to pull the ScalarDL container images from AWS/Azure Marketplace.
    * AWS Marketplace
+
      ```console
      kubectl create secret docker-registry reg-ecr-mp-secrets \
        --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
        --docker-username=AWS \
        --docker-password=$(aws ecr get-login-password --region us-east-1)
      ```
+
    * Azure Marketplace
+
      ```console
      kubectl create secret docker-registry reg-acr-secrets \
        --docker-server=<your private container registry login server> \
@@ -203,6 +222,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 
 1. Create a custom values file for ScalarDL Schema Loader (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -221,6 +241,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      EOF
      ```
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -240,6 +261,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
 
 1. Create a secret resource that includes a username and password for PostgreSQL.
+
    ```console
    kubectl create secret generic ledger-credentials-secret \
      --from-literal=SCALAR_DL_LEDGER_POSTGRES_USERNAME=postgres \
@@ -247,26 +269,32 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    ```
 
 1. Deploy the ScalarDL Schema Loader.
+
    ```console
    helm install schema-loader-ledger scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Schema Loader pod is deployed and completed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    postgresql-ledger-0                         1/1     Running     0          11m
    schema-loader-ledger-schema-loading-46rcr   0/1     Completed   0          3s
    ```
+
    If the ScalarDL Schema Loader pod is **ContainerCreating** or **Running**, wait for the process will be completed (The STATUS will be **Completed**).
 
 ## Step 6. Deploy ScalarDL Ledger on the Kubernetes cluster using Helm Charts
 
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -300,7 +328,9 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+
    * Azure Marketplace
+
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -336,20 +366,25 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
      ```
 
 1. Create secret resource `ledger-keys`.
+
    ```console
    kubectl create secret generic ledger-keys --from-file=private-key=./certs/ledger-key.pem
    ```
 
 1. Deploy the ScalarDL Ledger.
+
    ```console
    helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
    ```
 
 1. Check if the ScalarDL Ledger pods are deployed.
+
    ```console
    kubectl get pod
    ```
+
    [Command execution result]
+
    ```console
    NAME                                        READY   STATUS      RESTARTS   AGE
    postgresql-ledger-0                         1/1     Running     0          14m
@@ -361,13 +396,17 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    scalardl-ledger-ledger-9bdf7f8bd-9tw5x      1/1     Running     0          52s
    schema-loader-ledger-schema-loading-46rcr   0/1     Completed   0          3m38s
    ```
+
    If the ScalarDL Ledger pods are deployed properly, you can see the STATUS are **Running**.  
 
 1. Check if the ScalarDL Ledger services are deployed.
+
    ```console
    kubectl get svc
    ```
+
    [Command execution result]
+
    ```console
    NAME                            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
    kubernetes                      ClusterIP   10.96.0.1        <none>        443/TCP                         47d
@@ -378,6 +417,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
    scalardl-ledger-headless        ClusterIP   None             <none>        50051/TCP,50053/TCP,50052/TCP   83s
    scalardl-ledger-metrics         ClusterIP   10.98.4.217      <none>        8080/TCP                        83s
    ```
+
    If the ScalarDL Ledger services are deployed properly, you can see private IP addresses in the CLUSTER-IP column. (Note: `scalardl-ledger-headless` has no CLUSTER-IP.)  
 
 ## Step 7. Start a Client container
@@ -385,11 +425,13 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 We will use certificate files in a Client container. So, we create a secret resource and mount it to a Client container.  
 
 1. Create secret resource `client-keys`.
-   ```
+
+   ```console
    kubectl create secret generic client-keys --from-file=certificate=./certs/client.pem --from-file=private-key=./certs/client-key.pem
    ```
 
 1. Start a Client container on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' | kubectl apply -f -
    apiVersion: v1
@@ -415,10 +457,13 @@ We will use certificate files in a Client container. So, we create a secret reso
    ```
 
 1. Check if the Client container is running.
+
    ```console
    kubectl get pod scalardl-client
    ```
+
    [Command execution result]
+
    ```console
    NAME              READY   STATUS    RESTARTS   AGE
    scalardl-client   1/1     Running   0          11s
@@ -429,65 +474,81 @@ We will use certificate files in a Client container. So, we create a secret reso
 The following explains the minimum steps. If you want to know more details about ScalarDL and the contract, please refer to the [Getting Started with ScalarDL](https://github.com/scalar-labs/scalardl/blob/master/docs/getting-started.md).
 
 1. Run bash in the Client container.
+
    ```console
    kubectl exec -it scalardl-client -- bash
    ```
+
    After this step, run each command in the Client container.  
 
 1. Install the git, curl and unzip commands in the Client container.
+
    ```console
    apt update && apt install -y git curl unzip
    ```
 
 1. Clone ScalarDL Java Client SDK git repository.
+
    ```console
    git clone https://github.com/scalar-labs/scalardl-java-client-sdk.git
    ```
 
 1. Change the directory to `scalardl-java-client-sdk/`.
+
    ```console
    cd scalardl-java-client-sdk/
    ```
+
    ```console
    pwd
    ```
-   [Command execution result]
-   ```console
 
+   [Command execution result]
+
+   ```console
    /scalardl-java-client-sdk
    ```
 
 1. Change branch to arbitrary version.
+
    ```console
    git checkout -b v3.6.0 refs/tags/v3.6.0
    ```
+
    ```console
    git branch
    ```
+
    [Command execution result]
    ```console
      master
    * v3.6.0
    ```
+
    If you want to use another version, please specify the version (tag) you want to use. You need to use the same version of ScalarDL Ledger and ScalarDL Java Client SDK.
 
 1. Build the sample contracts.
+
    ```console
    ./gradlew assemble
    ```
 
 1. Download CLI tools of ScalarDL from [ScalarDL Java Client SDK Releases](https://github.com/scalar-labs/scalardl-java-client-sdk/releases).
+
    ```console
    curl -OL https://github.com/scalar-labs/scalardl-java-client-sdk/releases/download/v3.6.0/scalardl-java-client-sdk-3.6.0.zip
    ```
+
    You need to use the same version of CLI tools and ScalarDL Ledger.
 
 1. Unzip the `scalardl-java-client-sdk-3.6.0.zip` file.
+
    ```console
    unzip ./scalardl-java-client-sdk-3.6.0.zip
    ```
 
 1. Create a configuration file (client.properties) to access ScalarDL Ledger on the Kubernetes cluster.
+
    ```console
    cat << 'EOF' > client.properties
    scalar.dl.client.server.host=scalardl-ledger-envoy.default.svc.cluster.local
@@ -503,26 +564,32 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Register the sample contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file ./build/classes/java/main/com/org1/contract/StateUpdater.class
    ```
 
 1. Register the sample contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/register-contract --properties ./client.properties --contract-id StateReader --contract-binary-name com.org1.contract.StateReader --contract-class-file ./build/classes/java/main/com/org1/contract/StateReader.class
    ```
 
 1. Execute the contract `StateUpdater`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateUpdater --contract-argument '{"asset_id": "test_asset", "state": 3}'
    ```
    This sample contract updates the `state` (value) of the asset named `test_asset` to `3`.  
 
 1. Execute the contract `StateReader`.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/execute-contract --properties ./client.properties --contract-id StateReader --contract-argument '{"asset_id": "test_asset"}'
    ```
+
    [Command execution result]
+
    ```console
    Contract result:
    {
@@ -535,10 +602,13 @@ The following explains the minimum steps. If you want to know more details about
    ```
 
 1. Execute a validation request for the asset.
+
    ```console
    ./scalardl-java-client-sdk-3.6.0/bin/validate-ledger --properties ./client.properties --asset-id "test_asset"
    ```
+
    [Command execution result]
+
    ```console
    {
      "status_code" : "OK",
@@ -552,10 +622,12 @@ The following explains the minimum steps. If you want to know more details about
      "Auditor" : null
    }
    ```
+
    * Reference information
        * If the asset data is not tampered with, the validation request (validate-ledger command) returns `OK` as a result.
        * If the asset data is tampered with (e.g. the `state` value in the DB is tampered with), the validation request (validate-ledger command) returns a value other than `OK` (e.g. `INVALID_OUTPUT`) as a result, like the following.  
          [Command execution result (If the asset data is tampered with)]
+
          ```console
          {
            "status_code" : "INVALID_OUTPUT",
@@ -569,6 +641,7 @@ The following explains the minimum steps. If you want to know more details about
            "Auditor" : null
          }
          ```
+
            * In this way, the ScalarDL Ledger can detect data tampering.
 
 ## Step 9. Delete all resources
@@ -576,19 +649,23 @@ The following explains the minimum steps. If you want to know more details about
 After completing the ScalarDL Ledger tests on the Kubernetes cluster, remove all resources.
 
 1. Uninstall ScalarDL Ledger, ScalarDL Schema Loader, and PostgreSQL.
+
    ```console
    helm uninstall scalardl-ledger schema-loader-ledger postgresql-ledger
    ```
 
 1. Remove the Client container.
+
    ```
    kubectl delete pod scalardl-client --force --grace-period 0
    ```
 
 1. Remove the working directory and sample files (configuration file, key, and certificate).
+
    ```console
    cd ~
    ```
+   
    ```console
    rm -rf ~/scalardl-test/
    ```

--- a/docs/latest/helm-charts/how-to-deploy-scalar-products.md
+++ b/docs/latest/helm-charts/how-to-deploy-scalar-products.md
@@ -15,6 +15,7 @@ You must install the helm command to use Scalar Helm Charts. Please install the 
 ```console
 helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
 ```
+
 ```console
 helm repo update scalar-labs
 ```

--- a/docs/latest/helm-charts/how-to-deploy-scalardb-cluster.md
+++ b/docs/latest/helm-charts/how-to-deploy-scalardb-cluster.md
@@ -31,6 +31,7 @@ If you use ScalarDB Cluster with `direct-kubernetes` mode, you must:
 This method is necessary because the ScalarDB Cluster client library with `direct-kubernetes` mode runs the Kubernetes API from inside of your application pods to get information about the ScalarDB Cluster pods.
 
 * Role
+
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -42,7 +43,9 @@ This method is necessary because the ScalarDB Cluster client library with `direc
       resources: ["endpoints"]
       verbs: ["get", "watch", "list"]
   ```
+
 * RoleBinding
+
   ```yaml
   apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
@@ -57,7 +60,9 @@ This method is necessary because the ScalarDB Cluster client library with `direc
     name: scalardb-cluster-role
     apiGroup: rbac.authorization.k8s.io
   ```
+
 * ServiceAccount
+
   ```yaml
   apiVersion: v1
   kind: ServiceAccount

--- a/docs/latest/helm-charts/mount-files-or-volumes-on-scalar-pods.md
+++ b/docs/latest/helm-charts/mount-files-or-volumes-on-scalar-pods.md
@@ -8,6 +8,7 @@ You must mount the key and certificate files to run ScalarDL Auditor.
 
 * Configuration example
     * ScalarDL Ledger
+
       ```yaml
       ledger:
         ledgerProperties: |
@@ -16,7 +17,9 @@ You must mount the key and certificate files to run ScalarDL Auditor.
           scalar.dl.ledger.auditor.enabled=true
           scalar.dl.ledger.proof.private_key_path=/keys/private-key
       ```
+
     * ScalarDL Auditor
+
       ```yaml
       auditor:
         auditorProperties: |
@@ -30,6 +33,7 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 1. Set `extraVolumes` and `extraVolumeMounts` in the custom values file using the same syntax of Kubernetes manifest. You need to specify the directory name to the key `mountPath`.
    * Example
         * ScalarDL Ledger
+
           ```yaml
           ledger:
             extraVolumes:
@@ -41,7 +45,9 @@ In this example, you need to mount a **private-key** and a **certificate** file 
                 mountPath: /keys
                 readOnly: true
           ```
+
        * ScalarDL Auditor
+
          ```yaml
          auditor:
             extraVolumes:
@@ -60,11 +66,14 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
    * Example
        * ScalarDL Ledger
+
          ```console
          kubectl create secret generic ledger-keys \
            --from-file=private-key=./ledger-key.pem
          ```
+
        * ScalarDL Auditor
+
          ```console
          kubectl create secret generic auditor-keys \
            --from-file=private-key=./auditor-key.pem \
@@ -77,12 +86,15 @@ In this example, you need to mount a **private-key** and a **certificate** file 
 
    * Example
        * ScalarDL Ledger
+
          ```console
          $ ls -l /keys/
          total 0
          lrwxrwxrwx 1 root root 18 Jun 27 03:12 private-key -> ..data/private-key
          ```
+
        * ScalarDL Auditor
+
          ```console
          $ ls -l /keys/
          total 0
@@ -101,6 +113,7 @@ You can mount emptyDir to Scalar product pods by using the following keys in you
   * `auditor.extraVolumes` / `auditor.extraVolumeMounts` (ScalarDL Auditor)
 
 * Example (ScalarDB Server)
+
   ```yaml
   scalardb:
     extraVolumes:

--- a/docs/latest/helm-charts/use-secret-for-credentials.md
+++ b/docs/latest/helm-charts/use-secret-for-credentials.md
@@ -3,6 +3,7 @@
 You can pass credentials like **username** or **password** as environment variables via a `Secret` resource in Kubernetes. The docker images for previous versions of Scalar products use the `dockerize` command for templating properties files. The docker images for the latest versions of Scalar products get values directly from environment variables.
 
 Note: You cannot use the following environment variable names in your custom values file since these are used in the Scalar Helm Chart internal.
+
 ```console
 HELM_SCALAR_DB_CONTACT_POINTS
 HELM_SCALAR_DB_CONTACT_PORT
@@ -31,6 +32,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
    * Example
        * ScalarDB Server
            * ScalarDB Server 3.7 or earlier (Go template syntax)
+
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -39,7 +41,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
                   ...
              ```
+
            * ScalarDB Server 3.8 or later (Apache Commons Text syntax)
+
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -48,7 +52,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password=${env:SCALAR_DB_PASSWORD}
                   ...
              ```
+
        * ScalarDB Cluster
+
          ```yaml
          scalardbCluster:
            scalardbClusterNodeProperties: |
@@ -57,7 +63,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password=${env:SCALAR_DB_PASSWORD}
              ...
          ```
+
        * ScalarDL Ledger (Go template syntax)
+
           ```yaml
           ledger:
             ledgerProperties: |
@@ -66,7 +74,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
               scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
               ...
           ```
+
        * ScalarDL Auditor (Go template syntax)
+
          ```yaml
          auditor:
            auditorProperties: |
@@ -75,7 +85,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+
        * ScalarDL Schema Loader (Go template syntax)
+
          ```yaml
          schemaLoading:
            databaseProperties: |
@@ -88,6 +100,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 1. Create a `Secret` resource that includes credentials.  
    You need to specify the environment variable name as keys of the `Secret`.
    * Example
+
      ```console
      kubectl create secret generic scalardb-credentials-secret \
        --from-literal=SCALAR_DB_USERNAME=postgres \
@@ -103,26 +116,35 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
      * `schemaLoading.secretName` (ScalarDL Schema Loader)
    * Example
      * ScalarDB Server
+
        ```yaml
        scalardb:
          secretName: "scalardb-credentials-secret"
        ```
+
      * ScalarDB Cluster
+
        ```yaml
        scalardbCluster:
          secretName: "scalardb-cluster-credentials-secret"
        ```
+
      * ScalarDL Ledger
+
        ```yaml
        ledger:
          secretName: "ledger-credentials-secret"
        ```
+
      * ScalarDL Auditor
+
        ```yaml
        auditor:
          secretName: "auditor-credentials-secret"
        ```
+
      * ScalarDL Schema Loader
+
        ```yaml
        schemaLoading:
          secretName: "schema-loader-ledger-credentials-secret"
@@ -134,6 +156,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 
    * Example
        * Custom values file
+
          ```yaml
          scalardb:
            databaseProperties: |
@@ -142,7 +165,9 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              scalar.db.storage=jdbc
          ```
+
        * Properties file in containers
+       
          ```properties
          scalar.db.contact_points=jdbc:postgresql://postgresql-scalardb.default.svc.cluster.local:5432/postgres
          scalar.db.username=postgres


### PR DESCRIPTION
## Description

This PR fixes code block formatting in Scalar Helm Charts docs. Some code blocks, particularly those that contain hyphens (rendered as a bulleted item in Jekyll) and are nested in bulleted lists, don't appear as expected.

### Related issue or PR

N/A

### Type of change

- [X] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, and confirmed that the broken code blocks appeared as expected.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
