### PR TITLE
Add language dropdown menu to see docs in Japanese

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -24,6 +24,14 @@ main:
   - title: "&nbsp;&nbsp;&nbsp;Support&nbsp;&nbsp;&nbsp;"
     url: https://www.scalar-labs.com/support/
 
+languages:
+  - language-title-top: ""
+    language-children:
+      - language-title: "English"
+        language-url: /docs/
+      - language-ja-jp-title: "日本語"
+        language-ja-jp-url: /docs/ja-jp/
+
 # This navigation is for adding product editions that appear in the dropdown menu.
 editions:
   - edition-top-title: "" # This title is taken from the `edition_label` in `_data/ui-text.yml`.

--- a/_home/ja-jp/404.md
+++ b/_home/ja-jp/404.md
@@ -1,0 +1,12 @@
+---
+excerpt: "申し訳ありませんが、お探しのページは見つかりませんでした。"
+sitemap: false
+permalink: /ja-jp/404.html
+toc: false
+---
+
+# 404 - ページが見つかりません
+
+申し訳ありませんが、お探しのページは見つかりませんでした。
+
+[トップページに戻る](/docs/ja-jp/){: .btn .btn--primary}

--- a/_home/ja-jp/home.md
+++ b/_home/ja-jp/home.md
@@ -1,0 +1,63 @@
+---
+layout: parent-product-home
+permalink: /docs/ja-jp/
+hidden: true
+toc: false
+product_row:
+  - image_path: 
+    alt: ""
+    title: "Supported Databases" # This title will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
+    excerpt: "Databases that ScalarDB supports" # Add a brief product description (approximately 8 words)
+    url: "docs/latest/scalardb-supported-databases" # Add a relative URL to the product home page doc that is within this parent product docs site
+    btn_class: "btn--primary"
+    btn_label: "Get started" # This can be any other type of call to action
+  - image_path: 
+    alt: ""
+    title: "ScalarDB Schema Loader" # This title will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
+    excerpt: "Tool for creating schema" # Add a brief product description (approximately 8 words)
+    url: "docs/latest/schema-loader" # Add a relative URL to the product home page doc that is within this parent product docs site
+    btn_class: "btn--primary"
+    btn_label: "Get started" # This can be any other type of call to action
+  - image_path: 
+    alt: ""
+    title: "ScalarDB Cluster" # This title will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
+    excerpt: "Clustering solution for ScalarDB" # Add a brief product description (approximately 8 words)
+    url: "docs/latest/scalardb-cluster/" # Add a relative URL to the product home page doc that is within this parent product docs site
+    btn_class: "btn--primary"
+    btn_label: "Get started" # This can be any other type of call to action
+recommended_row:
+  - image_path: assets/images/book-green.svg # Choose the appropriate icon for the doc recommended here: (`book-green.svg`, `cloud-purple.svg`, `page-blue.svg`)
+    alt: ""
+    title: "Getting Started with ScalarDB" # The title for a recommended doc will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
+    excerpt: "Set up a simple electronic money app" # Add a brief description about the doc (approximately 8 words)
+    url: "docs/latest/getting-started-with-scalardb" # Add a relative URL to the product home page doc that is within this parent product docs site
+    btn_class: "btn--primary"
+    btn_label: "Learn more" # This can be any other type of call to action
+  - image_path: assets/images/book-green.svg # Choose the appropriate icon for the doc recommended here: (`book-green.svg`, `cloud-purple.svg`, `page-blue.svg`)
+    alt: ""
+    title: "ScalarDB Samples" # The title for a recommended doc will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
+    excerpt: "Set up sample applications" # Add a brief description about the doc (approximately 8 words)
+    url: "docs/latest/scalardb-samples/README" # Add a relative URL to the product home page doc that is within this parent product docs site
+    btn_class: "btn--primary"
+    btn_label: "Learn more" # This can be any other type of call to action
+  - image_path: assets/images/page-blue.svg # Choose the appropriate icon for the doc recommended here: (`book-green.svg`, `cloud-purple.svg`, `page-blue.svg`)
+    alt: ""
+    title: "ScalarDB Benchmarks" # The title for a recommended doc will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
+    excerpt: "Run benchmark programs for ScalarDB" # Add a brief description about the doc (approximately 8 words)
+    url: "docs/latest/scalardb-benchmarks/README" # Add a relative URL to the product home page doc that is within this parent product docs site
+    btn_class: "btn--primary"
+    btn_label: "Learn more" # This can be any other type of call to action
+---
+
+# ScalarDB Enterprise Documentation
+
+ScalarDB is a universal transaction manager that achieves:
+
+* Database/storage-agnostic ACID transactions in a scalable manner even if an underlying database or storage is not ACID compliant.
+* Multi-storage/database/service ACID transactions that can span multiple (possibly different) databases, storages, and services.
+
+{% include product_row %}
+
+## Recommended
+
+{% include recommended_row %}

