### PR TITLE
Add links to container images docs to the Kubernetes deployment doc

### DIFF
--- a/docs/3.10/scalar-kubernetes/deploy-kubernetes.md
+++ b/docs/3.10/scalar-kubernetes/deploy-kubernetes.md
@@ -15,6 +15,11 @@ The following documentation is to help you set up and deploy a ScalarDB environm
 * [How to install Scalar products through Azure Marketplace](AzureMarketplaceGuide.md)
 * [Create a bastion server](CreateBastionServer.md)
 
+## Container image guides
+
+* [How to get the container images of Scalar products](HowToGetContainerImages.md)
+* [How to use the container images](HowToUseContainerImages.md)
+
 ## Deployment guides
 
 * [Deploy ScalarDB Cluster on Amazon Elastic Kubernetes Service (EKS)](ManualDeploymentGuideScalarDBClusterOnEKS.md)

--- a/docs/3.11/scalar-kubernetes/deploy-kubernetes.md
+++ b/docs/3.11/scalar-kubernetes/deploy-kubernetes.md
@@ -15,6 +15,11 @@ The following documentation is to help you set up and deploy a ScalarDB environm
 * [How to install Scalar products through Azure Marketplace](AzureMarketplaceGuide.md)
 * [Create a bastion server](CreateBastionServer.md)
 
+## Container image guides
+
+* [How to get the container images of Scalar products](HowToGetContainerImages.md)
+* [How to use the container images](HowToUseContainerImages.md)
+
 ## Deployment guides
 
 * [Deploy ScalarDB Cluster on Amazon Elastic Kubernetes Service (EKS)](ManualDeploymentGuideScalarDBClusterOnEKS.md)

--- a/docs/3.12/scalar-kubernetes/deploy-kubernetes.md
+++ b/docs/3.12/scalar-kubernetes/deploy-kubernetes.md
@@ -15,6 +15,11 @@ The following documentation is to help you set up and deploy a ScalarDB environm
 * [How to install Scalar products through Azure Marketplace](AzureMarketplaceGuide.md)
 * [Create a bastion server](CreateBastionServer.md)
 
+## Container image guides
+
+* [How to get the container images of Scalar products](HowToGetContainerImages.md)
+* [How to use the container images](HowToUseContainerImages.md)
+
 ## Deployment guides
 
 * [Deploy ScalarDB Cluster on Amazon Elastic Kubernetes Service (EKS)](ManualDeploymentGuideScalarDBClusterOnEKS.md)

--- a/docs/3.7/scalar-kubernetes/deploy-kubernetes.md
+++ b/docs/3.7/scalar-kubernetes/deploy-kubernetes.md
@@ -15,6 +15,11 @@ The following documentation is to help you set up and deploy a ScalarDB environm
 * [How to install Scalar products through Azure Marketplace](AzureMarketplaceGuide.md)
 * [Create a bastion server](CreateBastionServer.md)
 
+## Container image guides
+
+* [How to get the container images of Scalar products](HowToGetContainerImages.md)
+* [How to use the container images](HowToUseContainerImages.md)
+
 ## Deployment guides
 
 * [Deploy ScalarDB Cluster on Amazon Elastic Kubernetes Service (EKS)](ManualDeploymentGuideScalarDBClusterOnEKS.md)

--- a/docs/3.8/scalar-kubernetes/deploy-kubernetes.md
+++ b/docs/3.8/scalar-kubernetes/deploy-kubernetes.md
@@ -15,6 +15,11 @@ The following documentation is to help you set up and deploy a ScalarDB environm
 * [How to install Scalar products through Azure Marketplace](AzureMarketplaceGuide.md)
 * [Create a bastion server](CreateBastionServer.md)
 
+## Container image guides
+
+* [How to get the container images of Scalar products](HowToGetContainerImages.md)
+* [How to use the container images](HowToUseContainerImages.md)
+
 ## Deployment guides
 
 * [Deploy ScalarDB Cluster on Amazon Elastic Kubernetes Service (EKS)](ManualDeploymentGuideScalarDBClusterOnEKS.md)

--- a/docs/3.9/scalar-kubernetes/deploy-kubernetes.md
+++ b/docs/3.9/scalar-kubernetes/deploy-kubernetes.md
@@ -15,6 +15,11 @@ The following documentation is to help you set up and deploy a ScalarDB environm
 * [How to install Scalar products through Azure Marketplace](AzureMarketplaceGuide.md)
 * [Create a bastion server](CreateBastionServer.md)
 
+## Container image guides
+
+* [How to get the container images of Scalar products](HowToGetContainerImages.md)
+* [How to use the container images](HowToUseContainerImages.md)
+
 ## Deployment guides
 
 * [Deploy ScalarDB Cluster on Amazon Elastic Kubernetes Service (EKS)](ManualDeploymentGuideScalarDBClusterOnEKS.md)

--- a/docs/latest/scalar-kubernetes/deploy-kubernetes.md
+++ b/docs/latest/scalar-kubernetes/deploy-kubernetes.md
@@ -15,6 +15,11 @@ The following documentation is to help you set up and deploy a ScalarDB environm
 * [How to install Scalar products through Azure Marketplace](AzureMarketplaceGuide.md)
 * [Create a bastion server](CreateBastionServer.md)
 
+## Container image guides
+
+* [How to get the container images of Scalar products](HowToGetContainerImages.md)
+* [How to use the container images](HowToUseContainerImages.md)
+
 ## Deployment guides
 
 * [Deploy ScalarDB Cluster on Amazon Elastic Kubernetes Service (EKS)](ManualDeploymentGuideScalarDBClusterOnEKS.md)


### PR DESCRIPTION
## Description

This PR adds links to new container images docs to the Kubernetes deploy doc across supported versions.

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-scalardb/pull/211
- https://github.com/scalar-labs/docs-scalardb/pull/209
- https://github.com/scalar-labs/docs-scalardb/pull/208
- https://github.com/scalar-labs/docs-scalardb/pull/207
- https://github.com/scalar-labs/docs-scalardb/pull/205
- https://github.com/scalar-labs/docs-scalardb/pull/204

## Changes made

- Added a `Container image guides` section to the `Deploying ScalarDB on Managed Kubernetes Services` doc across supported versions.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A