### PR TITLE
Add edition dropdown to improve switching between Enterprise and Community editions

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -24,6 +24,15 @@ main:
   - title: "&nbsp;&nbsp;&nbsp;Support&nbsp;&nbsp;&nbsp;"
     url: https://www.scalar-labs.com/support/
 
+# This navigation is for adding product editions that appear in the dropdown menu.
+editions:
+  - edition-top-title: "" # This title is taken from the `edition_label` in `_data/ui-text.yml`.
+    edition-children:
+    - edition-title: "Enterprise edition"
+      edition-url: "https://scalardb.scalar-labs.com/docs"
+    - edition-title: "Community edition"
+      edition-url: "https://scalardb-community.scalar-labs.com/docs"
+
 # This navigation is for adding product versions that appear in the dropdown menu. Make sure the latest version is labeled `<VERSION> (latest)`.
 versions:
   - version-top-title: "" # This title is taken from the `version_label` in `_data/ui-text.yml`.

--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -53,6 +53,7 @@ en: &DEFAULT_EN
   back_to_top                : "Back to top"
   contact_label              : "Contact Us" # For the contact button in the header navigation in `_includes/masthead.html` (added by josh-wong)
   version_label              : "Select version:" # For the version button in the side navigation in `_includes/sidebar.html` (added by josh-wong)
+  edition_label              : "Enterprise edition" # For the edition button in the masthead in `_includes/masthead.html` (added by josh-wong)
 en-US:
   <<: *DEFAULT_EN
 en-CA:

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -11,6 +11,32 @@
           {{ site.masthead_title | default: "|&nbsp;&nbsp;Docs" }}
           {% if site.subtitle %}<span class="site-subtitle">{{ site.subtitle }}</span>{% endif %}
         </a>
+        <!-- Adds dropdown for editions (added by josh-wong) -->
+        <nav id="site-nav" class="edition-greedy-nav">
+          <ul class="edition-visible-links">
+          {%- for link in site.data.navigation.editions -%}
+            {% assign class = nil %}
+            {% if page.edition-url contains link.edition-url %}
+              {% assign class = 'active' %}
+            {% endif %}
+            {% if link.edition-children %}
+            <li class="edition-dropdown {{ class }}">
+              <label for="touch-edition"><a class="edition-dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ include.title | default: site.data.ui-text[site.locale].edition_label }}&nbsp;&nbsp;<span><svg class="edition-dropdown-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"></path></svg></span></a></label>
+              <input type="checkbox" id="touch-edition">
+              <ul class="edition-dropdown-content">
+                {% for edition-children in link.edition-children %}
+                  <li>
+                    <a href="{{ site.baseurl }}{{ edition-children.edition-url }}">
+                      <span>{{ edition-children.edition-title }}</span>
+                    </a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </li>
+            {% endif %}
+          {% endfor %}
+          </ul>
+        </nav>
         <ul class="visible-links">
           {%- for link in site.data.navigation.main -%}
             <!-- Add navigation that matches our home page (added by josh-wong) -->

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,17 +3,8 @@ layout: default
 permalink: /:collection/:path/
 ---
 
-{% assign breadcrumbs_enabled = site.breadcrumbs %}
-{% if page.breadcrumbs != null %}
-  {% assign breadcrumbs_enabled = page.breadcrumbs %}
-{% endif %}
-{% if page.url != "/" and breadcrumbs_enabled %}
-  {% unless paginator %}
-    {% include breadcrumbs.html %}
-  {% endunless %}
-{% endif %}
-
 <div id="main" role="main">
+
   {% include sidebar.html %}
 
   <article class="page h-entry" itemscope itemtype="https://schema.org/CreativeWork">
@@ -21,6 +12,17 @@ permalink: /:collection/:path/
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date_to_xmlschema }}">{% endif %}
     {% if page.last_modified_at %}<meta itemprop="dateModified" content="{{ page.last_modified_at | date_to_xmlschema }}">{% endif %}
+
+    <!-- The following breadcrumb section was above the `<div id="main" role="main">` section, which caused the breadcrumbs to be hidden behind the masthead (modified by josh-wong). -->
+    {% assign breadcrumbs_enabled = site.breadcrumbs %}
+    {% if page.breadcrumbs != null %}
+      {% assign breadcrumbs_enabled = page.breadcrumbs %}
+    {% endif %}
+    {% if page.url != "/" and breadcrumbs_enabled %}
+      {% unless paginator %}
+        {% include breadcrumbs.html %}
+      {% endunless %}
+    {% endif %}
 
     <div class="page__inner-wrap">
       {% unless page.header.overlay_color or page.header.overlay_image %}

--- a/_layouts/parent-product-home.html
+++ b/_layouts/parent-product-home.html
@@ -3,16 +3,6 @@ layout: default
 permalink: /:collection/:path/
 ---
 
