### PR TITLE
Add ScalarDB Cluster docs to and remove ScalarDB Server docs from Kubernetes-related landing pages for versions 3.9 and 3.10 

### DIFF
--- a/docs/3.10/scalar-kubernetes/deploy-kubernetes.md
+++ b/docs/3.10/scalar-kubernetes/deploy-kubernetes.md
@@ -9,14 +9,14 @@ The following documentation is to help you set up and deploy a ScalarDB environm
 
 ## Installation guides
 
+* [Guidelines for creating an EKS cluster for ScalarDB Cluster](CreateEKSClusterForScalarDBCluster.md)
 * [How to install Scalar products through AWS Marketplace](AwsMarketplaceGuide.md)
 * [How to install Scalar products through Azure Marketplace](AzureMarketplaceGuide.md)
 * [Create a bastion server](CreateBastionServer.md)
 
 ## Deployment guides
 
-* [Deploy ScalarDB Server on Amazon Elastic Kubernetes Service (EKS)](ManualDeploymentGuideScalarDBServerOnEKS.md)
-* [Deploy ScalarDB Server on Azure Kubernetes Service (AKS)](ManualDeploymentGuideScalarDBServerOnAKS.md)
+* [Deploy ScalarDB Cluster on Amazon Elastic Kubernetes Service (EKS)](ManualDeploymentGuideScalarDBClusterOnEKS.md)
 
 ## Configuration guides
 

--- a/docs/3.9/scalar-kubernetes/deploy-kubernetes.md
+++ b/docs/3.9/scalar-kubernetes/deploy-kubernetes.md
@@ -9,14 +9,14 @@ The following documentation is to help you set up and deploy a ScalarDB environm
 
 ## Installation guides
 
+* [Guidelines for creating an EKS cluster for ScalarDB Cluster](CreateEKSClusterForScalarDBCluster.md)
 * [How to install Scalar products through AWS Marketplace](AwsMarketplaceGuide.md)
 * [How to install Scalar products through Azure Marketplace](AzureMarketplaceGuide.md)
 * [Create a bastion server](CreateBastionServer.md)
 
 ## Deployment guides
 
-* [Deploy ScalarDB Server on Amazon Elastic Kubernetes Service (EKS)](ManualDeploymentGuideScalarDBServerOnEKS.md)
-* [Deploy ScalarDB Server on Azure Kubernetes Service (AKS)](ManualDeploymentGuideScalarDBServerOnAKS.md)
+* [Deploy ScalarDB Cluster on Amazon Elastic Kubernetes Service (EKS)](ManualDeploymentGuideScalarDBClusterOnEKS.md)
 
 ## Configuration guides
 

--- a/docs/latest/scalar-kubernetes/deploy-kubernetes.md
+++ b/docs/latest/scalar-kubernetes/deploy-kubernetes.md
@@ -9,14 +9,14 @@ The following documentation is to help you set up and deploy a ScalarDB environm
 
 ## Installation guides
 
+* [Guidelines for creating an EKS cluster for ScalarDB Cluster](CreateEKSClusterForScalarDBCluster.md)
 * [How to install Scalar products through AWS Marketplace](AwsMarketplaceGuide.md)
 * [How to install Scalar products through Azure Marketplace](AzureMarketplaceGuide.md)
 * [Create a bastion server](CreateBastionServer.md)
 
 ## Deployment guides
 
-* [Deploy ScalarDB Server on Amazon Elastic Kubernetes Service (EKS)](ManualDeploymentGuideScalarDBServerOnEKS.md)
-* [Deploy ScalarDB Server on Azure Kubernetes Service (AKS)](ManualDeploymentGuideScalarDBServerOnAKS.md)
+* [Deploy ScalarDB Cluster on Amazon Elastic Kubernetes Service (EKS)](ManualDeploymentGuideScalarDBClusterOnEKS.md)
 
 ## Configuration guides
 


### PR DESCRIPTION
## Description

This PR adds ScalarDB Cluster docs to and removes ScalarDB Server docs from Kubernetes-related landing page doc for versions 3.9 and 3.10.

### Related issue or PR

N/A

### Type of change

- [x] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, and confirmed that the updated page included ScalarDB Cluster link and didn't include the deleted ScalarDB Server links for docs versions 3.9 and 3.10.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
