### PR TITLE
Fix issue with tabs not stacking properly when forced onto a second row; change color of tabs on hover

### DIFF
--- a/_sass/minimal-mistakes/_tabbed-content.scss
+++ b/_sass/minimal-mistakes/_tabbed-content.scss
@@ -13,6 +13,7 @@
   background-color: transparent;
   float: left;
   border: none;
+  border-bottom: 4px solid transparent; /* Added because the bottom border of a tab being hovered over forces the tab title to move when tabs get stacked on narrow screens. (modified by josh-wong) */
   outline: none;
   cursor: pointer;
   padding: 14px 16px;
@@ -24,7 +25,7 @@
 /* Change background color of buttons on hover */
 .tab button:hover {
   color: $scalar-primary-color;
-  background-color: $scalar-light-gray-background-color;
+  background-color: mix(#fff, $scalar-primary-color, 90%);
   border-bottom: 4px solid $scalar-primary-color;
 }
 


### PR DESCRIPTION
## Description

This PR:

- Fixes an issue with tabs not being stacked properly when tabs are forced onto a second row. This occurs when many tabs exist or when the browser window is narrow.
- Changes the color of tabs on hover.

## Related issues and/or PRs

N/A

## Changes made

- Added a border to the bottom of tabs to keep tab titles from not stacking properly when they are forced onto a second row.
- Changed the color of tabs on hover from gray to a light Scalar blue.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
