### PR TITLE
Apply centering and Scalar brand colors to Mermaid diagrams

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -32,7 +32,15 @@
   $(document).ready(function () {
     mermaid.initialize({
       startOnLoad:true,
-      theme: "default",
+      theme: "base", // Modified the Mermaid theme to match Scalar brand colors, as listed below; originally `theme: "default",` (modified by josh-wong).
+      themeVariables: {
+        primaryColor: "#D5EAFF",
+        primaryTextColor: "#3D4144",
+        primaryBorderColor: "#2673BB",
+        lineColor: "#3D4144",
+        secondaryColor: "#D5EAFF",
+        tertiaryColor: "#D5EAFF",
+      }
     });
     window.mermaid.init(undefined, document.querySelectorAll('.language-mermaid'));
   });

--- a/_layouts/mermaid.html
+++ b/_layouts/mermaid.html
@@ -3,7 +3,7 @@
   $(document).ready(function () {
     mermaid.initialize({
       startOnLoad:true,
-      theme: "default",
+      theme: "base",
     });
     window.mermaid.init(undefined, document.querySelectorAll('.language-mermaid'));
   });

--- a/_sass/minimal-mistakes/_syntax.scss
+++ b/_sass/minimal-mistakes/_syntax.scss
@@ -349,3 +349,10 @@ figure.highlight {
     border-bottom: 0;
   }
 }
+
+/* Make Mermaid diagrams centered (added by josh-wong). */
+.language-mermaid {
+  display: block;
+  margin: auto;
+  text-align: center;
+}


### PR DESCRIPTION
## Description

This PR applies centering and Scalar brand colors to Mermaid diagrams. Since our images are centered, we should also center Mermaid diagrams for consistency. To give the docs site a more Scalar-branded feel, our Mermaid diagrams should take on Scalar brand colors.

## Related issues and/or PRs

N/A

## Changes made

- Change the color of Mermaid diagrams by changing the default Mermaid theme and apply Scalar brand colors.
- Add styles to center Mermaid diagrams.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
