### PR TITLE
Add missing ScalarDB 3.11 docs to side navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -126,6 +126,8 @@ versions:
       #   url: /docs/latest/scalardb-data-loader/getting-started-export/
       # - title: "Import Function for ScalarDB Data Loader" # May be added in the near future.
       #   url: /docs/latest/scalardb-data-loader/getting-started-import/
+      - title: "ScalarDB Auth with ScalarDB SQL"
+        url : /docs/latest/scalardb-cluster/scalardb-auth-with-sql/
       - title: "How to Run ScalarDB GraphQL Server"
         url: /docs/latest/scalardb-graphql/how-to-run-server/
       - title: "How to Run Two-Phase Commit Transaction by Using ScalarDB GraphQL"
@@ -151,6 +153,8 @@ versions:
         url: /docs/latest/helm-charts/use-secret-for-credentials/
       - title: "How to Install ScalarDB Analytics with PostgreSQL in Your Local Environment by Using Docker"
         url: /docs/latest/scalardb-analytics-postgresql/installation/
+      - title: "ScalarDB Cluster Standalone Mode"
+        url: /docs/latest/scalardb-cluster/standalone-mode/
       - title: "ScalarDB GraphQL Deployment Guide on AWS"
         url: /docs/latest/scalardb-graphql/aws-deployment-guide/
       - title: "ScalarDB SQL Server"


### PR DESCRIPTION
## Description

This PR adds missing ScalarDB 3.11 docs to the side navigation.

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-scalardb/pull/110

## Changes made

- Add missing docs to side navigation.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
