### PR TITLE
Add out-of-support banner to ScalarDB 3.5 docs

### DIFF
--- a/docs/3.5/add-scalardb-to-your-build.md
+++ b/docs/3.5/add-scalardb-to-your-build.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Add ScalarDB to Your Build
 
 The ScalarDB library is available on the [Maven Central Repository](https://mvnrepository.com/artifact/com.scalar-labs/scalardb). You can add the library as a build dependency to your application by using Gradle or Maven.

--- a/docs/3.5/backup-restore.md
+++ b/docs/3.5/backup-restore.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # How to Back Up and Restore Databases Used Through ScalarDB
 
 Since ScalarDB provides transaction capabilities on top of non-transactional or transactional databases non-invasively, you need to take special care to back up and restore the databases in a transactionally consistent way.

--- a/docs/3.5/configurations.md
+++ b/docs/3.5/configurations.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDB Configurations
 
 This page describes the available configurations for ScalarDB.

--- a/docs/3.5/design.md
+++ b/docs/3.5/design.md
@@ -1,4 +1,6 @@
-## Scalar DB design document
+{% include scalardb/end-of-support.html %}
+
+# Scalar DB design document
 
 ## Introduction
 

--- a/docs/3.5/development-configurations.md
+++ b/docs/3.5/development-configurations.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Configuration Guides for ScalarDB
 
 The following is a list of configuration guides for ScalarDB:

--- a/docs/3.5/getting-started-with-scalardb-by-using-kotlin.md
+++ b/docs/3.5/getting-started-with-scalardb-by-using-kotlin.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Getting Started with ScalarDB by Using Kotlin
 
 This getting started tutorial explains how to configure your preferred database in ScalarDB and set up a basic electronic money application by using Kotlin. Since Kotlin has Java interoperability, you can use ScalarDB directly from Kotlin.

--- a/docs/3.5/getting-started-with-scalardb.md
+++ b/docs/3.5/getting-started-with-scalardb.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Getting Started with ScalarDB
 
 This getting started tutorial explains how to configure your preferred database in ScalarDB and set up a basic electronic money application.

--- a/docs/3.5/helm-charts/README.md
+++ b/docs/3.5/helm-charts/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Index
 
 ## For users

--- a/docs/3.5/helm-charts/ReleaseFlow.md
+++ b/docs/3.5/helm-charts/ReleaseFlow.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Release Flow
 
 ## Requirements

--- a/docs/3.5/helm-charts/configure-custom-values-envoy.md
+++ b/docs/3.5/helm-charts/configure-custom-values-envoy.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Configure a custom values file for Scalar Envoy
 
 This document explains how to create your custom values file for the Scalar Envoy chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/envoy/README.md) of the Scalar Envoy chart.

--- a/docs/3.5/helm-charts/configure-custom-values-file.md
+++ b/docs/3.5/helm-charts/configure-custom-values-file.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Configure a custom values file for Scalar Helm Charts
 
 When you deploy Scalar products using Scalar Helm Charts, you must prepare your custom values file based on your environment. Please refer to the following documents for more details on how to a create custom values file for each product.

--- a/docs/3.5/helm-charts/configure-custom-values-scalar-manager.md
+++ b/docs/3.5/helm-charts/configure-custom-values-scalar-manager.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Configure a custom values file for Scalar Manager
 
 This document explains how to create your custom values file for the Scalar Manager chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalar-manager/README.md) of the Scalar Manager chart.

--- a/docs/3.5/helm-charts/configure-custom-values-scalardb-cluster.md
+++ b/docs/3.5/helm-charts/configure-custom-values-scalardb-cluster.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Configure a custom values file for ScalarDB Cluster
 
 This document explains how to create your custom values file for the ScalarDB Cluster chart. For details on the parameters, see the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalardb-cluster/README.md) of the ScalarDB Cluster chart.

--- a/docs/3.5/helm-charts/configure-custom-values-scalardb-graphql.md
+++ b/docs/3.5/helm-charts/configure-custom-values-scalardb-graphql.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # [Deprecated] Configure a custom values file for ScalarDB GraphQL
 
 {% capture notice--info %}

--- a/docs/3.5/helm-charts/configure-custom-values-scalardb.md
+++ b/docs/3.5/helm-charts/configure-custom-values-scalardb.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # [Deprecated] Configure a custom values file for ScalarDB Server
 
 {% capture notice--info %}

