### PR TITLE
Change side navigation padding and background color on hover for readability

### DIFF
--- a/_sass/minimal-mistakes/_navigation.scss
+++ b/_sass/minimal-mistakes/_navigation.scss
@@ -512,6 +512,7 @@
   .nav__list .nav__items {
     margin: 0 1em 0 0; /* Adjusted spacing since the default spacing is too close to the scroll bar; originally `margin: 0;` (modified by josh-wong) */
     font-size: 1.25rem;
+    padding-right: 7px;
     
     ul {
       padding-left: 0.5em;
@@ -523,15 +524,18 @@
       /* Added a hover element to make navigation items more prominent when a visitor hovers over a link (added by josh-wong) */
       &:hover {
         color: $scalar-primary-color;
+        background-color: mix(#fff, $scalar-primary-color, 90%);
       }
     }
   
     .active {
-      margin-left: -0.5em;
+      margin-left: -0.6em;
+      margin-right: -7px;
       padding-left: 0.5em;
-      font-weight: bold;
+      padding-right: 7px;
+      font-weight: 500;
       color: $scalar-primary-color;
-      background-color: $scalar-light-gray-background-color; /* Added to make the page that visitors are on more prominent in the side navigation (added by josh-wong) */
+      background-color: mix(#fff, $scalar-primary-color, 90%); /* Added to make the page that visitors are on more prominent in the side navigation (added by josh-wong) */
       display: block; /* Added to make the background color take up 100% of space in the side navigation (added by josh-wong) */
     }
   
@@ -605,7 +609,7 @@
   
     // Scrollspy marks toc items as .active when they are in focus
     .active a {
-      @include yiq-contrasted($active-color);
+      @include yiq-contrasted(mix(#fff, $scalar-primary-color, 90%));
     }
   }
   

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -62,11 +62,15 @@
       font-size: $type-size-6;
       line-height: 1.5;
       margin-bottom: 12px;
+      padding-right: 7px;
   
       /* Added to give hover effect to items in navigation (added by josh-wong) */
       li {
         &:hover {
-          background-color: $scalar-light-gray-background-color;
+          background-color: mix(#fff, $scalar-primary-color, 90%);
+          margin-left: -10px;
+          padding-left: 10px;
+          padding-right: 7px;
         }
       }
     }


### PR DESCRIPTION
## Description

This PR improves readability of titles in the side navigation. Previously, the color was a little too difficult to see (light gray) and the padding was too tight when the user hovered over a title.

## Related issues and/or PRs

N/A

## Changes made

- Added more spacing around titles in the side navigation so that, when a user hovers over a title, the color surrounds the title and makes the hover action more noticeable.
- Applied a blue color based on Scalar's primary brand color when a user:
  - Hovers over a title in the side navigation.
  - Is actively on a page.
- Reduced the weight used to bold the page that the reader is on.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
