### PR TITLE
Add Release Support Policy page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -208,8 +208,8 @@ versions:
       #   url: /docs/releases/release-3.5/
       # - title: "v3.4"
       #   url: /docs/releases/release-3.4/
-      # - title: "Release Support Policy"
-      #   url: /docs/releases/release-support-policy
+      - title: "Release Support Policy"
+        url: /docs/releases/release-support-policy
 
 "3.10":
   - title: "⬅ ScalarDB Enterprise docs home" 
@@ -350,8 +350,8 @@ versions:
       #   url: /docs/releases/release-3.5/
       # - title: "v3.4"
       #   url: /docs/releases/release-3.4/
-      # - title: "Release Support Policy"
-      #   url: /docs/releases/release-support-policy
+      - title: "Release Support Policy"
+        url: /docs/releases/release-support-policy/
 
 "3.9":
   - title: "⬅ ScalarDB Enterprise docs home" 
@@ -492,8 +492,8 @@ versions:
       #   url: /docs/releases/release-3.5/
       # - title: "v3.4"
       #   url: /docs/releases/release-3.4/
-      # - title: "Release Support Policy"
-      #   url: /docs/releases/release-support-policy
+      - title: "Release Support Policy"
+        url: /docs/releases/release-support-policy/
 
 "3.8":
   - title: "⬅ ScalarDB Enterprise docs home" 
@@ -634,8 +634,8 @@ versions:
       #   url: /docs/releases/release-3.5/
       # - title: "v3.4"
       #   url: /docs/releases/release-3.4/
-      # - title: "Release Support Policy"
-      #   url: /docs/releases/release-support-policy
+      - title: "Release Support Policy"
+        url: /docs/releases/release-support-policy/
 
 "3.7":
   - title: "⬅ ScalarDB Enterprise docs home" 
@@ -774,8 +774,8 @@ versions:
       #   url: /docs/releases/release-3.5/
       # - title: "v3.4"
       #   url: /docs/releases/release-3.4/
-      # - title: "Release Support Policy"
-      #   url: /docs/releases/release-support-policy
+      - title: "Release Support Policy"
+        url: /docs/releases/release-support-policy/
 
 "3.6":
   - title: "⬅ ScalarDB Enterprise docs home" 
@@ -914,8 +914,8 @@ versions:
       #   url: /docs/releases/release-3.5/
       # - title: "v3.4"
       #   url: /docs/releases/release-3.4/
-      # - title: "Release Support Policy"
-      #   url: /docs/releases/release-support-policy
+      - title: "Release Support Policy"
+        url: /docs/releases/release-support-policy/
 
 "3.5":
   - title: "⬅ ScalarDB Enterprise docs home" 
@@ -1044,8 +1044,8 @@ versions:
       #   url: /docs/releases/release-3.5/
       # - title: "v3.4"
       #   url: /docs/releases/release-3.4/
-      # - title: "Release Support Policy"
-      #   url: /docs/releases/release-support-policy
+      - title: "Release Support Policy"
+        url: /docs/releases/release-support-policy/
 
 "3.4":
   - title: "⬅ ScalarDB Enterprise docs home" 
@@ -1158,5 +1158,5 @@ versions:
       #   url: /docs/releases/release-3.5/
       # - title: "v3.4"
       #   url: /docs/releases/release-3.4/
-      # - title: "Release Support Policy"
-      #   url: /docs/releases/release-support-policy
+      - title: "Release Support Policy"
+        url: /docs/releases/release-support-policy/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -63,7 +63,7 @@ versions:
 
 "latest":
   - title: "⬅ ScalarDB Enterprise docs home" 
-    url: /docs # Don't change this URL. This links back to the parent product home page.
+    url: /docs/ # Don't change this URL. This links back to the parent product home page.
   - title: "ScalarDB 3.11 Enterprise"
     children:
   # Get Started docs
@@ -209,11 +209,11 @@ versions:
       # - title: "v3.4"
       #   url: /docs/releases/release-3.4/
       - title: "Release Support Policy"
-        url: /docs/releases/release-support-policy
+        url: /docs/releases/release-support-policy/
 
 "3.10":
   - title: "⬅ ScalarDB Enterprise docs home" 
-    url: /docs # Don't change this URL. This links back to the parent product home page.
+    url: /docs/ # Don't change this URL. This links back to the parent product home page.
   - title: "ScalarDB 3.10 Enterprise"
     children:
   # Get Started docs
@@ -355,7 +355,7 @@ versions:
 
 "3.9":
   - title: "⬅ ScalarDB Enterprise docs home" 