--- a/docs/3.5/helm-charts/configure-custom-values-scalardl-auditor.md
+++ b/docs/3.5/helm-charts/configure-custom-values-scalardl-auditor.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Configure a custom values file for ScalarDL Auditor
 
 This document explains how to create your custom values file for the ScalarDL Auditor chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalardl-audit/README.md) of the ScalarDL Auditor chart.

--- a/docs/3.5/helm-charts/configure-custom-values-scalardl-ledger.md
+++ b/docs/3.5/helm-charts/configure-custom-values-scalardl-ledger.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Configure a custom values file for ScalarDL Ledger
 
 This document explains how to create your custom values file for the ScalarDL Ledger chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalardl/README.md) of the ScalarDL Ledger chart.

--- a/docs/3.5/helm-charts/configure-custom-values-scalardl-schema-loader.md
+++ b/docs/3.5/helm-charts/configure-custom-values-scalardl-schema-loader.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Configure a custom values file for ScalarDL Schema Loader
 
 This document explains how to create your custom values file for the ScalarDL Schema Loader chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/schema-loading/README.md) of the ScalarDL Schema Loader chart.

--- a/docs/3.5/helm-charts/getting-started-logging.md
+++ b/docs/3.5/helm-charts/getting-started-logging.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Getting Started with Helm Charts (Logging using Loki Stack)
 
 This document explains how to get started with log aggregation for Scalar products on Kubernetes using Grafana Loki (with Promtail).

--- a/docs/3.5/helm-charts/getting-started-monitoring.md
+++ b/docs/3.5/helm-charts/getting-started-monitoring.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Getting Started with Helm Charts (Monitoring using Prometheus Operator)
 
 This document explains how to get started with Scalar products monitoring on Kubernetes using Prometheus Operator (kube-prometheus-stack). Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.

--- a/docs/3.5/helm-charts/getting-started-scalar-helm-charts.md
+++ b/docs/3.5/helm-charts/getting-started-scalar-helm-charts.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Getting Started with Scalar Helm Charts
 
 This document explains how to get started with Scalar Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.

--- a/docs/3.5/helm-charts/getting-started-scalar-manager.md
+++ b/docs/3.5/helm-charts/getting-started-scalar-manager.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Getting Started with Helm Charts (Scalar Manager)
 Scalar Manager is a web-based dashboard that allows users to:
 * check the health of the Scalar products

--- a/docs/3.5/helm-charts/getting-started-scalardb.md
+++ b/docs/3.5/helm-charts/getting-started-scalardb.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # [Deprecated] Getting Started with Helm Charts (ScalarDB Server)
 
 {% capture notice--info %}

--- a/docs/3.5/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/3.5/helm-charts/getting-started-scalardl-auditor.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Getting Started with Helm Charts (ScalarDL Ledger and Auditor / Auditor mode)
 
 This document explains how to get started with ScalarDL Ledger and Auditor using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.

--- a/docs/3.5/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/3.5/helm-charts/getting-started-scalardl-ledger.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)
 
 This document explains how to get started with ScalarDL Ledger using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.

--- a/docs/3.5/helm-charts/how-to-deploy-scalar-manager.md
+++ b/docs/3.5/helm-charts/how-to-deploy-scalar-manager.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # How to deploy Scalar Manager
 
 This document explains how to deploy Scalar Manager using Scalar Helm Charts. You must prepare your custom values file. Please refer to the following document for more details on the custom values file for Scalar Manager.

--- a/docs/3.5/helm-charts/how-to-deploy-scalar-products.md
+++ b/docs/3.5/helm-charts/how-to-deploy-scalar-products.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Deploy Scalar products using Scalar Helm Charts
 
 This document explains how to deploy Scalar products using Scalar Helm Charts. If you want to test Scalar products on your local environment using a minikube cluster, please refer to the following getting started guide.

--- a/docs/3.5/helm-charts/how-to-deploy-scalardb-cluster.md
+++ b/docs/3.5/helm-charts/how-to-deploy-scalardb-cluster.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # How to deploy ScalarDB Cluster
 
 This document explains how to deploy ScalarDB Cluster by using Scalar Helm Charts. For details on the custom values file for ScalarDB Cluster, see [Configure a custom values file for ScalarDB Cluster](./configure-custom-values-scalardb-cluster.md).