--- a/_home/ja-jp/index.md
+++ b/_home/ja-jp/index.md
@@ -1,0 +1,6 @@
+---
+title: 
+permalink: /ja-jp/
+redirect_to:
+  - http://scalardb.scalar-labs.com/docs/ja-jp/
+---

--- a/_home/ja-jp/terms.md
+++ b/_home/ja-jp/terms.md
@@ -1,0 +1,8 @@
+---
+permalink: /ja-jp/terms/
+toc: false
+---
+
+# プライバシーポリシー
+
+株式会社スカラーのプライバシーポリシーの詳細については、[株式会社Scalarのプライバシーポリシー](https://www.scalar-labs.com/ja/privacy-policy/)をご覧ください。

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -22,9 +22,15 @@
             <ul class="version-dropdown-content">
               {% for version-children in link.version-children %}
                 <li>
-                  <a href="{{ site.baseurl }}{{ version-children.version-url }}">
-                    <span>{{ version-children.version-title }}</span>
-                  </a>
+                  {% if page.url contains '/docs/ja-jp/' %}
+                    <a href="{{ site.baseurl }}{{ version-children.version-ja-jp-url }}">
+                      <span>{{ version-children.version-ja-jp-title }}</span>
+                    </a>
+                  {% else %}
+                    <a href="{{ site.baseurl }}{{ version-children.version-url }}">
+                      <span>{{ version-children.version-title }}</span>
+                    </a>
+                  {% endif %}
                 </li>
               {% endfor %}
             </ul>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,8 +3,17 @@ layout: default
 permalink: /:collection/:path/
 ---
 
-<div id="main" role="main">
+{% assign breadcrumbs_enabled = site.breadcrumbs %}
+{% if page.breadcrumbs != null %}
+  {% assign breadcrumbs_enabled = page.breadcrumbs %}
+{% endif %}
+{% if page.url != "/" and breadcrumbs_enabled %}
+  {% unless paginator %}
+    {% include breadcrumbs.html %}
+  {% endunless %}
+{% endif %}
 
+<div id="main" role="main">
   {% include sidebar.html %}
 
   <article class="page h-entry" itemscope itemtype="https://schema.org/CreativeWork">
@@ -12,17 +21,6 @@ permalink: /:collection/:path/
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date_to_xmlschema }}">{% endif %}
     {% if page.last_modified_at %}<meta itemprop="dateModified" content="{{ page.last_modified_at | date_to_xmlschema }}">{% endif %}
-
-    <!-- The following breadcrumb section was above the `<div id="main" role="main">` section, which caused the breadcrumbs to be hidden behind the masthead (modified by josh-wong). -->
-    {% assign breadcrumbs_enabled = site.breadcrumbs %}
-    {% if page.breadcrumbs != null %}
-      {% assign breadcrumbs_enabled = page.breadcrumbs %}
-    {% endif %}
-    {% if page.url != "/" and breadcrumbs_enabled %}
-      {% unless paginator %}
-        {% include breadcrumbs.html %}
-      {% endunless %}
-    {% endif %}
 
     <div class="page__inner-wrap">
       {% unless page.header.overlay_color or page.header.overlay_image %}
@@ -35,6 +33,38 @@ permalink: /:collection/:path/
       {% endunless %}
 
       <section class="page__content e-content" itemprop="text">