-    url: /docs # Don't change this URL. This links back to the parent product home page.
+    url: /docs/ # Don't change this URL. This links back to the parent product home page.
   - title: "ScalarDB 3.9 Enterprise"
     children:
   # Get Started docs
@@ -497,7 +497,7 @@ versions:
 
 "3.8":
   - title: "⬅ ScalarDB Enterprise docs home" 
-    url: /docs # Don't change this URL. This links back to the parent product home page.
+    url: /docs/ # Don't change this URL. This links back to the parent product home page.
   - title: "ScalarDB 3.8 Enterprise"
     children:
   # Get Started docs
@@ -639,7 +639,7 @@ versions:
 
 "3.7":
   - title: "⬅ ScalarDB Enterprise docs home" 
-    url: /docs # Don't change this URL. This links back to the parent product home page.
+    url: /docs/ # Don't change this URL. This links back to the parent product home page.
   - title: "ScalarDB 3.7 Enterprise"
     children:
   # Get Started docs
@@ -779,7 +779,7 @@ versions:
 
 "3.6":
   - title: "⬅ ScalarDB Enterprise docs home" 
-    url: /docs # Don't change this URL. This links back to the parent product home page.
+    url: /docs/ # Don't change this URL. This links back to the parent product home page.
   - title: "ScalarDB 3.6 Enterprise"
     children:
   # Get Started docs
@@ -919,7 +919,7 @@ versions:
 
 "3.5":
   - title: "⬅ ScalarDB Enterprise docs home" 
-    url: /docs # Don't change this URL. This links back to the parent product home page.
+    url: /docs/ # Don't change this URL. This links back to the parent product home page.
   - title: "ScalarDB 3.5 Enterprise"
     children:
   # Get Started docs
@@ -1049,7 +1049,7 @@ versions:
 
 "3.4":
   - title: "⬅ ScalarDB Enterprise docs home" 
-    url: /docs # Don't change this URL. This links back to the parent product home page.
+    url: /docs/ # Don't change this URL. This links back to the parent product home page.
   - title: "ScalarDB 3.4 Enterprise"
     children:
   # Get Started docs

--- a/_sass/minimal-mistakes/_tables.scss
+++ b/_sass/minimal-mistakes/_tables.scss
@@ -37,3 +37,9 @@ td,
 th {
   vertical-align: middle;
 }