--- a/docs/3.5/helm-charts/how-to-deploy-scalardb-graphql.md
+++ b/docs/3.5/helm-charts/how-to-deploy-scalardb-graphql.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # [Deprecated] How to deploy ScalarDB GraphQL
 
 {% capture notice--info %}

--- a/docs/3.5/helm-charts/how-to-deploy-scalardb.md
+++ b/docs/3.5/helm-charts/how-to-deploy-scalardb.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # [Deprecated] How to deploy ScalarDB Server
 
 {% capture notice--info %}

--- a/docs/3.5/helm-charts/how-to-deploy-scalardl-auditor.md
+++ b/docs/3.5/helm-charts/how-to-deploy-scalardl-auditor.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # How to deploy ScalarDL Auditor
 
 This document explains how to deploy ScalarDL Auditor using Scalar Helm Charts. You must prepare your custom values file. Please refer to the following document for more details on the custom values file for ScalarDL Auditor and ScalarDL Schema Loader.

--- a/docs/3.5/helm-charts/how-to-deploy-scalardl-ledger.md
+++ b/docs/3.5/helm-charts/how-to-deploy-scalardl-ledger.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # How to deploy ScalarDL Ledger
 
 This document explains how to deploy ScalarDL Ledger using Scalar Helm Charts. You must prepare your custom values file. Please refer to the following document for more details on the custom values file for ScalarDL Ledger and ScalarDL Schema Loader.

--- a/docs/3.5/helm-charts/mount-files-or-volumes-on-scalar-pods.md
+++ b/docs/3.5/helm-charts/mount-files-or-volumes-on-scalar-pods.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Mount any files or volumes on Scalar product pods
 
 You can mount any files or volumes on Scalar product pods when you use ScalarDB Server, ScalarDB Cluster, or ScalarDL Helm Charts (ScalarDL Ledger and ScalarDL Auditor).

--- a/docs/3.5/helm-charts/samples/scalardb/scalardb-multi-storage-sample/README.md
+++ b/docs/3.5/helm-charts/samples/scalardb/scalardb-multi-storage-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDB Deployment Sample on Kubernetes (Multi-Storage Transactions)
 
 ## Version

--- a/docs/3.5/helm-charts/samples/scalardl/scalardl-auditor-mode-sample/README.md
+++ b/docs/3.5/helm-charts/samples/scalardl/scalardl-auditor-mode-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDL Deployment Sample on Kubernetes (Auditor mode)
 
 ## Version

--- a/docs/3.5/helm-charts/use-secret-for-credentials.md
+++ b/docs/3.5/helm-charts/use-secret-for-credentials.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # How to use Secret resources to pass credentials as environment variables into the properties file
 
 You can pass credentials like **username** or **password** as environment variables via a `Secret` resource in Kubernetes. The docker images for previous versions of Scalar products use the `dockerize` command for templating properties files. The docker images for the latest versions of Scalar products get values directly from environment variables.

--- a/docs/3.5/how-to-handle-exceptions.md
+++ b/docs/3.5/how-to-handle-exceptions.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # A Guide on How to Handle Exceptions
 
 Handling exceptions correctly in Scalar DB is very important.

