### PR TITLE
Remove horizontal line from version dropdown to fix spacing issue

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -50,7 +50,7 @@ versions:
     - version-title: "3.6"
       version-url: /docs/3.6/getting-started-with-scalardb/
     # The following link contains a list of versions of ScalarDB that are no longer supported.
-    - version-title: "<hr>Unsupported Versions"
+    - version-title: "Unsupported Versions"
       version-url: /docs/unsupported-versions/
 
 # ----- Adding navigation for versions ----- #


### PR DESCRIPTION
## Description

This PR removes the horizontal line in the version dropdown because the spacing at the bottom of the `Unsupported Versions` link is too narrow compared to the spacing above the text (padding imbalance). The horizontal line was initially added in another PR, but after merging that PR, the difference in spacing was more apparent.

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-scalardb/pull/117

## Changes made

- Removed the horizontal line in the version dropdown menu.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