+         <!-- Adds support for the language dropdown menu for the languages listed in `_data/navigation.yml`. For some reason, adding this dropdown menu to `_includes.masthead.html` results in broken links, regardless of trying to use a variety of logic in the  Liquid language (added by josh-wong). -->
+        <!-- ATTENTION: The following content within the `nav` tag contains the language dropdown. Enable this dropdown after we have added all Japanese docs to the ScalarDB docs site.
+        <nav id="site-nav" class="language-greedy-nav">
+          <ul class="language-visible-links">
+            {%- for link in site.data.navigation.languages -%}
+            {% assign class = nil %}
+            {% if page.language-url contains link.language-url %}
+            {% assign class = 'active' %}
+            {% endif %}
+            {% if link.language-children %}
+            <li class="language-dropdown {{ class }}">
+              <label for="touch-language"><a data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fas fa-globe fa-lg language-toggle" aria-hidden="true"></i><span class="language-dropdown-text">{% if page.url contains "docs/ja-jp" %}言語{% else %}Language{% endif %}<svg class="language-dropdown-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"></path></svg></span></a></label>
+              <input type="checkbox" id="touch-language">
+              <ul class="language-dropdown-content">
+                {% for language-children in link.language-children %}
+                <li>
+                  <a href="{{ page.url | replace: 'docs/ja-jp', 'docs' }}">
+                    <span>{{ language-children.language-title }}</span>
+                  </a>
+                </li>
+                <li>
+                  <a href="{{ page.url | replace: 'docs', 'docs/ja-jp' | replace: 'docs/ja-jp/ja-jp', 'docs/ja-jp' }}">
+                    <span>{{ language-children.language-ja-jp-title }}</span>
+                  </a>
+                </li>
+                {% endfor %}
+              </ul>
+            </li>
+            {% endif %}
+            {% endfor %}
+          </ul>
+        </nav> -->
         {% if page.toc %}
           <aside class="sidebar__right {% if page.toc_sticky %}sticky{% endif %}">
             <nav class="toc">

--- a/_layouts/parent-product-home.html
+++ b/_layouts/parent-product-home.html
@@ -3,6 +3,16 @@ layout: default
 permalink: /:collection/:path/
 ---
 
+{% assign breadcrumbs_enabled = site.breadcrumbs %}
+{% if page.breadcrumbs != null %}
+  {% assign breadcrumbs_enabled = page.breadcrumbs %}
+{% endif %}
+{% if page.url != "/" and breadcrumbs_enabled %}
+  {% unless paginator %}
+    {% include breadcrumbs.html %}
+  {% endunless %}
+{% endif %}
+
 <div id="main" role="main">
   {% include sidebar.html %}
 
@@ -11,17 +21,6 @@ permalink: /:collection/:path/
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date_to_xmlschema }}">{% endif %}
     {% if page.last_modified_at %}<meta itemprop="dateModified" content="{{ page.last_modified_at | date_to_xmlschema }}">{% endif %}
-
-    <!-- The following breadcrumb section was above the `<div id="main" role="main">` section, which caused the breadcrumbs to be hidden behind the masthead (modified by josh-wong). -->
-      {% assign breadcrumbs_enabled = site.breadcrumbs %}
-      {% if page.breadcrumbs != null %}
-        {% assign breadcrumbs_enabled = page.breadcrumbs %}
-      {% endif %}
-      {% if page.url != "/" and breadcrumbs_enabled %}
-        {% unless paginator %}
-          {% include breadcrumbs.html %}
-        {% endunless %}
-      {% endif %}
 
     <div class="page__inner-wrap">
       {% unless page.header.overlay_color or page.header.overlay_image %}
@@ -43,6 +42,39 @@ permalink: /:collection/:path/
           </aside>
         {% endif %}
         {{ content }}
+        <!-- Adds support for the language dropdown menu for the languages listed in `_data/navigation.yml`. For some reason, adding this dropdown menu to `_includes.masthead.html` results in broken links, regardless of trying to use a variety of logic in the  Liquid language (added by josh-wong). -->
+         <!-- ATTENTION: The following content within the `nav` tag contains the language dropdown. Enable this dropdown after we have added all Japanese docs to the ScalarDB docs site.
+        <nav id="site-nav" class="language-greedy-nav">
+          <ul class="language-visible-links">
+            {%- for link in site.data.navigation.languages -%}
+            {% assign class = nil %}
+            {% if page.language-url contains link.language-url %}
+            {% assign class = 'active' %}
+            {% endif %}
+            {% if link.language-children %}
+            <li class="language-dropdown {{ class }}">
+              <label for="touch-language"><a data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fas fa-globe fa-lg language-toggle" aria-hidden="true"></i><span class="language-dropdown-text">{% if page.url contains "docs/ja-jp" %}言語{% else %}Language{% endif %}<svg class="language-dropdown-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"></path></svg></span></a></label>
+              <input type="checkbox" id="touch-language">
+              <ul class="language-dropdown-content">
+                {% for language-children in link.language-children %}
+                <li>
+                  <a href="{{ page.url | replace: 'docs/ja-jp', 'docs' }}">
+                    <span>{{ language-children.language-title }}</span>
+                  </a>
+                </li>
+                <li>
+                  <a href="{{ page.url | replace: 'docs', 'docs/ja-jp' | replace: 'docs/ja-jp/ja-jp', 'docs/ja-jp' }}">
+                    <span>{{ language-children.language-ja-jp-title }}</span>
+                  </a>
+                </li>
+                {% endfor %}
+              </ul>
+            </li>
+            {% endif %}
+            {% endfor %}
+          </ul>
+        </nav>
+        -->
         {% if page.link %}<div><a href="{{ page.link }}" class="btn btn--primary">{{ site.data.ui-text[site.locale].ext_link_label | default: "Direct Link" }}</a></div>{% endif %}
       </section>
 