+
+/* Added the following style to show when a product version is no longer supported in `release-support-policy.md` (added by josh-wong) */
+.version-out-of-support {
+  background-color: $version-out-of-support-background-color;
+  opacity: 0.80;
+}

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -74,6 +74,7 @@ $muted-text-color: mix(#fff, $text-color, 20%) !default;
 $border-color: $lighter-gray !default;
 $form-background-color: $lighter-gray !default;
 $footer-background-color: $lighter-gray !default;
+$version-out-of-support-background-color: mix(#000, $background-color, 15%) !default;
 
 /* Scalar colors (added by josh-wong) */
 $scalar-primary-color: #2673BB !default;

--- a/_sass/minimal-mistakes/skins/_dark.scss
+++ b/_sass/minimal-mistakes/skins/_dark.scss
@@ -13,6 +13,7 @@ $gray: #7a8288 !default;
 $dark-gray: #eaeaea !default; /* This color isn't really gray and should be refactored. However, doing so would take considerable time, so I'm leaving it as is for now (modified by josh-wong). */
 $form-background-color: mix(#000, $background-color, 15%) !default;
 $footer-background-color: mix(#000, $background-color, 30%) !default;
+$version-out-of-support-background-color: mix(#000, $background-color, 99%) !default;
 $lighter-gray: mix(#fff, $gray, 90%) !default;
 $link-color: mix(#fff, #2673BB, 20%) !default;
 $link-color-hover: mix(#fff, $link-color, 50%) !default;

--- a/docs/releases/release-support-policy.md
+++ b/docs/releases/release-support-policy.md
@@ -1,0 +1,83 @@
+# Release Support Policy
+
+This page describes Scalar's support policy for major and minor version releases of ScalarDB.
+
+## Terms and definitions
+
+- **Maintenance Support:** Scalar will provide product updates, including code fixes, documentation, and technical support through its [support portal](https://support.scalar-labs.com/) to customers with a commercial license, until the date specified.
+- **Assistance Support:** Scalar will continue to provide technical support through its [support portal](https://support.scalar-labs.com/) to customers with a commercial license until the date specified.
+- **Extended Support:** Extended Support is available as an add-on for customers with a commercial license who want support for a version that is no longer under Maintenance Support or Assistance Support.
+
+## Release support timelines
+
+<table>
+  <thead>
+    <tr>
+      <th>Version</th>
+      <th>Release Date</th>
+      <th>Maintenance Support Ends</th>
+      <th>Assistance Support Ends</th>
+      <th>Extended Support</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="/docs/releases/release-3.11#v3110">3.11</a></td>
+      <td>2023-12-27</td>
+      <td>-</td>
+      <td>-</td>
+      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+    </tr>
+    <tr>
+      <td><a href="/docs/releases/release-3.10#v3100">3.10</a></td>
+      <td>2023-07-20</td>
+      <td>2024-12-26</td>
+      <td>2025-06-24</td>
+      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+    </tr>
+    <tr>
+      <td><a href="/docs/releases/release-3.9#v390">3.9</a></td>
+      <td>2023-04-27</td>
+      <td>2024-07-19</td>
+      <td>2025-01-15</td>
+      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+    </tr>
+    <tr>
+      <td><a href="/docs/releases/release-3.8#v380">3.8</a></td>
+      <td>2023-01-17</td>
+      <td>2024-04-26</td>
+      <td>2024-10-23</td>
+      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+    </tr>
+    <tr>
+      <td><a href="/docs/releases/release-3.7#v370">3.7</a></td>
+      <td>2022-09-03</td>
+      <td>2024-01-17</td>
+      <td>2024-07-15</td>
+      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+    </tr>
+    <tr>
+      <td><a href="/docs/releases/release-3.6#v360">3.6</a></td>
+      <td>2022-07-08</td>
+      <td>2023-09-03</td>
+      <td>2024-03-01</td>
+      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+    </tr>
+    <tr class="version-out-of-support">
+      <td><a href="/docs/releases/release-3.5#v350">3.5</a>*</td>
+      <td>2022-02-16</td>
+      <td>2023-07-08</td>
+      <td>2024-01-04</td>
+      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+    </tr>
+    <tr class="version-out-of-support">
+      <td><a href="/docs/releases/release-3.4#v340">3.4</a>*</td>
+      <td>2021-12-02</td>
+      <td>2023-02-16</td>
+      <td>2023-08-15</td>
+      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+    </tr>
+  </tbody>
+</table>
+
+&#42; This product version is no longer supported under Maintenance Support or Assistance Support.

--- a/docs/releases/release-support-policy.md
+++ b/docs/releases/release-support-policy.md
@@ -4,7 +4,7 @@ This page describes Scalar's support policy for major and minor version releases
 
 ## Terms and definitions
 
-- **Maintenance Support:** Scalar will provide product updates, including code fixes, documentation, and technical support through its [support portal](https://support.scalar-labs.com/) to customers with a commercial license, until the date specified.
+- **Maintenance Support:** Scalar will provide product updates, including code fixes and documentation, and technical support through its [support portal](https://support.scalar-labs.com/) to customers with a commercial license, until the date specified.
 - **Assistance Support:** Scalar will continue to provide technical support through its [support portal](https://support.scalar-labs.com/) to customers with a commercial license until the date specified.
 - **Extended Support:** Extended Support is available as an add-on for customers with a commercial license who want support for a version that is no longer under Maintenance Support or Assistance Support.
 

--- a/docs/releases/release-support-policy.md
+++ b/docs/releases/release-support-policy.md
@@ -5,7 +5,7 @@ This page describes Scalar's support policy for major and minor version releases
 ## Terms and definitions
 
 - **Maintenance Support:** Scalar will provide product updates, including code fixes and documentation, and technical support through its [support portal](https://support.scalar-labs.com/) to customers with a commercial license, until the date specified.
-- **Assistance Support:** Scalar will continue to provide technical support through its [support portal](https://support.scalar-labs.com/) to customers with a commercial license until the date specified.
+- **Assistance Support:** Scalar will provide limited technical support for non-code-related questions in the form of FAQs and inquiries through its [support portal](https://support.scalar-labs.com/) to customers with a commercial license until the date specified.
 - **Extended Support:** Extended Support is available as an add-on for customers with a commercial license who want support for a version that is no longer under Maintenance Support or Assistance Support.
 
 ## Release support timelines


### PR DESCRIPTION
## Description

This PR adds a page showing our Release Support Policy for ScalarDB Enterprise edition.

## Related issues and/or PRs

N/A

## Changes made

- Created the Release Support Policy page.
- Added styles for giving out-of-support versions a darker-colored background.
- Added the Release Support Policy page to the side navigation.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
