### PR TITLE
Increase font size in tables

### DIFF
--- a/_sass/minimal-mistakes/_tables.scss
+++ b/_sass/minimal-mistakes/_tables.scss
@@ -7,7 +7,7 @@ table {
   margin-bottom: 1em;
   width: 100%;
   font-family: $global-font-family;
-  font-size: $type-size-6;
+  font-size: $type-size-5; /* Originally `font-size: $type-size-6;` (modified by josh-wong) */
   border-collapse: collapse;
   overflow-x: auto;
 


### PR DESCRIPTION
## Description

This PR increases the size of the fonts in tables. Previously, the fonts didn't match the size of the body text, which made the tables difficult to read.

### Related issue or PR

N/A

### Type of change

- [ ] Documentation (new or updated documentation)
- [x] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, and navigated to multiple pages that have tables. On those pages, I confirmed that the text in the tables appeared as expected with the larger fonts size.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
