### PR TITLE
Add banner about Japanese docs being machine translated

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -66,6 +66,11 @@ permalink: /:collection/:path/
         {% endif %}
         {% unless page.header.overlay_color or page.header.overlay_image %}
         <header>
+          <!-- This if statement shows that the Japanese content on the page has been machine translated (added by josh-wong). -->
+          {% if page.url contains 'ja-jp' %}
+          {% include common/translation-ja-jp.html %}
+          {% endif %}
+
           {% if page.title %}<h1 id="page-title" class="page__title p-name" itemprop="headline">
           <a href="{{ page.url | absolute_url }}" class="u-url" itemprop="url">{{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}</a>
         </h1>{% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -23,15 +23,6 @@ permalink: /:collection/:path/
     {% if page.last_modified_at %}<meta itemprop="dateModified" content="{{ page.last_modified_at | date_to_xmlschema }}">{% endif %}
 
     <div class="page__inner-wrap">
-      {% unless page.header.overlay_color or page.header.overlay_image %}
-        <header>
-          {% if page.title %}<h1 id="page-title" class="page__title p-name" itemprop="headline">
-            <a href="{{ page.url | absolute_url }}" class="u-url" itemprop="url">{{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}</a>
-          </h1>{% endif %}
-          {% include page__meta.html %}
-        </header>
-      {% endunless %}
-
       <section class="page__content e-content" itemprop="text">
          <!-- Adds support for the language dropdown menu for the languages listed in `_data/navigation.yml`. For some reason, adding this dropdown menu to `_includes.masthead.html` results in broken links, regardless of trying to use a variety of logic in the  Liquid language (added by josh-wong). -->
         <!-- ATTENTION: The following content within the `nav` tag contains the language dropdown. Enable this dropdown after we have added all Japanese docs to the ScalarDB docs site.
@@ -73,6 +64,14 @@ permalink: /:collection/:path/
             </nav>
           </aside>
         {% endif %}
+        {% unless page.header.overlay_color or page.header.overlay_image %}
+        <header>
+          {% if page.title %}<h1 id="page-title" class="page__title p-name" itemprop="headline">
+          <a href="{{ page.url | absolute_url }}" class="u-url" itemprop="url">{{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}</a>
+        </h1>{% endif %}
+          {% include page__meta.html %}
+        </header>
+        {% endunless %}
         {{ content }}
         {% if page.link %}<div><a href="{{ page.link }}" class="btn btn--primary">{{ site.data.ui-text[site.locale].ext_link_label | default: "Direct Link" }}</a></div>{% endif %}
       </section>


### PR DESCRIPTION
## Description

This PR adds a banner that is displayed at the top of Japanese docs, which we might add in the future, stating that the contents have been machine translated.

> [!NOTE]
>
> If the banner is added to pages individually instead, the search results cause titles to become `null`. This PR proactively avoids that issue, which is why this PR is labeled as an `enhancement` rather than a `bugfix`.

## Related issues and/or PRs

The following PR fixes the issue, which happened on the live ScalarDL docs site:

- https://github.com/scalar-labs/docs-scalardl/pull/121

## Changes made

- Moved the title of the doc so that the banner could be added above it.
  - Needed to move the header because simply adding the banner to above the heading caused the sidebar where the table of contents is to shift down, leaving a large gap between the bottom of the "Contact us" button and the language dropdown.
- Added the banner above the title and make it appear only on Japanese pages.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A