--- a/docs/3.5/index.md
+++ b/docs/3.5/index.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDB
 
 [![CI](https://github.com/scalar-labs/scalardb/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/scalar-labs/scalardb/actions/workflows/ci.yaml)

--- a/docs/3.5/multi-storage-transactions.md
+++ b/docs/3.5/multi-storage-transactions.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Multi-Storage Transactions
 
 ScalarDB transactions can span multiple storages or databases while maintaining ACID compliance by using a feature called *multi-storage transactions*.

--- a/docs/3.5/redirect-getting-started.md
+++ b/docs/3.5/redirect-getting-started.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 ---
 redirect_from: 
   - /docs/3.5/getting-started/

--- a/docs/3.5/requirements.md
+++ b/docs/3.5/requirements.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Requirements and Recommendations for the Underlying Databases of ScalarDB
 
 This document explains the requirements and recommendations in the underlying databases of ScalarDB to make ScalarDB applications work correctly.

--- a/docs/3.5/scalar-kubernetes/AccessScalarProducts.md
+++ b/docs/3.5/scalar-kubernetes/AccessScalarProducts.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Make ScalarDB or ScalarDL deployed in a Kubernetes cluster environment available from applications
 
 This document explains how to make ScalarDB or ScalarDL deployed in a Kubernetes cluster environment available from applications. To make ScalarDB or ScalarDL available from applications, you can use Scalar Envoy via a Kubernetes service resource named `<HELM_RELEASE_NAME>-envoy`. You can use `<HELM_RELEASE_NAME>-envoy` in several ways, such as:

--- a/docs/3.5/scalar-kubernetes/AwsMarketplaceGuide.md
+++ b/docs/3.5/scalar-kubernetes/AwsMarketplaceGuide.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # How to install Scalar products through AWS Marketplace
 
 Scalar products (ScalarDB, ScalarDL, and their tools) are available in the AWS Marketplace as container images. This guide explains how to install Scalar products through the AWS Marketplace.

--- a/docs/3.5/scalar-kubernetes/AzureMarketplaceGuide.md
+++ b/docs/3.5/scalar-kubernetes/AzureMarketplaceGuide.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # How to install Scalar products through Azure Marketplace
 
 Scalar products (ScalarDB, ScalarDL, and their tools) are provided in Azure Marketplace as container offers. This guide explains how to install Scalar products through Azure Marketplace.

--- a/docs/3.5/scalar-kubernetes/BackupNoSQL.md
+++ b/docs/3.5/scalar-kubernetes/BackupNoSQL.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Back up a NoSQL database in a Kubernetes environment
 
 This guide explains how to create a transactionally consistent backup of managed databases that ScalarDB or ScalarDL uses in a Kubernetes environment. Please note that, when using a NoSQL database or multiple databases, you **must** pause ScalarDB or ScalarDL to create a transactionally consistent backup.

--- a/docs/3.5/scalar-kubernetes/BackupRDB.md
+++ b/docs/3.5/scalar-kubernetes/BackupRDB.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Back up an RDB in a Kubernetes environment
 
 This guide explains how to create a backup of a single relational database (RDB) that ScalarDB or ScalarDL uses in a Kubernetes environment. Please note that this guide assumes that you are using a managed database from a cloud services provider.

--- a/docs/3.5/scalar-kubernetes/BackupRestoreGuide.md
+++ b/docs/3.5/scalar-kubernetes/BackupRestoreGuide.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Back up and restore ScalarDB or ScalarDL data in a Kubernetes environment
 
 This guide explains how to backup and restore ScalarDB or ScalarDL data in a Kubernetes environment. Please note that this guide assumes that you are using a managed database from a cloud services provider as the backend database for ScalarDB or ScalarDL. The following is a list of the managed databases that this guide assumes you might be using:

--- a/docs/3.5/scalar-kubernetes/CreateAKSClusterForScalarDB.md
+++ b/docs/3.5/scalar-kubernetes/CreateAKSClusterForScalarDB.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Guidelines for creating an AKS cluster for ScalarDB Server
 
 This document explains the requirements and recommendations for creating an Azure Kubernetes Service (AKS) cluster for ScalarDB Server deployment. For details on how to deploy ScalarDB Server on an AKS cluster, see [Deploy ScalarDB Server on AKS](./ManualDeploymentGuideScalarDBServerOnAKS.md).

--- a/docs/3.5/scalar-kubernetes/CreateAKSClusterForScalarDL.md
+++ b/docs/3.5/scalar-kubernetes/CreateAKSClusterForScalarDL.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Guidelines for creating an AKS cluster for ScalarDL Ledger
 
 This document explains the requirements and recommendations for creating an Azure Kubernetes Service (AKS) cluster for ScalarDL Ledger deployment. For details on how to deploy ScalarDL Ledger on an AKS cluster, see [Deploy ScalarDL Ledger on AKS](./ManualDeploymentGuideScalarDLOnAKS.md).

--- a/docs/3.5/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
+++ b/docs/3.5/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Guidelines for creating an AKS cluster for ScalarDL Ledger and ScalarDL Auditor
 
 This document explains the requirements and recommendations for creating an Azure Kubernetes Service (AKS) cluster for ScalarDL Ledger and ScalarDL Auditor deployment. For details on how to deploy ScalarDL Ledger and ScalarDL Auditor on an AKS cluster, see [Deploy ScalarDL Ledger and ScalarDL Auditor on AKS](./ManualDeploymentGuideScalarDLAuditorOnAKS.md).

--- a/docs/3.5/scalar-kubernetes/CreateAKSClusterForScalarProducts.md
+++ b/docs/3.5/scalar-kubernetes/CreateAKSClusterForScalarProducts.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Guidelines for creating an AKS cluster for Scalar products
 
 To create an Azure Kubernetes Service (AKS) cluster for Scalar products, refer to the following:

--- a/docs/3.5/scalar-kubernetes/CreateBastionServer.md
+++ b/docs/3.5/scalar-kubernetes/CreateBastionServer.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Create a bastion server
 
 This document explains how to create a bastion server and install some tools for the deployment of Scalar products.

--- a/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarDB.md
+++ b/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarDB.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # (Deprecated) Guidelines for creating an EKS cluster for ScalarDB Server
 
 {% capture notice--warning %}

--- a/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarDBCluster.md
+++ b/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarDBCluster.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Guidelines for creating an EKS cluster for ScalarDB Cluster
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDB Cluster deployment. For details on how to deploy ScalarDB Cluster on an EKS cluster, see [Deploy ScalarDB Cluster on Amazon EKS](./ManualDeploymentGuideScalarDBClusterOnEKS.md).

--- a/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarDL.md
+++ b/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarDL.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Guidelines for creating an EKS cluster for ScalarDL Ledger
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDL Ledger deployment. For details on how to deploy ScalarDL Ledger on an EKS cluster, see [Deploy ScalarDL Ledger on Amazon EKS](./ManualDeploymentGuideScalarDLOnEKS.md).

--- a/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
+++ b/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Guidelines for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDL Ledger and ScalarDL Auditor deployment. For details on how to deploy ScalarDL Ledger and ScalarDL Auditor on an EKS cluster, see [Deploy ScalarDL Ledger and ScalarDL Auditor on Amazon EKS](./ManualDeploymentGuideScalarDLAuditorOnEKS.md).

--- a/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
+++ b/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Guidelines for creating an Amazon EKS cluster for Scalar products
 
 To create an Amazon Elastic Kubernetes Service (EKS) cluster for Scalar products, refer to the following:

--- a/docs/3.5/scalar-kubernetes/K8sLogCollectionGuide.md
+++ b/docs/3.5/scalar-kubernetes/K8sLogCollectionGuide.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Collecting logs from Scalar products on a Kubernetes cluster
 
 This document explains how to deploy Grafana Loki and Promtail on Kubernetes with Helm. After following this document, you can collect logs of Scalar products on your Kubernetes environment.

--- a/docs/3.5/scalar-kubernetes/K8sMonitorGuide.md
+++ b/docs/3.5/scalar-kubernetes/K8sMonitorGuide.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Monitoring Scalar products on a Kubernetes cluster
 
 This document explains how to deploy Prometheus Operator on Kubernetes with Helm. After following this document, you can use Prometheus, Alertmanager, and Grafana for monitoring Scalar products on your Kubernetes environment.

--- a/docs/3.5/scalar-kubernetes/ManualDeploymentGuideScalarDBClusterOnEKS.md
+++ b/docs/3.5/scalar-kubernetes/ManualDeploymentGuideScalarDBClusterOnEKS.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Deploy ScalarDB Cluster on Amazon Elastic Kubernetes Service (EKS)
 
 This guide explains how to deploy ScalarDB Cluster on Amazon Elastic Kubernetes Service (EKS).

--- a/docs/3.5/scalar-kubernetes/ManualDeploymentGuideScalarDBServerOnAKS.md
+++ b/docs/3.5/scalar-kubernetes/ManualDeploymentGuideScalarDBServerOnAKS.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Deploy ScalarDB Server on Azure Kubernetes Service (AKS)
 
 This guide explains how to deploy ScalarDB Server on Azure Kubernetes Service (AKS).

--- a/docs/3.5/scalar-kubernetes/ManualDeploymentGuideScalarDBServerOnEKS.md
+++ b/docs/3.5/scalar-kubernetes/ManualDeploymentGuideScalarDBServerOnEKS.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Deploy ScalarDB Server on Amazon Elastic Kubernetes Service (EKS)
 
 This guide explains how to deploy ScalarDB Server on Amazon Elastic Kubernetes Service (EKS).

--- a/docs/3.5/scalar-kubernetes/ManualDeploymentGuideScalarDLAuditorOnAKS.md
+++ b/docs/3.5/scalar-kubernetes/ManualDeploymentGuideScalarDLAuditorOnAKS.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Deploy ScalarDL Ledger and ScalarDL Auditor on Azure Kubernetes Service (AKS)
 
 This guide explains how to deploy ScalarDL Ledger and ScalarDL Auditor on Azure Kubernetes Service (AKS).

--- a/docs/3.5/scalar-kubernetes/ManualDeploymentGuideScalarDLAuditorOnEKS.md
+++ b/docs/3.5/scalar-kubernetes/ManualDeploymentGuideScalarDLAuditorOnEKS.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Deploy ScalarDL Ledger and ScalarDL Auditor on Amazon Elastic Kubernetes Service (EKS)
 
 This guide explains how to deploy ScalarDL Ledger and ScalarDL Auditor on Amazon Elastic Kubernetes Service (EKS).

--- a/docs/3.5/scalar-kubernetes/ManualDeploymentGuideScalarDLOnAKS.md
+++ b/docs/3.5/scalar-kubernetes/ManualDeploymentGuideScalarDLOnAKS.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Deploy ScalarDL Ledger on Azure Kubernetes Service (AKS)
 
 This document explains how to deploy **ScalarDL Ledger** on Azure Kubernetes Service (AKS).

--- a/docs/3.5/scalar-kubernetes/ManualDeploymentGuideScalarDLOnEKS.md
+++ b/docs/3.5/scalar-kubernetes/ManualDeploymentGuideScalarDLOnEKS.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Deploy ScalarDL Ledger on Amazon Elastic Kubernetes Service (EKS)
 
 This document explains how to deploy **ScalarDL Ledger** on Amazon Elastic Kubernetes Service (EKS).

--- a/docs/3.5/scalar-kubernetes/NetworkPeeringForScalarDLAuditor.md
+++ b/docs/3.5/scalar-kubernetes/NetworkPeeringForScalarDLAuditor.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Configure Network Peering for ScalarDL Auditor Mode
 
 This document explains how to connect multiple private networks for ScalarDL Auditor mode to perform network peering. For ScalarDL Auditor mode to work properly, you must connect ScalarDL Ledger to ScalarDL Auditor.

--- a/docs/3.5/scalar-kubernetes/ProductionChecklistForScalarDBCluster.md
+++ b/docs/3.5/scalar-kubernetes/ProductionChecklistForScalarDBCluster.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Production checklist for ScalarDB Cluster
 
 This checklist provides recommendations when deploying ScalarDB Cluster in a production environment.

--- a/docs/3.5/scalar-kubernetes/ProductionChecklistForScalarProducts.md
+++ b/docs/3.5/scalar-kubernetes/ProductionChecklistForScalarProducts.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Production checklist for Scalar products
 
 To make your deployment ready for production, refer to the following:

--- a/docs/3.5/scalar-kubernetes/RegularCheck.md
+++ b/docs/3.5/scalar-kubernetes/RegularCheck.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Components to Regularly Check When Running in a Kubernetes Environment
 
 Most of the components deployed by manual deployment guides are self-healing with the help of the managed Kubernetes services and Kubernetes self-healing capability. There are also configured alerts that occur when some unexpected behavior happens. Thus, there shouldn't be so many things to do day by day for the deployment of Scalar products on the managed Kubernetes cluster. However, it is recommended to check the status of a system on a regular basis to see if everything is working fine. Here is the list of things you might want to do on a regular basis.

--- a/docs/3.5/scalar-kubernetes/RestoreDatabase.md
+++ b/docs/3.5/scalar-kubernetes/RestoreDatabase.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Restore databases in a Kubernetes environment
 
 This guide explains how to restore databases that ScalarDB or ScalarDL uses in a Kubernetes environment. Please note that this guide assumes that you are using a managed database from a cloud services provider as the backend database for ScalarDB or ScalarDL.

--- a/docs/3.5/scalar-kubernetes/SetupDatabase.md
+++ b/docs/3.5/scalar-kubernetes/SetupDatabase.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Set up a database for ScalarDB/ScalarDL deployment
 
 This guide explains how to set up a database for ScalarDB/ScalarDL deployment on cloud services.

--- a/docs/3.5/scalar-kubernetes/SetupDatabaseForAWS.md
+++ b/docs/3.5/scalar-kubernetes/SetupDatabaseForAWS.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Set up a database for ScalarDB/ScalarDL deployment on AWS
 
 This guide explains how to set up a database for ScalarDB/ScalarDL deployment on AWS.

--- a/docs/3.5/scalar-kubernetes/SetupDatabaseForAzure.md
+++ b/docs/3.5/scalar-kubernetes/SetupDatabaseForAzure.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Set up a database for ScalarDB/ScalarDL deployment on Azure
 
 This guide explains how to set up a database for ScalarDB/ScalarDL deployment on Azure.

--- a/docs/3.5/scalar-kubernetes/deploy-kubernetes.md
+++ b/docs/3.5/scalar-kubernetes/deploy-kubernetes.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Deploying ScalarDB on Managed Kubernetes Services
 
 The following documentation is to help you set up and deploy a ScalarDB environment on managed Kubernetes services.

--- a/docs/3.5/scalar-kubernetes/manage-kubernetes.md
+++ b/docs/3.5/scalar-kubernetes/manage-kubernetes.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Managing ScalarDB on Managed Kubernetes Services
 
 The following documentation is to help you manage a ScalarDB environment on managed Kubernetes services.

--- a/docs/3.5/scalardb-benchmarks/README.md
+++ b/docs/3.5/scalardb-benchmarks/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDB Benchmarking Tools
 
 This tutorial describes how to run benchmarking tools for ScalarDB. Database benchmarking is helpful for evaluating how databases perform against a set of standards.

--- a/docs/3.5/scalardb-data-loader/getting-started-export.md
+++ b/docs/3.5/scalardb-data-loader/getting-started-export.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Getting started with Export
 
 This document explains how you can get started with the Scalar DB Data Loader Export function.

--- a/docs/3.5/scalardb-data-loader/getting-started-import.md
+++ b/docs/3.5/scalardb-data-loader/getting-started-import.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Getting started with Import
 
 This document explains how you can get started with the Scalar DB Data Loader Import function.

--- a/docs/3.5/scalardb-graphql/aws-deployment-guide.md
+++ b/docs/3.5/scalardb-graphql/aws-deployment-guide.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Deployment Guide on AWS
 
 This document explains how to deploy ScalarDB GraphQL servers on the Amazon EKS environment.

--- a/docs/3.5/scalardb-graphql/getting-started-with-scalardb-graphql.md
+++ b/docs/3.5/scalardb-graphql/getting-started-with-scalardb-graphql.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Getting Started with ScalarDB GraphQL
 
 ScalarDB GraphQL is an interface layer that allows client applications to communicate with a [ScalarDB](https://github.com/scalar-labs/scalardb) database with GraphQL.

--- a/docs/3.5/scalardb-graphql/how-to-run-server.md
+++ b/docs/3.5/scalardb-graphql/how-to-run-server.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # How to Run ScalarDB GraphQL Server
 
 ScalarDB GraphQL Server is an interface layer that allows client applications to communicate with [ScalarDB](https://github.com/scalar-labs/scalardb) with GraphQL.

--- a/docs/3.5/scalardb-graphql/how-to-run-two-phase-commit-transaction.md
+++ b/docs/3.5/scalardb-graphql/how-to-run-two-phase-commit-transaction.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # How to run two-phase commit transaction
 
 ScalarDB GraphQL supports two-phase commit style transactions

--- a/docs/3.5/scalardb-graphql/index.md
+++ b/docs/3.5/scalardb-graphql/index.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDB GraphQL Server
 
 ScalarDB GraphQL Server is an interface layer that allows client applications to communicate with [ScalarDB](https://github.com/scalar-labs/scalardb) with GraphQL.

--- a/docs/3.5/scalardb-samples/README.md
+++ b/docs/3.5/scalardb-samples/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDB Samples
 
 This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):

--- a/docs/3.5/scalardb-samples/microservice-transaction-sample/README.md
+++ b/docs/3.5/scalardb-samples/microservice-transaction-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Create a Sample Application That Supports Microservice Transactions
 
 This tutorial describes how to create a sample application that supports microservice transactions in ScalarDB.

--- a/docs/3.5/scalardb-samples/multi-storage-transaction-sample/README.md
+++ b/docs/3.5/scalardb-samples/multi-storage-transaction-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Create a Sample Application That Supports Multi-Storage Transactions
 
 This tutorial describes how to create a sample application that supports the multi-storage transactions feature in ScalarDB.

--- a/docs/3.5/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
+++ b/docs/3.5/scalardb-samples/scalardb-analytics-postgresql-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Run Analytical Queries on Sample Data by Using ScalarDB Analytics with PostgreSQL
 
 This tutorial describes how to run analytical queries on sample data by using ScalarDB Analytics with PostgreSQL.

--- a/docs/3.5/scalardb-samples/scalardb-graphql-sample/README.md
+++ b/docs/3.5/scalardb-samples/scalardb-graphql-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Create a Sample Application That Uses ScalarDB GraphQL
 
 {% capture notice--info %}

--- a/docs/3.5/scalardb-samples/scalardb-sample/README.md
+++ b/docs/3.5/scalardb-samples/scalardb-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Create a Sample Application That Uses ScalarDB
 
 This tutorial describes how to create a sample e-commerce application by using ScalarDB.

--- a/docs/3.5/scalardb-samples/scalardb-server-sample/README.md
+++ b/docs/3.5/scalardb-samples/scalardb-server-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
 For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).

--- a/docs/3.5/scalardb-samples/scalardb-sql-jdbc-sample/README.md
+++ b/docs/3.5/scalardb-samples/scalardb-sql-jdbc-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Create a Sample Application That Uses ScalarDB SQL (JDBC)
 
 {% capture notice--info %}

--- a/docs/3.5/scalardb-samples/spring-data-microservice-transaction-sample/README.md
+++ b/docs/3.5/scalardb-samples/spring-data-microservice-transaction-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Sample application of Spring Data JDBC for ScalarDB with Microservice Transactions
 
 This tutorial describes how to create a sample Spring Boot application for microservice transactions by using Spring Data JDBC for ScalarDB.

--- a/docs/3.5/scalardb-samples/spring-data-multi-storage-transaction-sample/README.md
+++ b/docs/3.5/scalardb-samples/spring-data-multi-storage-transaction-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Sample application of Spring Data JDBC for ScalarDB with Multi-storage Transactions
 
 This tutorial describes how to create a sample Spring Boot application by using Spring Data JDBC for ScalarDB with Multi-storage Transactions.

--- a/docs/3.5/scalardb-samples/spring-data-sample/README.md
+++ b/docs/3.5/scalardb-samples/spring-data-sample/README.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Sample application of Spring Data JDBC for ScalarDB
 
 This tutorial describes how to create a sample Spring Boot application by using Spring Data JDBC for ScalarDB.

--- a/docs/3.5/scalardb-server.md
+++ b/docs/3.5/scalardb-server.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Scalar DB server
 
 Scalar DB server is a gRPC server that implements Scalar DB interface. 

--- a/docs/3.5/scalardb-supported-databases.md
+++ b/docs/3.5/scalardb-supported-databases.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Supported Databases
 
 ScalarDB supports the following databases and their versions.

--- a/docs/3.5/schema-loader.md
+++ b/docs/3.5/schema-loader.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # ScalarDB Schema Loader
 
 ScalarDB has its own data model and schema that maps to the implementation-specific data model and schema. In addition, ScalarDB stores internal metadata, such as transaction IDs, record versions, and transaction statuses, to manage transaction logs and statuses when you use the Consensus Commit transaction manager.

--- a/docs/3.5/schema.md
+++ b/docs/3.5/schema.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Database schema in Scalar DB
 
 Scalar DB has its own data model and schema, that maps to the implementation specific data model and schema.

--- a/docs/3.5/two-phase-commit-transactions.md
+++ b/docs/3.5/two-phase-commit-transactions.md
@@ -1,3 +1,5 @@
+{% include scalardb/end-of-support.html %}
+
 # Transactions with a Two-Phase Commit Interface
 
 ScalarDB supports executing transactions with a two-phase commit interface. With the two-phase commit interface, you can execute a transaction that spans multiple processes or applications, like in a microservice architecture.


### PR DESCRIPTION
## Description

This PR adds an out-of-support banner to ScalarDB 3.5 docs to show that version is no longer supported.

## Related issues and/or PRs

N/A

## Changes made

- Added the out-of-support banner to the top of ScalarDB 3.5 docs.
 
## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
