### PR TITLE
Add workflows to automatically create PRs for includes from private docs repository

### DIFF
--- a/.github/workflows/auto-create-pr-common-includes.yml
+++ b/.github/workflows/auto-create-pr-common-includes.yml
@@ -4,7 +4,7 @@ name: ✨ Auto-create pull request - Common includes
 on:
   push:
     branches:
-      - _includes/common/**
+      - sync-common-includes
       
 jobs:
   create-pull-request:

--- a/.github/workflows/auto-create-pr-common-includes.yml
+++ b/.github/workflows/auto-create-pr-common-includes.yml
@@ -1,0 +1,38 @@
+# This workflow auto-creates PRs for common includes that come from the centralized private docs repository where we update our docs.
+name: ✨ Auto-create pull request - Common includes
+
+on:
+  push:
+    branches:
+      - _includes/common/**
+      
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const result = await github.rest.pulls.create({
+              title: 'AUTO: Docs repo sync - Common includes',
+              owner,
+              repo,
+              head: '${{ github.ref_name }}',
+              base: 'main',
+              body: [
+                'This is an automated pull request (PR) to sync changes to common includes in the centralized private docs repo to this public docs site repo.',
+                '',
+                'Before merging this PR, confirm the following:',
+                '',
+                '- [ ] I have confirmed that this PR can be merged without waiting (if necessary).',
+                '  - An example of when a PR must wait to be merged is when the docs are part of a pending release of a new product version.'
+              ].join('\n')
+            });
+            github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: result.data.number,
+              labels: ['documentation', 'triage']
+            });

--- a/.github/workflows/auto-create-pr-helm-charts.yml
+++ b/.github/workflows/auto-create-pr-helm-charts.yml
@@ -1,0 +1,39 @@
+# This workflow auto-creates PRs for Helm Charts docs that come from the centralized private docs repository where we update our docs.
+name: ✨ Auto-create pull request - Helm Charts docs
+
+on:
+  push:
+    branches:
+      - helm-charts/**
+      
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const result = await github.rest.pulls.create({
+              title: 'AUTO: Docs repo sync - Helm Charts',
+              owner,
+              repo,
+              head: '${{ github.ref_name }}',
+              base: 'main',
+              body: [
+                'This is an automated pull request (PR) to sync changes to Helm Charts docs in the centralized private docs repo to this public docs site repo.',
+                '',
+                'Before merging this PR, confirm the following:',
+                '',
+                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary).',
+                '- [ ] I have confirmed that this PR can be merged without waiting (if necessary).',
+                '  - An example of when a PR must wait to be merged is when the docs are part of a pending release of a new product version.'
+              ].join('\n')
+            });
+            github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: result.data.number,
+              labels: ['documentation', 'helm-charts', 'triage']
+            });

--- a/.github/workflows/auto-create-pr-scalar-kubernetes.yml
+++ b/.github/workflows/auto-create-pr-scalar-kubernetes.yml
@@ -1,0 +1,39 @@
+# This workflow auto-creates PRs for Scalar Kubernetes docs that come from the centralized private docs repository where we update our docs.
+name: ✨ Auto-create pull request - Scalar Kubernetes docs
+
+on:
+  push:
+    branches:
+      - scalar-kubernetes/**
+      
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const result = await github.rest.pulls.create({
+              title: 'AUTO: Docs repo sync - Scalar Kubernetes',
+              owner,
+              repo,
+              head: '${{ github.ref_name }}',
+              base: 'main',
+              body: [
+                'This is an automated pull request (PR) to sync changes to Scalar Kubernetes docs in the centralized private docs repo to this public docs site repo.',
+                '',
+                'Before merging this PR, confirm the following:',
+                '',
+                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary).',
+                '- [ ] I have confirmed that this PR can be merged without waiting (if necessary).',
+                '  - An example of when a PR must wait to be merged is when the docs are part of a pending release of a new product version.'
+              ].join('\n')
+            });
+            github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: result.data.number,
+              labels: ['documentation', 'scalar-kubernetes', 'triage']
+            });

--- a/.github/workflows/auto-create-pr-scalardb-includes.yml
+++ b/.github/workflows/auto-create-pr-scalardb-includes.yml
@@ -4,7 +4,7 @@ name: ✨ Auto-create pull request - ScalarDB includes
 on:
   push:
     branches:
-      - _includes/scalardb/**
+      - sync-scalardb-includes
       
 jobs:
   create-pull-request:

--- a/.github/workflows/auto-create-pr-scalardb-includes.yml
+++ b/.github/workflows/auto-create-pr-scalardb-includes.yml
@@ -1,0 +1,38 @@
+# This workflow auto-creates PRs for ScalarDB includes that come from the centralized private docs repository where we update our docs.
+name: ✨ Auto-create pull request - ScalarDB includes
+
+on:
+  push:
+    branches:
+      - _includes/scalardb/**
+      
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const result = await github.rest.pulls.create({
+              title: 'AUTO: Docs repo sync - ScalarDB includes',
+              owner,
+              repo,
+              head: '${{ github.ref_name }}',
+              base: 'main',
+              body: [
+                'This is an automated pull request (PR) to sync changes to ScalarDB includes in the centralized private docs repo to this public docs site repo.',
+                '',
+                'Before merging this PR, confirm the following:',
+                '',
+                '- [ ] I have confirmed that this PR can be merged without waiting (if necessary).',
+                '  - An example of when a PR must wait to be merged is when the docs are part of a pending release of a new product version.'
+              ].join('\n')
+            });
+            github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: result.data.number,
+              labels: ['improvement', 'triage']
+            });

--- a/.github/workflows/auto-create-pr-scalardb-includes.yml
+++ b/.github/workflows/auto-create-pr-scalardb-includes.yml
@@ -34,5 +34,5 @@ jobs:
               owner,
               repo,
               issue_number: result.data.number,
-              labels: ['improvement', 'triage']
+              labels: ['documentation', 'scalardb', 'triage']
             });

--- a/.github/workflows/auto-create-pr-scalardb.yml
+++ b/.github/workflows/auto-create-pr-scalardb.yml
@@ -1,0 +1,39 @@
+# This workflow auto-creates PRs for ScalarDB docs that come from the centralized private docs repository where we update our docs.
+name: ✨ Auto-create pull request - ScalarDB docs
+
+on:
+  push:
+    branches:
+      - scalardb/**
+      
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const result = await github.rest.pulls.create({
+              title: 'AUTO: Docs repo sync - ScalarDB',
+              owner,
+              repo,
+              head: '${{ github.ref_name }}',
+              base: 'main',
+              body: [
+                'This is an automated pull request (PR) to sync changes to ScalarDB docs in the centralized private docs repo to this public docs site repo.',
+                '',
+                'Before merging this PR, confirm the following:',
+                '',
+                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary).',
+                '- [ ] I have confirmed that this PR can be merged without waiting (if necessary).',
+                '  - An example of when a PR must wait to be merged is when the docs are part of a pending release of a new product version.'
+              ].join('\n')
+            });
+            github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: result.data.number,
+              labels: ['documentation', 'scalardb', 'triage']
+            });


### PR DESCRIPTION
## Description

This PR adds workflows to automatically create PRs for includes from the private, centralized docs repository.

> [!NOTE]
>
> Includes in the Jekyll static site generator are files stored in the `_includes` folder that can be reused in other docs. For more information, see [Jekyll's explanation on includes](https://jekyllrb.com/docs/includes/).

## Related issues and/or PRs

N/A

## Changes made

- Added workflow (`.yml`) files for ScalarDB includes and common includes.
  - ScalarDB includes are specific to only the docs on the ScalarDB docs site.
  - Common includes are or can be used in the docs on all Scalar product docs sites.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A