-{% assign breadcrumbs_enabled = site.breadcrumbs %}
-{% if page.breadcrumbs != null %}
-  {% assign breadcrumbs_enabled = page.breadcrumbs %}
-{% endif %}
-{% if page.url != "/" and breadcrumbs_enabled %}
-  {% unless paginator %}
-    {% include breadcrumbs.html %}
-  {% endunless %}
-{% endif %}
-
 <div id="main" role="main">
   {% include sidebar.html %}
 
@@ -21,6 +11,17 @@ permalink: /:collection/:path/
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date_to_xmlschema }}">{% endif %}
     {% if page.last_modified_at %}<meta itemprop="dateModified" content="{{ page.last_modified_at | date_to_xmlschema }}">{% endif %}
+
+    <!-- The following breadcrumb section was above the `<div id="main" role="main">` section, which caused the breadcrumbs to be hidden behind the masthead (modified by josh-wong). -->
+      {% assign breadcrumbs_enabled = site.breadcrumbs %}
+      {% if page.breadcrumbs != null %}
+        {% assign breadcrumbs_enabled = page.breadcrumbs %}
+      {% endif %}
+      {% if page.url != "/" and breadcrumbs_enabled %}
+        {% unless paginator %}
+          {% include breadcrumbs.html %}
+        {% endunless %}
+      {% endif %}
 
     <div class="page__inner-wrap">
       {% unless page.header.overlay_color or page.header.overlay_image %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -8,16 +8,6 @@ layout: default
   {% include page__hero_video.html %}
 {% endif %}
 
-{% assign breadcrumbs_enabled = site.breadcrumbs %}
-{% if page.breadcrumbs != null %}
-  {% assign breadcrumbs_enabled = page.breadcrumbs %}
-{% endif %}
-{% if page.url != "/" and breadcrumbs_enabled %}
-  {% unless paginator %}
-    {% include breadcrumbs.html %}
-  {% endunless %}
-{% endif %}
-
 <div id="main" role="main">
   {% include sidebar.html %}
 
@@ -27,8 +17,19 @@ layout: default
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date_to_xmlschema }}">{% endif %}
     {% if page.last_modified_at %}<meta itemprop="dateModified" content="{{ page.last_modified_at | date_to_xmlschema }}">{% endif %}
 
+    <!-- The following breadcrumb section was above the `<div id="main" role="main">` section, which caused the breadcrumbs to be hidden behind the masthead (modified by josh-wong). -->
+    {% assign breadcrumbs_enabled = site.breadcrumbs %}
+    {% if page.breadcrumbs != null %}
+      {% assign breadcrumbs_enabled = page.breadcrumbs %}
+    {% endif %}
+    {% if page.url != "/" and breadcrumbs_enabled %}
+      {% unless paginator %}
+        {% include breadcrumbs.html %}
+      {% endunless %}
+    {% endif %}
+    {% unless page.header.overlay_color or page.header.overlay_image %}
+    
     <div class="page__inner-wrap">
-      {% unless page.header.overlay_color or page.header.overlay_image %}
         <header>
           {% if page.title %}<h1 id="page-title" class="page__title p-name" itemprop="headline">
             <a href="{{ page.url | absolute_url }}" class="u-url" itemprop="url">{{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}</a>

--- a/_sass/minimal-mistakes/_masthead.scss
+++ b/_sass/minimal-mistakes/_masthead.scss
@@ -96,4 +96,168 @@
       font-weight: 700;
     }
   }
+
+  /* Add styles to support dropdown menu for editions in `masthead.html`, which are specified in `navigation.yml` (added by josh-wong) */
   
