### PR TITLE
Change the Twitter icon to the X icon and reorder icons in the footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -62,17 +62,17 @@ analytics:
 footer:
   links:
     - label: "" # Leave `label` blank so that only the social icon appears
-      icon: "fab fa-fw fa-github"
-      url: "https://github.com/scalar-labs"
-    - label: "" # Leave `label` blank so that only the social icon appears
-      icon: "fab fa-fw fa-facebook-square"
+      icon: "fab fa-fw fa-facebook"
       url: "https://www.facebook.com/scalar.labs"
     - label: "" # Leave `label` blank so that only the social icon appears
-      icon: "fab fa-fw fa-twitter-square"
+      icon: "fa-brands fa-x-twitter"
       url: "https://twitter.com/scalar_labs"
     - label: "" # Leave `label` blank so that only the social icon appears
-      icon: "fab fa-fw fa-linkedin"
+      icon: "fab fa-fw fa-linkedin-in"
       url: "https://www.linkedin.com/company/scalarlabs"
+    - label: "" # Leave `label` blank so that only the social icon appears
+      icon: "fab fa-fw fa-github"
+      url: "https://github.com/scalar-labs"
 
 # Reading Files
 include:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,8 +15,8 @@
 
 <!-- For all browsers -->
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
-<link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-<noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css"></noscript>
+<link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6/css/all.min.css"></noscript>
 
 {% if site.head_scripts %}
   {% for script in site.head_scripts %}

--- a/_sass/minimal-mistakes/_utilities.scss
+++ b/_sass/minimal-mistakes/_utilities.scss
@@ -207,7 +207,8 @@ body:hover .visually-hidden button {
   .fas,
   .fab,
   .far,
-  .fal {
+  .fal,
+  .fa-brands {
     color: $text-color;
   }
 
@@ -397,8 +398,8 @@ body:hover .visually-hidden button {
     }
   }
 
-  .fa-twitter,
-  .fa-twitter-square {
+  .fa-x-twitter,
+  .fa-x-twitter-square {
     color: $light-gray; /* Modified to match color of footer text; originally `$twitter-color;` (modified by josh-wong) */
 
     /* Makes social icons lighter when hovered over (added by josh-wong) */


### PR DESCRIPTION
## Description

This PR changes the Twitter icon to the X icon and reorders social media icons in the footer. Since Twitter has rebranded to X, we should change the icon to reflect that rebranding.

## Related issues and/or PRs

N/A

## Changes made

- Upgraded the version of Font Awesome that the Jekyll theme uses from v5.x.x to v6.x.x.
  - We couldn't use the X icon without upgrading to a newer version of Font Awesome.
- Changed the Twitter icon to the X icon in the footer.
- Reordered the social media icons in the footer.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
