### PR TITLE
Remove large, awkward spacing when starting the contents of a tab with a heading or a list

### DIFF
--- a/_sass/minimal-mistakes/_tabbed-content.scss
+++ b/_sass/minimal-mistakes/_tabbed-content.scss
@@ -47,4 +47,20 @@
     margin: auto;
     display: block;
   }
+
+  h2:first-child,
+  h3:first-child,
+  h4:first-child,
+  h5:first-child,
+  h6:first-child {
+    margin: 0 0 0.5em;
+    line-height: 1.2;
+    font-family: $header-font-family;
+    font-weight: bold;
+  }
+
+  ul:first-child,
+  ol:first-child {
+    margin-top: 0;
+  }
 }


### PR DESCRIPTION
## Description

This PR removes the large, awkward spacing that appears when starting the contents of a tab with a heading or a list. 

This issue occurred because the headings and lists used the global styles, which provide spacing before headings and lists. By adding styles for headings and lists that are specific to only those within tabbed content, we can avoid the awkward spacing issue.

## Related issues and/or PRs

N/A

## Changes made

- Added `:first-child` styles for headings and lists that are in tabs.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A