--- a/_sass/minimal-mistakes.scss
+++ b/_sass/minimal-mistakes.scss
@@ -30,6 +30,7 @@
 @import "minimal-mistakes/search";
 @import "minimal-mistakes/syntax";
 @import "minimal-mistakes/tabbed-content"; /* Added to support tabbed content (added by josh-wong) */
+@import "minimal-mistakes/language-dropdown"; /* Added to support the language dropdown (added by josh-wong) */
 
 /* Utility classes */
 @import "minimal-mistakes/utilities";

--- a/_sass/minimal-mistakes/_language-dropdown.scss
+++ b/_sass/minimal-mistakes/_language-dropdown.scss
@@ -1,0 +1,181 @@
+  /* Add styles to support the switcher for languages, which are specified in `_layouts/page.html` (added by josh-wong). */
+
+.language-greedy-nav {
+display: inline-block;
+margin: 5px;
+display: -webkit-box;
+display: -ms-flexbox;
+display: flex;
+-webkit-box-align: center;
+-ms-flex-align: center;
+align-items: center;
+min-height: 2.1em;
+/* width: 190px; */
+margin-bottom: 0;
+text-align: right;
+font-size: $type-size-5;
+min-width: 140px;
+position: fixed;
+z-index: 11;
+
+/* Added to hide the language dropdown menu on mobile and narrow screens since it makes the Scalar logo tiny (added by josh-wong). */
+// @media screen and (max-width: $small) {
+//   display: none;
+// }
+
+  a {
+    display: block;
+    padding: 0.5em;
+    color: $background-color;
+    -webkit-transition: none;
+    transition: none;
+
+    &:hover {
+      background-color: mix(#000, $background-color, 10%);
+      color: mix(#000, $text-color, 90%);
+    }
+  }
+}
+
+.language-visible-links {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  position: fixed;
+  top: 95px;
+  right: 25px;
+  /* justify-content: flex-end; */
+  /* min-width: auto; */
+  /* float: inline-end; */
+  /* overflow: hidden; */
+  /* max-width: fit-content; */
+
+  li {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    /* background-color: $background-color; */
+  }
+
+  a {
+    position: relative;
+    color: $background-color;
+    cursor: pointer;
+    opacity: unset;
+    margin-bottom: -5px;
+
+    &:before {
+      content: "";
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      height: 0px;
+      background: $primary-color;
+      width: 100%;
+      -webkit-transition: $global-transition;
+      transition: $global-transition;
+      -webkit-transform: scaleX(0) translate3d(0, 0, 0);
+      transform: scaleX(0) translate3d(0, 0, 0); // hide
+    }
+
+    &:hover:before {
+      -webkit-transform: scaleX(1);
+      -ms-transform: scaleX(1);
+      transform: scaleX(1); // reveal
+      background-color: mix(#000, $background-color, 10%);
+    }
+  }
+
+  .language-toggle {
+    color: $language-toggle;
+  }
+
+  .language-dropdown {
+    float: left;
+    /* width: 210px; */
+    min-width: 100%;
+    /* max-width: 75%; */
+    font-weight: 500;
+    vertical-align: middle;
+    cursor: default;
+    background-color: $scalar-light-gray-background-color;
+    color: $text-color;
+
+    li {
+      line-height: 1em;
+    }
+    &:hover {
+      background-color: mix($gray, $background-color, 20%);
+    }
+  }
+
+  .language-dropdown-text {
+    color: $text-color;
+    padding: 0 0 0 8px;
+  }
+
+  .language-dropdown-arrow {
+    width: 20px;
+    vertical-align: middle;
+    color: $text-color;
+  }
+
+  .language-dropdown-content {
+    display: none;
+    position: relative;
+    background-color: $background-color;
+    box-shadow: $box-shadow;
+    z-index: 21;
+    /* border: 1pt solid $border-color; */
+    padding-top: 5px;
+    padding-bottom: 5px;
+
+    li {
+      padding: 0;
+      margin: 0;
+    }
+  }
+
+  .language-dropdown-content a {
+    padding: 0 15px 0 15px;
+    margin: 1px;
+    color: $dark-gray;
+    line-height: 1.6em;
+    margin-bottom: 0;
+  }
+
+  /* Adds support for a clickable language dropdown menu (added by josh-wong) */
+  #touch-language {
+    position: absolute;
+    opacity: 0;
+    height: 0px;
+  }
+
+  #touch-language:checked + .language-dropdown-content {
+    /* min-height: 100%; */
+    display: block;
+    /* margin: 0 0 0 3.5em; */
+  }
+
+  /* The following dropdown method is `hover`, which is the default behavior in Minimal Mistakes theme. Comment this out if we want the dropdown to be clicked on rather than hovered over to access (modified by josh-wong).
+  .language-dropdown:hover .language-dropdown-content {
+    display: block;
+  } */
+
+  .language-dropdown-content a:hover {
+    background-color: $scalar-light-gray-background-color;
+  }
+
+  .language-dropdown-content a:not(:last-child) {
+    border-bottom: none;
+  }
+}
+
+.hidden {
+  display: none;
+}

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -244,6 +244,8 @@
   
   .sidebar__right {
     margin-bottom: 1em;
+    padding-top: 1.5em; /* Added to give some spacing below the language dropdown menu (added by josh-wong). */
+    padding-bottom: 1.5em; /* Added to give some spacing below the language dropdown menu (added by josh-wong). */
   
     @include breakpoint($large) {
       position: absolute;

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -75,6 +75,7 @@ $border-color: $lighter-gray !default;
 $form-background-color: $lighter-gray !default;
 $footer-background-color: $lighter-gray !default;
 $version-out-of-support-background-color: mix(#000, $background-color, 15%) !default;
+$language-toggle: #3C4143 !default;
 
 /* Scalar colors (added by josh-wong) */
 $scalar-primary-color: #2673BB !default;

--- a/_sass/minimal-mistakes/skins/_dark.scss
+++ b/_sass/minimal-mistakes/skins/_dark.scss
@@ -13,7 +13,7 @@ $gray: #7a8288 !default;
 $dark-gray: #eaeaea !default; /* This color isn't really gray and should be refactored. However, doing so would take considerable time, so I'm leaving it as is for now (modified by josh-wong). */
 $form-background-color: mix(#000, $background-color, 15%) !default;
 $footer-background-color: mix(#000, $background-color, 30%) !default;
-$version-out-of-support-background-color: mix(#000, $background-color, 99%) !default;
+$language-toggle: #E9EAEB !default;
 $lighter-gray: mix(#fff, $gray, 90%) !default;
 $link-color: mix(#fff, #2673BB, 20%) !default;
 $link-color-hover: mix(#fff, $link-color, 50%) !default;
@@ -24,6 +24,7 @@ $masthead-link-color-hover: mix(#000, $text-color, 20%) !default;
 $navicon-link-color-hover: mix(#000, $background-color, 30%) !default;
 $scalar-primary-color: #2673BB !default;
 $scalar-light-gray-background-color: #1c1c1c !default; /* This color isn't really light gray and should be refactored. However, doing so would take considerable time, so I'm leaving it as is for now (modified by josh-wong). */
+$version-out-of-support-background-color: mix(#000, $background-color, 99%) !default;
 
 /* syntax highlighting (base16) */
 $base00: #1C1C1C !default;


### PR DESCRIPTION
## Description

This PR adds a language dropdown menu so that visitors can see ScalarDB Enterprise docs and related docs in either English or Japanese.

> [!IMPORTANT]
>
> The language dropdown is currently disabled (commented out) since we don't have docs in Japanese. After we add docs in Japanese, we'll need to enable (uncomment) the language dropdown.

## Related issues and/or PRs

N/A

## Changes made

- Added a language dropdown menu and the necessary styles to the heading of the docs site.
  - Included a function to allow switching between the same page in English or in Japanese.
- Updated related side navigation and version navigation elements to support docs in Japanese.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
