### PR TITLE
Hide TOC on pages that have no subheadings

### DIFF
--- a/docs/3.10/development-configurations.md
+++ b/docs/3.10/development-configurations.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Configuration Guides for ScalarDB
 
 The following is a list of configuration guides for ScalarDB:

--- a/docs/3.10/guides.md
+++ b/docs/3.10/guides.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Developer Guides for ScalarDB
 
 The following is a list of developer guides for ScalarDB:

--- a/docs/3.10/scalardb-cluster/getting-started-with-scalardb-cluster-overview.md
+++ b/docs/3.10/scalardb-cluster/getting-started-with-scalardb-cluster-overview.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Getting Started with ScalarDB Cluster
 
 The following are tutorials for getting started with using ScalarDB Cluster:

--- a/docs/3.10/scalardb-samples/README.md
+++ b/docs/3.10/scalardb-samples/README.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # ScalarDB Samples
 
 This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):

--- a/docs/3.11/development-configurations.md
+++ b/docs/3.11/development-configurations.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Configuration Guides for ScalarDB
 
 The following is a list of configuration guides for ScalarDB:

--- a/docs/3.11/guides.md
+++ b/docs/3.11/guides.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Developer Guides for ScalarDB
 
 The following is a list of developer guides for ScalarDB:

--- a/docs/3.11/scalardb-cluster/getting-started-with-scalardb-cluster-overview.md
+++ b/docs/3.11/scalardb-cluster/getting-started-with-scalardb-cluster-overview.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Getting Started with ScalarDB Cluster
 
 The following are tutorials for getting started with using ScalarDB Cluster:

--- a/docs/3.11/scalardb-samples/README.md
+++ b/docs/3.11/scalardb-samples/README.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # ScalarDB Samples
 
 This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):

--- a/docs/3.4/development-configurations.md
+++ b/docs/3.4/development-configurations.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 {% include scalardb/end-of-support.html %}
 
 # Configuration Guides for ScalarDB

--- a/docs/3.4/scalardb-samples/README.md
+++ b/docs/3.4/scalardb-samples/README.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 {% include scalardb/end-of-support.html %}
 
 # ScalarDB Samples

--- a/docs/3.5/development-configurations.md
+++ b/docs/3.5/development-configurations.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 {% include scalardb/end-of-support.html %}
 
 # Configuration Guides for ScalarDB

--- a/docs/3.5/scalardb-samples/README.md
+++ b/docs/3.5/scalardb-samples/README.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 {% include scalardb/end-of-support.html %}
 
 # ScalarDB Samples

--- a/docs/3.6/development-configurations.md
+++ b/docs/3.6/development-configurations.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Configuration Guides for ScalarDB
 
 The following is a list of configuration guides for ScalarDB:

--- a/docs/3.6/guides.md
+++ b/docs/3.6/guides.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Developer Guides for ScalarDB
 
 The following is a list of developer guides for ScalarDB:

--- a/docs/3.6/scalardb-samples/README.md
+++ b/docs/3.6/scalardb-samples/README.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # ScalarDB Samples
 
 This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):

--- a/docs/3.7/development-configurations.md
+++ b/docs/3.7/development-configurations.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Configuration Guides for ScalarDB
 
 The following is a list of configuration guides for ScalarDB:

--- a/docs/3.7/guides.md
+++ b/docs/3.7/guides.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Developer Guides for ScalarDB
 
 The following is a list of developer guides for ScalarDB:

--- a/docs/3.7/scalardb-samples/README.md
+++ b/docs/3.7/scalardb-samples/README.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # ScalarDB Samples
 
 This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):

--- a/docs/3.8/development-configurations.md
+++ b/docs/3.8/development-configurations.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Configuration Guides for ScalarDB
 
 The following is a list of configuration guides for ScalarDB:

--- a/docs/3.8/guides.md
+++ b/docs/3.8/guides.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Developer Guides for ScalarDB
 
 The following is a list of developer guides for ScalarDB:

--- a/docs/3.8/scalardb-samples/README.md
+++ b/docs/3.8/scalardb-samples/README.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # ScalarDB Samples
 
 This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):

--- a/docs/3.9/development-configurations.md
+++ b/docs/3.9/development-configurations.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Configuration Guides for ScalarDB
 
 The following is a list of configuration guides for ScalarDB:

--- a/docs/3.9/guides.md
+++ b/docs/3.9/guides.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Developer Guides for ScalarDB
 
 The following is a list of developer guides for ScalarDB:

--- a/docs/3.9/scalardb-cluster/getting-started-with-scalardb-cluster-overview.md
+++ b/docs/3.9/scalardb-cluster/getting-started-with-scalardb-cluster-overview.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Getting Started with ScalarDB Cluster
 
 The following are tutorials for getting started with using ScalarDB Cluster:

--- a/docs/3.9/scalardb-samples/README.md
+++ b/docs/3.9/scalardb-samples/README.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # ScalarDB Samples
 
 This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):

--- a/docs/latest/development-configurations.md
+++ b/docs/latest/development-configurations.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Configuration Guides for ScalarDB
 
 The following is a list of configuration guides for ScalarDB:

--- a/docs/latest/guides.md
+++ b/docs/latest/guides.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Developer Guides for ScalarDB
 
 The following is a list of developer guides for ScalarDB:

--- a/docs/latest/scalardb-cluster/getting-started-with-scalardb-cluster-overview.md
+++ b/docs/latest/scalardb-cluster/getting-started-with-scalardb-cluster-overview.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # Getting Started with ScalarDB Cluster
 
 The following are tutorials for getting started with using ScalarDB Cluster:

--- a/docs/latest/scalardb-samples/README.md
+++ b/docs/latest/scalardb-samples/README.md
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # ScalarDB Samples
 
 This repository contains sample applications for [ScalarDB](https://github.com/scalar-labs/scalardb):


### PR DESCRIPTION
## Description

This PR hides the table of contents (TOC) on pages that have no subheadings.

## Related issues and/or PRs

N/A

## Changes made

- Added front matter to the top of the Markdown file that disables the TOC.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A