### PR TITLE
Remove Community edition from version dropdown

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -37,8 +37,6 @@ editions:
 versions:
   - version-top-title: "" # This title is taken from the `version_label` in `_data/ui-text.yml`.
     version-children:
-    - version-title: "Community edition"
-      version-url: "https://scalardb-community.scalar-labs.com/docs"
     - version-title: "3.10 (latest)"
       version-url: /docs/latest/getting-started-with-scalardb/
     - version-title: "3.9"


### PR DESCRIPTION
## Description

This PR removes the `Community edition` link that was mistakenly left over in the `Select version` dropdown in the side navigation.

## Related issues and/or PRs

Related to https://github.com/scalar-labs/docs-scalardb/pull/105

## Changes made

Removed the `Community edition` link from the `Select version` dropdown.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