+  .edition-greedy-nav {
+    position: relative;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    min-height: $nav-height;
+    /* width: 190px; */
+    
+    /* Added to hide the edition dropdown menu on mobile and narrow screens since it makes the Scalar logo tiny (added by josh-wong). */
+    @media screen and (max-width: $small) {
+      display: none;
+    }
+
+      a {
+        display: block;
+        padding: 0.5em 0 0.3em 0;
+        color: $background-color;
+        text-decoration: none;
+        -webkit-transition: none;
+        transition: none;
+        font-size: $type-size-5-5;
+    
+        &:hover {
+          color: $background-color;
+        }
+      }
+    }
+    
+    .edition-visible-links {
+      display: -webkit-box;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: end;
+      -ms-flex-pack: end;
+      justify-content: flex-start;
+      -webkit-box-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      /* overflow: hidden; */
+      /* max-width: fit-content; */
+    
+      li {
+        -webkit-box-flex: 0;
+        -ms-flex: none;
+        flex: none;
+        font-size: $type-size-5;
+        background-color: $background-color;
+      }
+    
+      a {
+        position: relative;
+        color: $background-color;
+        cursor: pointer;
+        opacity: unset;
+    
+        &:before {
+          content: "";
+          position: absolute;
+          left: 0;
+          bottom: 0;
+          height: 0px; /* Modified to remove the gray underline when hovering over links in the header navigation in `masthead.html`; originally `4px;` (modified by josh-wong) */
+          background: $primary-color;
+          width: 100%;
+          -webkit-transition: $global-transition;
+          transition: $global-transition;
+          -webkit-transform: scaleX(0) translate3d(0, 0, 0);
+          transform: scaleX(0) translate3d(0, 0, 0); // hide
+        }
+    
+        &:hover:before {
+          -webkit-transform: scaleX(1);
+          -ms-transform: scaleX(1);
+          transform: scaleX(1); // reveal
+        }
+      }
+    
+      .edition-dropdown {
+        float: left;
+        /* width: 210px; */
+        min-width: 100%;
+        /* max-width: 75%; */
+        font-size: $type-size-5;
+        font-weight: 500;
+        vertical-align: middle;
+        cursor: default;
+        background-color: $scalar-light-gray-background-color;
+        outline-color: $scalar-primary-color;
+  
+        li {
+          line-height: 1em;
+        }
+        &:hover {
+          background-color: mix(#fff, $scalar-primary-color, 80%);
+        }
+      }
+    
+      .edition-dropdown-arrow {
+        max-width: 20px;
+        vertical-align: middle;
+        padding-top: 2px;
+        float: right;
+      }
+    
+      .edition-dropdown-content {
+        display: none;
+        position: absolute;
+        background-color: $background-color;
+        box-shadow: $box-shadow;
+        z-index: 21;
+        border: 1pt solid $border-color;
+        /* width: 210px; */
+        min-width: 100%;
+        /* max-width: 75%; */
+        padding-top: 5px;
+        padding-bottom: 5px;
+  
+        li {
+          padding: 0;
+          margin: 0;
+        }
+      }
+    
+      .edition-dropdown-content a {
+        padding: 0 15px 0 15px;
+        margin: 1px;
+        color: $dark-gray;
+        line-height: 1.6em;
+        margin-bottom: 0;
+      }
+    
+      /* Adds support for a clickable edition dropdown menu (added by josh-wong) */
+      #touch-edition {
+        position: absolute;
+        opacity: 0;
+        height: 0px;
+      }    
+  
+      #touch-edition:checked + .edition-dropdown-content {
+        min-height: 100%;
+        display: block;
+      }
+  
+      /* The following dropdown method is `hover`, which is the default behavior in Minimal Mistakes theme. Comment this out if we want the dropdown to be clicked on rather than hovered over to access (modified by josh-wong).
+      .edition-dropdown:hover .edition-dropdown-content {
+        display: block;
+      } */
+    
+      .edition-dropdown-content a:hover {
+        background-color: $scalar-light-gray-background-color;
+      }
+    
+      .edition-dropdown-content a:not(:last-child) {
+        border-bottom: none; 
+      }
+    }
+
+    .hidden {
+      display: none;
+    }

--- a/_sass/minimal-mistakes/_navigation.scss
+++ b/_sass/minimal-mistakes/_navigation.scss
@@ -8,9 +8,8 @@
 
    .breadcrumbs {
     @include clearfix;
-    margin: 0 auto;
-    max-width: 100%;
-    padding-left: 1em;
+    /* margin: 0 auto; */ /* Commented out because the spacing on the left was indented too far (modified by josh-wong) */    max-width: 100%;
+    /* padding-left: 1em; */ /* Commented out because the spacing on the left was indented too far (modified by josh-wong) */
     padding-right: 1em;
     font-family: $sans-serif;
     -webkit-animation: $intro-transition;
@@ -28,7 +27,7 @@
       font-size: $type-size-6;
   
       @include breakpoint($large) {
-        float: right;
+        float: left; /* Changed so that the breadcrumbs would be left aligned and flush with the page content; originally `float: right;`, which caused the breadcrumbs to be in the middle of the page (modified by josh-wong). */
         width: calc(100% - #{$right-sidebar-width-narrow});
       }
   


### PR DESCRIPTION
## Description

This PR adds a dropdown in the masthead for users to easily see and switch between docs for ScalarDB Enterprise and ScaalrDB Community.

> [!NOTE]
> 
> This PR also includes some changes to the breadcrumbs feature in our Jekyll theme. However, I decided not to enable breadcrumbs because the breadcrumb path was a little awkward (the first two links in the path were duplicates, which was expected based on the site's folder structure). 
> 
> If we really want to implement breadcrumbs int he future, we will need to address the duplicate links in breadcrumbs.

## Related issues and/or PRs

N/A

## Changes made

- Added a dropdown menu that contains links to docs for ScalarDB Enterprise docs and ScalarDB Community.
- Improved the placement of and styles for breadcrumbs since they were hidden and not well aligned with the content on the page.
  - Again, breadcrumbs are currently not enabled. I changed these styles as I was testing the feature and decided to include those changes in case we decide to enable breadcrumbs in the future after fixing the issue described in the `## Description` section above.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
