### PR TITLE
Fix Markdown file extension for GitHub links

### DIFF
--- a/docs/scalardb-benchmarks/README.mdx
+++ b/docs/scalardb-benchmarks/README.mdx
@@ -23,7 +23,7 @@ This tutorial describes how to run benchmarking tools for ScalarDB. Database ben
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.
 - A client to run the benchmarking tools
 - A target database
-  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.mdx).
+  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
 :::note
 
@@ -59,9 +59,9 @@ $ ./gradlew shadowJar
 
 ### Load the schema
 
-Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
+Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
 
-In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx).
+In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md).
 
 After applying the schema and configuring the properties file, select a benchmark and follow the instructions to create the tables.
 

--- a/docs/scalardb-cluster-dotnet-client-sdk/getting-started-with-auth.mdx
+++ b/docs/scalardb-cluster-dotnet-client-sdk/getting-started-with-auth.mdx
@@ -1,6 +1,6 @@
 # Getting Started with ScalarDB Auth by Using ScalarDB Cluster .NET Client SDK
 
-The ScalarDB Cluster .NET Client SDK supports [ScalarDB Auth](https://github.com/scalar-labs/scalardb-cluster/blob/main/docs/scalardb-auth-with-sql.mdx), which allows you to authenticate and authorize your requests to ScalarDB Cluster.
+The ScalarDB Cluster .NET Client SDK supports [ScalarDB Auth](https://github.com/scalar-labs/scalardb-cluster/blob/main/docs/scalardb-auth-with-sql.md), which allows you to authenticate and authorize your requests to ScalarDB Cluster.
 
 ## Set credentials in `ScalarDbOptions`
 

--- a/docs/scalardb-cluster/developer-guide-for-scalardb-cluster-with-java-api.mdx
+++ b/docs/scalardb-cluster/developer-guide-for-scalardb-cluster-with-java-api.mdx
@@ -112,7 +112,7 @@ scalar.db.contact_points=direct-kubernetes:ns/scalardb-cluster
 ### Schema Loader for Cluster
 
 To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster).
-Using the Schema Loader for Cluster is basically the same as using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different.
+Using the Schema Loader for Cluster is basically the same as using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different.
 You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.12.1).
 After downloading the JAR file, you can run Schema Loader for Cluster with the following command:
 
@@ -149,7 +149,7 @@ This section describes how to use ScalarDB Cluster SQL though JDBC and Spring Da
 
 ### ScalarDB Cluster SQL via JDBC
 
-Using ScalarDB Cluster SQL via JDBC is almost the same using [ScalarDB JDBC](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx) except for how to add the JDBC driver to your project.
+Using ScalarDB Cluster SQL via JDBC is almost the same using [ScalarDB JDBC](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md) except for how to add the JDBC driver to your project.
 
 In addition to adding the ScalarDB Cluster Java Client SDK as described in [Add ScalarDB Cluster Java Client SDK to your build](#add-scalardb-cluster-java-client-sdk-to-your-build), you need to add the following dependencies to your project:
 
@@ -180,11 +180,11 @@ To add the dependencies by using Maven, use the following:
 ```
 
 Other than that, using ScalarDB Cluster SQL via JDBC is the same as using ScalarDB JDBC.
-For details about ScalarDB JDBC, see [ScalarDB JDBC Guide](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx).
+For details about ScalarDB JDBC, see [ScalarDB JDBC Guide](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md).
 
 ### ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB
 
-Similar to ScalarDB Cluster SQL via JDBC, using ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB is almost the same as using [Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx) except for how to add it to your project.
+Similar to ScalarDB Cluster SQL via JDBC, using ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB is almost the same as using [Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md) except for how to add it to your project.
 
 In addition to adding the ScalarDB Cluster Java Client SDK as described in [Add ScalarDB Cluster Java Client SDK to your build](#add-scalardb-cluster-java-client-sdk-to-your-build), you need to add the following dependencies to your project:
 
@@ -215,7 +215,7 @@ To add the dependencies by using Maven, use the following:
 ```
 
 Other than that, using ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB is the same as using Spring Data JDBC for ScalarDB.
-For details about Spring Data JDBC for ScalarDB, see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details about Spring Data JDBC for ScalarDB, see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ### ScalarDB Cluster SQL client configurations
 
@@ -243,15 +243,15 @@ scalar.db.sql.connection_mode=cluster
 scalar.db.sql.cluster_mode.contact_points=direct-kubernetes:ns/scalardb-cluster
 ```
 
-For details about how to configure ScalarDB JDBC, see [JDBC connection URL](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx#jdbc-connection-url).
+For details about how to configure ScalarDB JDBC, see [JDBC connection URL](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md#jdbc-connection-url).
 
-For details about how to configure Spring Data JDBC for ScalarDB, see [Configurations](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx#configurations).
+For details about how to configure Spring Data JDBC for ScalarDB, see [Configurations](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md#configurations).
 
 ### SQL CLI for Cluster
 
 You need to use the dedicated SQL CLI for ScalarDB Cluster (SQL CLI for Cluster).
 
-Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.mdx) except the name of the JAR file is different.
+Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.md) except the name of the JAR file is different.
 You can download the SQL CLI for Cluster from [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.12.1).
 After downloading the JAR file, you can run SQL CLI for Cluster with the following command:
 

--- a/docs/scalardb-cluster/getting-started-with-scalardb-cluster-graphql.mdx
+++ b/docs/scalardb-cluster/getting-started-with-scalardb-cluster-graphql.mdx
@@ -107,7 +107,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 ## Step 3. Load a schema
 
 To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster).
-Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different.
+Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different.
 You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.12.1).
 After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
 

--- a/docs/scalardb-cluster/getting-started-with-scalardb-cluster-sql-jdbc.mdx
+++ b/docs/scalardb-cluster/getting-started-with-scalardb-cluster-sql-jdbc.mdx
@@ -105,7 +105,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 ## Step 4. Load a schema
 
 To load a schema via ScalarDB Cluster SQL, you need to use the dedicated SQL CLI for ScalarDB Cluster (SQL CLI for Cluster).
-Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.mdx) except the name of the JAR file is different.
+Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.md) except the name of the JAR file is different.
 You can download the SQL CLI for Cluster from [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.12.1).
 After downloading the JAR file, you can use SQL CLI for Cluster by running the following command:
 

--- a/docs/scalardb-cluster/getting-started-with-scalardb-cluster-sql-spring-data-jdbc.mdx
+++ b/docs/scalardb-cluster/getting-started-with-scalardb-cluster-sql-spring-data-jdbc.mdx
@@ -105,7 +105,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 ## Step 4. Load a schema
 
 To load a schema via ScalarDB Cluster SQL, you need to use the dedicated SQL CLI for ScalarDB Cluster (SQL CLI for Cluster).
-Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.mdx) except the name of the JAR file is different.
+Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.md) except the name of the JAR file is different.
 You can download the SQL CLI for Cluster from [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.12.1).
 After downloading the JAR file, you can run SQL CLI for Cluster with the following command:
 

--- a/docs/scalardb-cluster/getting-started-with-scalardb-cluster.mdx
+++ b/docs/scalardb-cluster/getting-started-with-scalardb-cluster.mdx
@@ -4,7 +4,7 @@ This tutorial describes how to create a sample application that uses [ScalarDB C
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample/README.mdx) but takes advantage of ScalarDB Cluster.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample/README.md) but takes advantage of ScalarDB Cluster.
 
 The following diagram shows the system architecture of the sample application:
 

--- a/docs/scalardb-cluster/getting-started-with-using-go-for-scalardb-cluster.mdx
+++ b/docs/scalardb-cluster/getting-started-with-using-go-for-scalardb-cluster.mdx
@@ -62,7 +62,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 
 ## Step 3. Load a schema
 
-To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
+To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
 
 ```shell
 $ java -jar scalardb-cluster-schema-loader-3.12.2-all.jar --config database.properties -f schema.json --coordinator

--- a/docs/scalardb-cluster/getting-started-with-using-python-for-scalardb-cluster.mdx
+++ b/docs/scalardb-cluster/getting-started-with-using-python-for-scalardb-cluster.mdx
@@ -62,7 +62,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 
 ## Step 3. Load a schema
 
-To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
+To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
 
 ```shell
 $ java -jar scalardb-cluster-schema-loader-3.12.2-all.jar --config database.properties -f schema.json --coordinator

--- a/docs/scalardb-cluster/scalardb-auth-with-sql.mdx
+++ b/docs/scalardb-cluster/scalardb-auth-with-sql.mdx
@@ -6,7 +6,7 @@ This document describes how to use ScalarDB Auth with ScalarDB SQL.
 
 ## ScalarDB Auth Overview
 
-By using ScalarDB Auth, you can create users and grant or revoke their privileges. You can create a user by using the `CREATE USER` command, and you can grant or revoke one's privileges on a table or a namespace by using the `GRANT` or `REVOKE` command, respectively. For details about such data control language (DCL) commands, see [DCL](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.mdx#dcl).
+By using ScalarDB Auth, you can create users and grant or revoke their privileges. You can create a user by using the `CREATE USER` command, and you can grant or revoke one's privileges on a table or a namespace by using the `GRANT` or `REVOKE` command, respectively. For details about such data control language (DCL) commands, see [DCL](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.md#dcl).
 
 Users can log in to ScalarDB Cluster with a username and a password and execute SQL statements if they have the required privileges.
 

--- a/docs/scalardb-cluster/scalardb-cluster-configurations.mdx
+++ b/docs/scalardb-cluster/scalardb-cluster-configurations.mdx
@@ -3,7 +3,7 @@
 This document describes the configurations for ScalarDB Cluster.
 ScalarDB Cluster consists of multiple cluster nodes, and you need to configure each cluster node.
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), you can configure the following configurations for each cluster node.
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), you can configure the following configurations for each cluster node.
 
 ## Basic configurations
 

--- a/docs/scalardb-cluster/scalardb-cluster-sql-grpc-api-guide.mdx
+++ b/docs/scalardb-cluster/scalardb-cluster-sql-grpc-api-guide.mdx
@@ -51,7 +51,7 @@ By calling `Begin`, you receive a transaction ID in the response, which you can 
 Also, you can call `Execute` without a transaction ID to execute a one-shot transaction.
 In this case, the transaction is automatically committed after it is executed.
 You can use this method to execute DDL statements as well.
-For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.mdx).
+For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.md).
 Please note, however, that `Execute` supports only DML and DDL statements.
 
 When you call `Begin`, you can optionally specify a transaction ID.
@@ -126,7 +126,7 @@ By calling `Begin` or `Join`, you receive a transaction ID in the response, whic
 
 In addition, you can call `Execute` without a transaction ID to execute a one-shot transaction.
 In this case, the transaction is automatically committed after it is executed.
-You can use this method to execute DDL statements as well. For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.mdx).
+You can use this method to execute DDL statements as well. For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.md).
 Please note, however, that `Execute` supports only DML and DDL statements.
 
 When you call `Begin`, you can optionally specify a transaction ID.

--- a/docs/scalardb-graphql/aws-deployment-guide.mdx
+++ b/docs/scalardb-graphql/aws-deployment-guide.mdx
@@ -26,7 +26,7 @@ In this document, a placeholder cluster name `<your-cluster-name>` will be used 
 
 We need to load a database schema to the database before starting ScalarDB GraphQL.
 
-Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx).
+Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md).
 
 1. Create a `database.properties` configuration file for DynamoDB
 

--- a/docs/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
+++ b/docs/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/docs/scalardb-graphql/index.mdx
+++ b/docs/scalardb-graphql/index.mdx
@@ -12,7 +12,7 @@ To build and install the ScalarDB GraphQL Server, use `./gradlew installDist`, w
 
 ## Run
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), the GraphQL server reads the following:
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), the GraphQL server reads the following:
 
 * `scalar.db.graphql.port` ... Port number for GraphQL server. The default is `8080`.
 * `scalar.db.graphql.path` ... Path component of the URL of the GraphQL endpoint. The default is `/graphql`.

--- a/docs/scalardb-samples/microservice-transaction-sample/README.mdx
+++ b/docs/scalardb-samples/microservice-transaction-sample/README.mdx
@@ -4,7 +4,7 @@ This tutorial describes how to create a sample application that supports microse
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) when using ScalarDB.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) when using ScalarDB.
 
 The sample application has two microservices called the *Customer Service* and the *Order Service* based on the [database-per-service pattern](https://microservices.io/patterns/data/database-per-service.html):
 

--- a/docs/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
+++ b/docs/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
@@ -19,7 +19,7 @@ The database that you will be using in the sample application is Cassandra. Alth
 
 :::note
 
-Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx#handle-sqlexception).
+Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md#handle-sqlexception).
 
 :::
 

--- a/docs/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
+++ b/docs/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
@@ -2,7 +2,7 @@
 
 This tutorial describes how to create a sample Spring Boot application for microservice transactions by using Spring Data JDBC for ScalarDB.
 
-For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ## Prerequisites
 

--- a/docs/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
+++ b/docs/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB with Multi-storage Transaction.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB with Multi-storage Transaction.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ![Overview](images/overview.png)
 

--- a/docs/scalardb-samples/spring-data-sample/README.mdx
+++ b/docs/scalardb-samples/spring-data-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ### Schema
 

--- a/docs/scalardb-sql/configurations.mdx
+++ b/docs/scalardb-sql/configurations.mdx
@@ -33,7 +33,7 @@ The configurations for Direct mode are as follows:
 | `scalar.db.sql.statement_cache.size`    | Maximum number of cached statements. | `100`   |
 
 Note that in Direct mode, you need to configure the transaction manager, as well.
-For details about configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations).
+For details about configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations).
 
 In addition, for details about ScalarDB SQL Server, see [ScalarDB SQL Server](sql-server.mdx).
 
@@ -54,7 +54,7 @@ The configurations for Server mode are as follows:
 ScalarDB SQL Server is a gRPC server that implements the ScalarDB SQL interface.
 This section explains the ScalarDB SQL Server configurations.
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), the following configurations are available for ScalarDB SQL Server:
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), the following configurations are available for ScalarDB SQL Server:
 
 | Name                                             | Description                                      | Default                |
 |--------------------------------------------------|--------------------------------------------------|------------------------|

--- a/docs/scalardb-sql/getting-started-with-jdbc.mdx
+++ b/docs/scalardb-sql/getting-started-with-jdbc.mdx
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with ScalarDB JDBC with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for ScalarDB exists.
 
@@ -222,7 +222,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how ScalarDB JDBC is used. For more information, please take a look at the following documents.
 
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB JDBC Guide](jdbc-guide.mdx)
 * [ScalarDB SQL Grammar](grammar.mdx)
 * [ScalarDB SQL Command Line interface](command-line-interface.mdx)

--- a/docs/scalardb-sql/getting-started-with-sql.mdx
+++ b/docs/scalardb-sql/getting-started-with-sql.mdx
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with ScalarDB SQL with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for ScalarDB exists.
 
@@ -210,7 +210,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how ScalarDB SQL is used. For more information, please take a look at the following documents.
 
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL API Guide](sql-api-guide.mdx)
 * [ScalarDB SQL Grammar](grammar.mdx)
 * [ScalarDB SQL Command Line interface](command-line-interface.mdx)

--- a/docs/scalardb-sql/grammar.mdx
+++ b/docs/scalardb-sql/grammar.mdx
@@ -95,7 +95,7 @@ CreateNamespaceStatement statement3 =
 
 The `CREATE TABLE` command creates a table.
 
-For details about the ScalarDB data model, see [ScalarDB Design Document](https://github.com/scalar-labs/scalardb/blob/master/docs/design.mdx).
+For details about the ScalarDB data model, see [ScalarDB Design Document](https://github.com/scalar-labs/scalardb/blob/master/docs/design.md).
 
 #### Grammar
 
@@ -762,7 +762,7 @@ SelectStatement statement4 =
 
 ### SELECT (with cross-partition scan)
 
-By enabling the cross-partition scan option, the `SELECT` command can retrieve all records across partitions without specifying the `WHERE` clause. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
+By enabling the cross-partition scan option, the `SELECT` command can retrieve all records across partitions without specifying the `WHERE` clause. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
 
 :::warning
 
@@ -828,7 +828,7 @@ SelectStatement statement2 =
 
 ### SELECT (with cross-partition scan filtering and ordering)
 
-By enabling the cross-partition scan option with filtering and ordering, the `SELECT` command can flexibly retrieve records across partitions with arbitrary conditions and orderings. Currently, the options are valid only for JDBC databases. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
+By enabling the cross-partition scan option with filtering and ordering, the `SELECT` command can flexibly retrieve records across partitions with arbitrary conditions and orderings. Currently, the options are valid only for JDBC databases. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
 
 #### Grammar
 
@@ -1258,7 +1258,7 @@ UpdateStatement statement2 =
 
 ### UPDATE (with cross-partition scan)
 
-By enabling the cross-partition scan option, the `UPDATE` command can update all records across partitions without specifying the `WHERE` clause. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
+By enabling the cross-partition scan option, the `UPDATE` command can update all records across partitions without specifying the `WHERE` clause. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
 
 :::warning
 
@@ -1315,7 +1315,7 @@ UpdateStatement statement =
 
 ### UPDATE (with cross-partition scan filtering)
 
-By enabling the cross-partition scan option with filtering, the `UPDATE` command can flexibly update records across partitions with arbitrary conditions. Currently, the option is valid only for JDBC databases. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
+By enabling the cross-partition scan option with filtering, the `UPDATE` command can flexibly update records across partitions with arbitrary conditions. Currently, the option is valid only for JDBC databases. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
 
 #### Grammar
 
@@ -1530,7 +1530,7 @@ DeleteStatement statement2 =
 
 ### DELETE (with cross-partition scan)
 
-By enabling the cross-partition scan option, the `DELETE` command can delete all records across partitions without specifying the `WHERE` clause. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
+By enabling the cross-partition scan option, the `DELETE` command can delete all records across partitions without specifying the `WHERE` clause. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
 
 :::warning
 
@@ -1579,7 +1579,7 @@ DeleteStatement statement = StatementBuilder.deleteFrom("ns", "tbl").build();
 
 ### DELETE (with cross-partition scan filtering)
 
-By enabling the cross-partition scan option with filtering, the `DELETE` command can flexibly delete records across partitions with arbitrary conditions. Currently, the option is valid only for JDBC databases. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
+By enabling the cross-partition scan option with filtering, the `DELETE` command can flexibly delete records across partitions with arbitrary conditions. Currently, the option is valid only for JDBC databases. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
 
 #### Grammar
 

--- a/docs/scalardb-sql/migration-guide.mdx
+++ b/docs/scalardb-sql/migration-guide.mdx
@@ -37,11 +37,11 @@ BM===>AM
    - Follow the administration guide of your database.
 4. Set up a ScalarDB environment.
    - Prepare a configuration file so that ScalarDB can access target databases.
-   - For details about ScalarDB configurations, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx).
+   - For details about ScalarDB configurations, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md).
 5. Import your database to ScalarDB.
    - Prepare an import schema file that defines target schemas and tables. The schemas and tables will be mapped to ScalarDB namespaces and tables, respectively. Note that "schema" is a synonym for "database" in some database systems.
    - Run the ScalarDB Schema Loader with the import option, the ScalarDB configuration file that you created, and the schema file that you prepared.
-   - For details on how to use Schema Loader, see [Run Schema Loader for importing existing tables](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.mdx#run-schema-loader-for-importing-existing-tables).
+   - For details on how to use Schema Loader, see [Run Schema Loader for importing existing tables](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.md#run-schema-loader-for-importing-existing-tables).
 6. Switch your application and check the behavior.
    - Now, you can switch your application to the ScalarDB-based application.
 
@@ -49,10 +49,10 @@ BM===>AM
 
 Before starting the migration, check the following questions. If the answer to any of these questions is "No", you must address them before proceeding with the migration.
 
-- Are your target database and version one of the [supported relational databases (called JDBC databases in ScalarDB) and versions](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.mdx#jdbc-databases)?
-- Do you have a fully privileged account that can manage the target database? For details, see [Privileges to access the underlying databases](https://github.com/scalar-labs/scalardb/blob/master/docs/requirements.mdx#privileges-to-access-the-underlying-databases).
+- Are your target database and version one of the [supported relational databases (called JDBC databases in ScalarDB) and versions](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md#jdbc-databases)?
+- Do you have a fully privileged account that can manage the target database? For details, see [Privileges to access the underlying databases](https://github.com/scalar-labs/scalardb/blob/master/docs/requirements.md#privileges-to-access-the-underlying-databases).
 - Do all target tables have primary keys?
-- Is the data type of each column supported in ScalarDB? For supported data types and how they are mapped to ScalarDB data types, see [Data-type mapping from JDBC databases to ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.mdx#data-type-mapping-from-jdbc-databases-to-scalardb).
+- Is the data type of each column supported in ScalarDB? For supported data types and how they are mapped to ScalarDB data types, see [Data-type mapping from JDBC databases to ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.md#data-type-mapping-from-jdbc-databases-to-scalardb).
 - Do the functionality and grammar of the queries in your application comply with the [ScalarDB SQL specifications](./grammar.mdx)? Or, for non-compliant queries, can you re-write them for ScalarDB? For examples of re-writes, see [How to migrate your application](#how-to-migrate-your-application).
 - After migrating your applications and databases into ScalarDB applications and ScalarDB-managed databases, respectively, can you stop accessing the databases directly? In other words, is it acceptable for you to always access the databases through ScalarDB?
 
@@ -68,7 +68,7 @@ Depending on your application environment, you may need to migrate your applicat
 
 If your application is based on Java, you can use the ScalarDB JDBC driver when migrating. For details on how to add dependencies for the ScalarDB JDBC driver and rewrite the connection URL, see the [ScalarDB JDBC Guide](./jdbc-guide.mdx).
 
-If your application is not based on Java, you can connect ScalarDB and issue SQL via gRPC. For details, see [ScalarDB Cluster SQL gRPC API Guide](https://github.com/scalar-labs/scalardb-cluster/blob/main/docs/scalardb-cluster-sql-grpc-api-guide.mdx).
+If your application is not based on Java, you can connect ScalarDB and issue SQL via gRPC. For details, see [ScalarDB Cluster SQL gRPC API Guide](https://github.com/scalar-labs/scalardb-cluster/blob/main/docs/scalardb-cluster-sql-grpc-api-guide.md).
 
 ### Modify SQL statements
 
@@ -98,12 +98,12 @@ Although ScalarDB SQL does not provide some functionalities, such as aggregate q
 
 ## Limitations
 
-Due to the difference in data types, ScalarDB will throw an error when writing data larger than the maximum size of the column in the underlying database, even if the size is acceptable for the ScalarDB data type. Conversely, in a few types, the data in the underlying database may be larger than the maximum size in ScalarDB. For details, see [Data-type mapping from JDBC databases to ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.mdx#data-type-mapping-from-jdbc-databases-to-scalardb).
+Due to the difference in data types, ScalarDB will throw an error when writing data larger than the maximum size of the column in the underlying database, even if the size is acceptable for the ScalarDB data type. Conversely, in a few types, the data in the underlying database may be larger than the maximum size in ScalarDB. For details, see [Data-type mapping from JDBC databases to ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.md#data-type-mapping-from-jdbc-databases-to-scalardb).
 
 ## References
 
-- [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.mdx)
+- [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md)
 - [ScalarDB SQL API Guide](./sql-api-guide.mdx)
 - [ScalarDB JDBC Guide](./jdbc-guide.mdx)
 - [ScalarDB SQL Grammar](./grammar.mdx)
-- [Importing Existing Tables to ScalarDB by Using ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.mdx)
+- [Importing Existing Tables to ScalarDB by Using ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.md)

--- a/docs/scalardb-sql/sql-server.mdx
+++ b/docs/scalardb-sql/sql-server.mdx
@@ -81,7 +81,7 @@ scalar.db.consensus_commit.isolation_level=SNAPSHOT
 scalar.db.consensus_commit.serializable_strategy=
 ```
 
-For more details about the configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations).
+For more details about the configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations).
 
 In addition, for more details about the configurations for ScalarDB SQL Server, see [ScalarDB SQL Configurations](configurations.mdx).
 
@@ -153,5 +153,5 @@ Please see [ScalarDB SQL Configurations](configurations.mdx) for more details of
 
 * [Getting Started with ScalarDB SQL](getting-started-with-sql.mdx)
 * [Getting Started with ScalarDB JDBC](getting-started-with-jdbc.mdx)
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL Configurations](configurations.mdx)

--- a/versioned_docs/version-3.10/scalardb-benchmarks/README.mdx
+++ b/versioned_docs/version-3.10/scalardb-benchmarks/README.mdx
@@ -23,7 +23,7 @@ This tutorial describes how to run benchmarking tools for ScalarDB. Database ben
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.
 - A client to run the benchmarking tools
 - A target database
-  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.mdx).
+  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
 :::note
 
@@ -59,9 +59,9 @@ $ ./gradlew shadowJar
 
 ### Load the schema
 
-Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
+Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
 
-In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx).
+In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md).
 
 After applying the schema and configuring the properties file, select a benchmark and follow the instructions to create the tables.
 

--- a/versioned_docs/version-3.10/scalardb-cluster/developer-guide-for-scalardb-cluster-with-java-api.mdx
+++ b/versioned_docs/version-3.10/scalardb-cluster/developer-guide-for-scalardb-cluster-with-java-api.mdx
@@ -214,7 +214,7 @@ scalar.db.contact_points=direct-kubernetes:ns/scalardb-cluster
 ### Schema Loader for Cluster
 
 To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster).
-Using the Schema Loader for Cluster is basically the same as using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different.
+Using the Schema Loader for Cluster is basically the same as using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different.
 You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.10.3).
 After downloading the JAR file, you can run Schema Loader for Cluster with the following command:
 
@@ -251,7 +251,7 @@ This section describes how to use ScalarDB Cluster SQL though JDBC and Spring Da
 
 ### ScalarDB Cluster SQL via JDBC
 
-Using ScalarDB Cluster SQL via JDBC is almost the same using [ScalarDB JDBC](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx) except for how to add the JDBC driver to your project.
+Using ScalarDB Cluster SQL via JDBC is almost the same using [ScalarDB JDBC](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md) except for how to add the JDBC driver to your project.
 
 In addition to adding ScalarDB Cluster Client as described in [Add ScalarDB Cluster Client to your build](#add-scalardb-cluster-client-to-your-build), you need to add the following dependencies to your project:
 
@@ -282,11 +282,11 @@ To add the dependencies by using Maven, use the following:
 ```
 
 Other than that, using ScalarDB Cluster SQL via JDBC is the same as using ScalarDB JDBC.
-For details about ScalarDB JDBC, see [ScalarDB JDBC Guide](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx).
+For details about ScalarDB JDBC, see [ScalarDB JDBC Guide](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md).
 
 ### ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB
 
-Similar to ScalarDB Cluster SQL via JDBC, using ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB is almost the same as using [Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx) except for how to add it to your project.
+Similar to ScalarDB Cluster SQL via JDBC, using ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB is almost the same as using [Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md) except for how to add it to your project.
 
 In addition to adding ScalarDB Cluster Client as described in [Add ScalarDB Cluster Client to your build](#add-scalardb-cluster-client-to-your-build), you need to add the following dependencies to your project:
 
@@ -317,7 +317,7 @@ To add the dependencies by using Maven, use the following:
 ```
 
 Other than that, using ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB is the same as using Spring Data JDBC for ScalarDB.
-For details about Spring Data JDBC for ScalarDB, see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details about Spring Data JDBC for ScalarDB, see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ### Client configurations
 
@@ -345,16 +345,16 @@ scalar.db.sql.connection_mode=cluster
 scalar.db.sql.cluster_mode.contact_points=direct-kubernetes:ns/scalardb-cluster
 ```
 
-For details about how to configure ScalarDB JDBC, see [JDBC connection URL](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx#jdbc-connection-url).
+For details about how to configure ScalarDB JDBC, see [JDBC connection URL](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md#jdbc-connection-url).
 
-For details about how to configure Spring Data JDBC for ScalarDB, see [Configurations](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx#configurations).
+For details about how to configure Spring Data JDBC for ScalarDB, see [Configurations](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md#configurations).
 
 
 ### SQL CLI for Cluster
 
 You need to use the dedicated SQL CLI for ScalarDB Cluster (SQL CLI for Cluster).
 
-Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.mdx) except the name of the JAR file is different.
+Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.md) except the name of the JAR file is different.
 You can download the SQL CLI for Cluster from [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.10.3).
 After downloading the JAR file, you can run SQL CLI for Cluster with the following command:
 

--- a/versioned_docs/version-3.10/scalardb-cluster/getting-started-with-scalardb-cluster-graphql.mdx
+++ b/versioned_docs/version-3.10/scalardb-cluster/getting-started-with-scalardb-cluster-graphql.mdx
@@ -99,7 +99,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 ## Step 3. Load a schema
 
 To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster).
-Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different.
+Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different.
 You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.10.3).
 After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
 

--- a/versioned_docs/version-3.10/scalardb-cluster/getting-started-with-scalardb-cluster-sql-jdbc.mdx
+++ b/versioned_docs/version-3.10/scalardb-cluster/getting-started-with-scalardb-cluster-sql-jdbc.mdx
@@ -132,7 +132,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 ## Step 4. Load a schema
 
 To load a schema via ScalarDB Cluster SQL, you need to use the dedicated SQL CLI for ScalarDB Cluster (SQL CLI for Cluster).
-Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.mdx) except the name of the JAR file is different.
+Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.md) except the name of the JAR file is different.
 You can download the SQL CLI for Cluster from [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.10.3).
 After downloading the JAR file, you can use SQL CLI for Cluster by running the following command:
 

--- a/versioned_docs/version-3.10/scalardb-cluster/getting-started-with-scalardb-cluster-sql-spring-data-jdbc.mdx
+++ b/versioned_docs/version-3.10/scalardb-cluster/getting-started-with-scalardb-cluster-sql-spring-data-jdbc.mdx
@@ -132,7 +132,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 ## Step 4. Load a schema
 
 To load a schema via ScalarDB Cluster SQL, you need to use the dedicated SQL CLI for ScalarDB Cluster (SQL CLI for Cluster).
-Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.mdx) except the name of the JAR file is different.
+Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.md) except the name of the JAR file is different.
 You can download the SQL CLI for Cluster from [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.10.3).
 After downloading the JAR file, you can run SQL CLI for Cluster with the following command:
 

--- a/versioned_docs/version-3.10/scalardb-cluster/getting-started-with-scalardb-cluster.mdx
+++ b/versioned_docs/version-3.10/scalardb-cluster/getting-started-with-scalardb-cluster.mdx
@@ -7,7 +7,7 @@ This tutorial describes how to create a sample application that uses [ScalarDB C
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample/README.mdx) but takes advantage of ScalarDB Cluster.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample/README.md) but takes advantage of ScalarDB Cluster.
 
 The following diagram shows the system architecture of the sample application:
 

--- a/versioned_docs/version-3.10/scalardb-cluster/getting-started-with-using-go-for-scalardb-cluster.mdx
+++ b/versioned_docs/version-3.10/scalardb-cluster/getting-started-with-using-go-for-scalardb-cluster.mdx
@@ -67,7 +67,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 
 ## Step 3. Load a schema
 
-To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
+To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
 
 ```shell
 $ java -jar scalardb-cluster-schema-loader-3.10.3-all.jar --config database.properties -f schema.json --coordinator

--- a/versioned_docs/version-3.10/scalardb-cluster/getting-started-with-using-python-for-scalardb-cluster.mdx
+++ b/versioned_docs/version-3.10/scalardb-cluster/getting-started-with-using-python-for-scalardb-cluster.mdx
@@ -67,7 +67,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 
 ## Step 3. Load a schema
 
-To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
+To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
 
 ```shell
 $ java -jar scalardb-cluster-schema-loader-3.10.3-all.jar --config database.properties -f schema.json --coordinator

--- a/versioned_docs/version-3.10/scalardb-cluster/scalardb-cluster-configurations.mdx
+++ b/versioned_docs/version-3.10/scalardb-cluster/scalardb-cluster-configurations.mdx
@@ -3,7 +3,7 @@
 This document describes the configurations for ScalarDB Cluster.
 ScalarDB Cluster consists of multiple cluster nodes, and you need to configure each cluster node.
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), you can configure the following configurations for each cluster node.
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), you can configure the following configurations for each cluster node.
 
 ## Basic configurations
 

--- a/versioned_docs/version-3.10/scalardb-cluster/scalardb-cluster-sql-grpc-api-guide.mdx
+++ b/versioned_docs/version-3.10/scalardb-cluster/scalardb-cluster-sql-grpc-api-guide.mdx
@@ -51,7 +51,7 @@ By calling `Begin`, you receive a transaction ID in the response, which you can 
 Also, you can call `Execute` without a transaction ID to execute a one-shot transaction.
 In this case, the transaction is automatically committed after it is executed.
 You can use this method to execute DDL statements as well.
-For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.mdx).
+For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.md).
 Please note, however, that `Execute` supports only DML and DDL statements.
 
 When you call `Begin`, you can optionally specify a transaction ID.
@@ -126,7 +126,7 @@ By calling `Begin` or `Join`, you receive a transaction ID in the response, whic
 
 In addition, you can call `Execute` without a transaction ID to execute a one-shot transaction.
 In this case, the transaction is automatically committed after it is executed.
-You can use this method to execute DDL statements as well. For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.mdx).
+You can use this method to execute DDL statements as well. For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.md).
 Please note, however, that `Execute` supports only DML and DDL statements.
 
 When you call `Begin`, you can optionally specify a transaction ID.

--- a/versioned_docs/version-3.10/scalardb-graphql/aws-deployment-guide.mdx
+++ b/versioned_docs/version-3.10/scalardb-graphql/aws-deployment-guide.mdx
@@ -26,7 +26,7 @@ In this document, a placeholder cluster name `<your-cluster-name>` will be used 
 
 We need to load a database schema to the database before starting ScalarDB GraphQL.
 
-Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx).
+Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md).
 
 1. Create a `database.properties` configuration file for DynamoDB
 

--- a/versioned_docs/version-3.10/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
+++ b/versioned_docs/version-3.10/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.mdx) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/versioned_docs/version-3.10/scalardb-graphql/index.mdx
+++ b/versioned_docs/version-3.10/scalardb-graphql/index.mdx
@@ -12,7 +12,7 @@ To build and install the ScalarDB GraphQL Server, use `./gradlew installDist`, w
 
 ## Run
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), the GraphQL server reads the following:
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), the GraphQL server reads the following:
 
 * `scalar.db.graphql.port` ... Port number for GraphQL server. The default is `8080`.
 * `scalar.db.graphql.path` ... Path component of the URL of the GraphQL endpoint. The default is `/graphql`.

--- a/versioned_docs/version-3.10/scalardb-samples/microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.10/scalardb-samples/microservice-transaction-sample/README.mdx
@@ -4,7 +4,7 @@ This tutorial describes how to create a sample application that supports microse
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) when using ScalarDB.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) when using ScalarDB.
 
 The sample application has two microservices called the *Customer Service* and the *Order Service* based on the [database-per-service pattern](https://microservices.io/patterns/data/database-per-service.html):
 

--- a/versioned_docs/version-3.10/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
+++ b/versioned_docs/version-3.10/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
@@ -19,7 +19,7 @@ The database that you will be using in the sample application is Cassandra. Alth
 
 :::note
 
-Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx#handle-sqlexception).
+Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md#handle-sqlexception).
 
 :::
 

--- a/versioned_docs/version-3.10/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.10/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
@@ -2,7 +2,7 @@
 
 This tutorial describes how to create a sample Spring Boot application for microservice transactions by using Spring Data JDBC for ScalarDB.
 
-For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ## Prerequisites
 

--- a/versioned_docs/version-3.10/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.10/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB with Multi-storage Transaction.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB with Multi-storage Transaction.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ![Overview](images/overview.png)
 

--- a/versioned_docs/version-3.10/scalardb-samples/spring-data-sample/README.mdx
+++ b/versioned_docs/version-3.10/scalardb-samples/spring-data-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ### Schema
 

--- a/versioned_docs/version-3.10/scalardb-sql/configurations.mdx
+++ b/versioned_docs/version-3.10/scalardb-sql/configurations.mdx
@@ -33,7 +33,7 @@ The configurations for Direct mode are as follows:
 | `scalar.db.sql.statement_cache.size`    | Maximum number of cached statements. | `100`   |
 
 Note that in Direct mode, you need to configure the transaction manager, as well.
-For details about configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations).
+For details about configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations).
 
 In addition, for details about ScalarDB SQL Server, see [ScalarDB SQL Server](sql-server.mdx).
 
@@ -54,7 +54,7 @@ The configurations for Server mode are as follows:
 ScalarDB SQL Server is a gRPC server that implements the ScalarDB SQL interface.
 This section explains the ScalarDB SQL Server configurations.
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), the following configurations are available for ScalarDB SQL Server:
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), the following configurations are available for ScalarDB SQL Server:
 
 | Name                                             | Description                                      | Default                |
 |--------------------------------------------------|--------------------------------------------------|------------------------|

--- a/versioned_docs/version-3.10/scalardb-sql/getting-started-with-jdbc.mdx
+++ b/versioned_docs/version-3.10/scalardb-sql/getting-started-with-jdbc.mdx
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with ScalarDB JDBC with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for ScalarDB exists.
 
@@ -222,7 +222,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how ScalarDB JDBC is used. For more information, please take a look at the following documents.
 
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB JDBC Guide](jdbc-guide.mdx)
 * [ScalarDB SQL Grammar](grammar.mdx)
 * [ScalarDB SQL Command Line interface](command-line-interface.mdx)

--- a/versioned_docs/version-3.10/scalardb-sql/getting-started-with-sql.mdx
+++ b/versioned_docs/version-3.10/scalardb-sql/getting-started-with-sql.mdx
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with ScalarDB SQL with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for ScalarDB exists.
 
@@ -210,7 +210,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how ScalarDB SQL is used. For more information, please take a look at the following documents.
 
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL API Guide](sql-api-guide.mdx)
 * [ScalarDB SQL Grammar](grammar.mdx)
 * [ScalarDB SQL Command Line interface](command-line-interface.mdx)

--- a/versioned_docs/version-3.10/scalardb-sql/grammar.mdx
+++ b/versioned_docs/version-3.10/scalardb-sql/grammar.mdx
@@ -86,7 +86,7 @@ CreateNamespaceStatement statement3 =
 
 `CREATE TABLE` command creates a table.
 
-Please see [ScalarDB design document - Data Model](https://github.com/scalar-labs/scalardb/blob/master/docs/design.mdx#data-model) for the details of the ScalarDB Data Model.
+Please see [ScalarDB design document - Data Model](https://github.com/scalar-labs/scalardb/blob/master/docs/design.md#data-model) for the details of the ScalarDB Data Model.
 
 #### Grammar
 

--- a/versioned_docs/version-3.10/scalardb-sql/sql-server.mdx
+++ b/versioned_docs/version-3.10/scalardb-sql/sql-server.mdx
@@ -81,7 +81,7 @@ scalar.db.consensus_commit.isolation_level=SNAPSHOT
 scalar.db.consensus_commit.serializable_strategy=
 ```
 
-For more details about the configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations).
+For more details about the configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations).
 
 In addition, for more details about the configurations for ScalarDB SQL Server, see [ScalarDB SQL Configurations](configurations.mdx).
 
@@ -153,5 +153,5 @@ Please see [ScalarDB SQL Configurations](configurations.mdx) for more details of
 
 * [Getting Started with ScalarDB SQL](getting-started-with-sql.mdx)
 * [Getting Started with ScalarDB JDBC](getting-started-with-jdbc.mdx)
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL Configurations](configurations.mdx)

--- a/versioned_docs/version-3.11/scalardb-benchmarks/README.mdx
+++ b/versioned_docs/version-3.11/scalardb-benchmarks/README.mdx
@@ -23,7 +23,7 @@ This tutorial describes how to run benchmarking tools for ScalarDB. Database ben
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.
 - A client to run the benchmarking tools
 - A target database
-  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.mdx).
+  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
 :::note
 
@@ -59,9 +59,9 @@ $ ./gradlew shadowJar
 
 ### Load the schema
 
-Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
+Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
 
-In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx).
+In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md).
 
 After applying the schema and configuring the properties file, select a benchmark and follow the instructions to create the tables.
 

--- a/versioned_docs/version-3.11/scalardb-cluster-dotnet-client-sdk/getting-started-with-auth.mdx
+++ b/versioned_docs/version-3.11/scalardb-cluster-dotnet-client-sdk/getting-started-with-auth.mdx
@@ -1,6 +1,6 @@
 # Getting Started with ScalarDB Auth by Using ScalarDB Cluster .NET Client SDK
 
-The ScalarDB Cluster .NET Client SDK supports [ScalarDB Auth](https://github.com/scalar-labs/scalardb-cluster/blob/main/docs/scalardb-auth-with-sql.mdx), which allows you to authenticate and authorize your requests to ScalarDB Cluster.
+The ScalarDB Cluster .NET Client SDK supports [ScalarDB Auth](https://github.com/scalar-labs/scalardb-cluster/blob/main/docs/scalardb-auth-with-sql.md), which allows you to authenticate and authorize your requests to ScalarDB Cluster.
 
 ## Set credentials in `ScalarDbOptions`
 

--- a/versioned_docs/version-3.11/scalardb-cluster/developer-guide-for-scalardb-cluster-with-java-api.mdx
+++ b/versioned_docs/version-3.11/scalardb-cluster/developer-guide-for-scalardb-cluster-with-java-api.mdx
@@ -112,7 +112,7 @@ scalar.db.contact_points=direct-kubernetes:ns/scalardb-cluster
 ### Schema Loader for Cluster
 
 To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster).
-Using the Schema Loader for Cluster is basically the same as using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different.
+Using the Schema Loader for Cluster is basically the same as using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different.
 You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.11.1).
 After downloading the JAR file, you can run Schema Loader for Cluster with the following command:
 
@@ -149,7 +149,7 @@ This section describes how to use ScalarDB Cluster SQL though JDBC and Spring Da
 
 ### ScalarDB Cluster SQL via JDBC
 
-Using ScalarDB Cluster SQL via JDBC is almost the same using [ScalarDB JDBC](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx) except for how to add the JDBC driver to your project.
+Using ScalarDB Cluster SQL via JDBC is almost the same using [ScalarDB JDBC](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md) except for how to add the JDBC driver to your project.
 
 In addition to adding the ScalarDB Cluster Java Client SDK as described in [Add ScalarDB Cluster Java Client SDK to your build](#add-scalardb-cluster-java-client-sdk-to-your-build), you need to add the following dependencies to your project:
 
@@ -180,11 +180,11 @@ To add the dependencies by using Maven, use the following:
 ```
 
 Other than that, using ScalarDB Cluster SQL via JDBC is the same as using ScalarDB JDBC.
-For details about ScalarDB JDBC, see [ScalarDB JDBC Guide](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx).
+For details about ScalarDB JDBC, see [ScalarDB JDBC Guide](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md).
 
 ### ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB
 
-Similar to ScalarDB Cluster SQL via JDBC, using ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB is almost the same as using [Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx) except for how to add it to your project.
+Similar to ScalarDB Cluster SQL via JDBC, using ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB is almost the same as using [Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md) except for how to add it to your project.
 
 In addition to adding the ScalarDB Cluster Java Client SDK as described in [Add ScalarDB Cluster Java Client SDK to your build](#add-scalardb-cluster-java-client-sdk-to-your-build), you need to add the following dependencies to your project:
 
@@ -215,7 +215,7 @@ To add the dependencies by using Maven, use the following:
 ```
 
 Other than that, using ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB is the same as using Spring Data JDBC for ScalarDB.
-For details about Spring Data JDBC for ScalarDB, see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details about Spring Data JDBC for ScalarDB, see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ### ScalarDB Cluster SQL client configurations
 
@@ -243,15 +243,15 @@ scalar.db.sql.connection_mode=cluster
 scalar.db.sql.cluster_mode.contact_points=direct-kubernetes:ns/scalardb-cluster
 ```
 
-For details about how to configure ScalarDB JDBC, see [JDBC connection URL](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx#jdbc-connection-url).
+For details about how to configure ScalarDB JDBC, see [JDBC connection URL](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md#jdbc-connection-url).
 
-For details about how to configure Spring Data JDBC for ScalarDB, see [Configurations](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx#configurations).
+For details about how to configure Spring Data JDBC for ScalarDB, see [Configurations](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md#configurations).
 
 ### SQL CLI for Cluster
 
 You need to use the dedicated SQL CLI for ScalarDB Cluster (SQL CLI for Cluster).
 
-Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.mdx) except the name of the JAR file is different.
+Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.md) except the name of the JAR file is different.
 You can download the SQL CLI for Cluster from [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.11.1).
 After downloading the JAR file, you can run SQL CLI for Cluster with the following command:
 

--- a/versioned_docs/version-3.11/scalardb-cluster/getting-started-with-scalardb-cluster-graphql.mdx
+++ b/versioned_docs/version-3.11/scalardb-cluster/getting-started-with-scalardb-cluster-graphql.mdx
@@ -107,7 +107,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 ## Step 3. Load a schema
 
 To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster).
-Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different.
+Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different.
 You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.11.1).
 After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
 

--- a/versioned_docs/version-3.11/scalardb-cluster/getting-started-with-scalardb-cluster-sql-jdbc.mdx
+++ b/versioned_docs/version-3.11/scalardb-cluster/getting-started-with-scalardb-cluster-sql-jdbc.mdx
@@ -105,7 +105,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 ## Step 4. Load a schema
 
 To load a schema via ScalarDB Cluster SQL, you need to use the dedicated SQL CLI for ScalarDB Cluster (SQL CLI for Cluster).
-Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.mdx) except the name of the JAR file is different.
+Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.md) except the name of the JAR file is different.
 You can download the SQL CLI for Cluster from [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.11.1).
 After downloading the JAR file, you can use SQL CLI for Cluster by running the following command:
 

--- a/versioned_docs/version-3.11/scalardb-cluster/getting-started-with-scalardb-cluster-sql-spring-data-jdbc.mdx
+++ b/versioned_docs/version-3.11/scalardb-cluster/getting-started-with-scalardb-cluster-sql-spring-data-jdbc.mdx
@@ -105,7 +105,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 ## Step 4. Load a schema
 
 To load a schema via ScalarDB Cluster SQL, you need to use the dedicated SQL CLI for ScalarDB Cluster (SQL CLI for Cluster).
-Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.mdx) except the name of the JAR file is different.
+Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.md) except the name of the JAR file is different.
 You can download the SQL CLI for Cluster from [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.11.1).
 After downloading the JAR file, you can run SQL CLI for Cluster with the following command:
 

--- a/versioned_docs/version-3.11/scalardb-cluster/getting-started-with-scalardb-cluster.mdx
+++ b/versioned_docs/version-3.11/scalardb-cluster/getting-started-with-scalardb-cluster.mdx
@@ -4,7 +4,7 @@ This tutorial describes how to create a sample application that uses [ScalarDB C
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample/README.mdx) but takes advantage of ScalarDB Cluster.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample/README.md) but takes advantage of ScalarDB Cluster.
 
 The following diagram shows the system architecture of the sample application:
 

--- a/versioned_docs/version-3.11/scalardb-cluster/getting-started-with-using-go-for-scalardb-cluster.mdx
+++ b/versioned_docs/version-3.11/scalardb-cluster/getting-started-with-using-go-for-scalardb-cluster.mdx
@@ -62,7 +62,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 
 ## Step 3. Load a schema
 
-To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
+To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
 
 ```shell
 $ java -jar scalardb-cluster-schema-loader-3.11.1-all.jar --config database.properties -f schema.json --coordinator

--- a/versioned_docs/version-3.11/scalardb-cluster/getting-started-with-using-python-for-scalardb-cluster.mdx
+++ b/versioned_docs/version-3.11/scalardb-cluster/getting-started-with-using-python-for-scalardb-cluster.mdx
@@ -62,7 +62,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 
 ## Step 3. Load a schema
 
-To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
+To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
 
 ```shell
 $ java -jar scalardb-cluster-schema-loader-3.11.1-all.jar --config database.properties -f schema.json --coordinator

--- a/versioned_docs/version-3.11/scalardb-cluster/scalardb-auth-with-sql.mdx
+++ b/versioned_docs/version-3.11/scalardb-cluster/scalardb-auth-with-sql.mdx
@@ -6,7 +6,7 @@ This document describes how to use ScalarDB Auth with ScalarDB SQL.
 
 ## ScalarDB Auth Overview
 
-By using ScalarDB Auth, you can create users and grant or revoke their privileges. You can create a user by using the `CREATE USER` command, and you can grant or revoke one's privileges on a table or a namespace by using the `GRANT` or `REVOKE` command, respectively. For details about such data control language (DCL) commands, see [DCL](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.mdx#dcl).
+By using ScalarDB Auth, you can create users and grant or revoke their privileges. You can create a user by using the `CREATE USER` command, and you can grant or revoke one's privileges on a table or a namespace by using the `GRANT` or `REVOKE` command, respectively. For details about such data control language (DCL) commands, see [DCL](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.md#dcl).
 
 Users can log in to ScalarDB Cluster with a username and a password and execute SQL statements if they have the required privileges.
 

--- a/versioned_docs/version-3.11/scalardb-cluster/scalardb-cluster-configurations.mdx
+++ b/versioned_docs/version-3.11/scalardb-cluster/scalardb-cluster-configurations.mdx
@@ -3,7 +3,7 @@
 This document describes the configurations for ScalarDB Cluster.
 ScalarDB Cluster consists of multiple cluster nodes, and you need to configure each cluster node.
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), you can configure the following configurations for each cluster node.
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), you can configure the following configurations for each cluster node.
 
 ## Basic configurations
 

--- a/versioned_docs/version-3.11/scalardb-cluster/scalardb-cluster-sql-grpc-api-guide.mdx
+++ b/versioned_docs/version-3.11/scalardb-cluster/scalardb-cluster-sql-grpc-api-guide.mdx
@@ -51,7 +51,7 @@ By calling `Begin`, you receive a transaction ID in the response, which you can 
 Also, you can call `Execute` without a transaction ID to execute a one-shot transaction.
 In this case, the transaction is automatically committed after it is executed.
 You can use this method to execute DDL statements as well.
-For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.mdx).
+For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.md).
 Please note, however, that `Execute` supports only DML and DDL statements.
 
 When you call `Begin`, you can optionally specify a transaction ID.
@@ -126,7 +126,7 @@ By calling `Begin` or `Join`, you receive a transaction ID in the response, whic
 
 In addition, you can call `Execute` without a transaction ID to execute a one-shot transaction.
 In this case, the transaction is automatically committed after it is executed.
-You can use this method to execute DDL statements as well. For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.mdx).
+You can use this method to execute DDL statements as well. For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.md).
 Please note, however, that `Execute` supports only DML and DDL statements.
 
 When you call `Begin`, you can optionally specify a transaction ID.

--- a/versioned_docs/version-3.11/scalardb-graphql/aws-deployment-guide.mdx
+++ b/versioned_docs/version-3.11/scalardb-graphql/aws-deployment-guide.mdx
@@ -26,7 +26,7 @@ In this document, a placeholder cluster name `<your-cluster-name>` will be used 
 
 We need to load a database schema to the database before starting ScalarDB GraphQL.
 
-Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx).
+Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md).
 
 1. Create a `database.properties` configuration file for DynamoDB
 

--- a/versioned_docs/version-3.11/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
+++ b/versioned_docs/version-3.11/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/versioned_docs/version-3.11/scalardb-graphql/index.mdx
+++ b/versioned_docs/version-3.11/scalardb-graphql/index.mdx
@@ -12,7 +12,7 @@ To build and install the ScalarDB GraphQL Server, use `./gradlew installDist`, w
 
 ## Run
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), the GraphQL server reads the following:
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), the GraphQL server reads the following:
 
 * `scalar.db.graphql.port` ... Port number for GraphQL server. The default is `8080`.
 * `scalar.db.graphql.path` ... Path component of the URL of the GraphQL endpoint. The default is `/graphql`.

--- a/versioned_docs/version-3.11/scalardb-samples/microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.11/scalardb-samples/microservice-transaction-sample/README.mdx
@@ -4,7 +4,7 @@ This tutorial describes how to create a sample application that supports microse
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) when using ScalarDB.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) when using ScalarDB.
 
 The sample application has two microservices called the *Customer Service* and the *Order Service* based on the [database-per-service pattern](https://microservices.io/patterns/data/database-per-service.html):
 

--- a/versioned_docs/version-3.11/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
+++ b/versioned_docs/version-3.11/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
@@ -19,7 +19,7 @@ The database that you will be using in the sample application is Cassandra. Alth
 
 :::note
 
-Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx#handle-sqlexception).
+Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md#handle-sqlexception).
 
 :::
 

--- a/versioned_docs/version-3.11/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.11/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
@@ -2,7 +2,7 @@
 
 This tutorial describes how to create a sample Spring Boot application for microservice transactions by using Spring Data JDBC for ScalarDB.
 
-For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ## Prerequisites
 

--- a/versioned_docs/version-3.11/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.11/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB with Multi-storage Transaction.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB with Multi-storage Transaction.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ![Overview](images/overview.png)
 

--- a/versioned_docs/version-3.11/scalardb-samples/spring-data-sample/README.mdx
+++ b/versioned_docs/version-3.11/scalardb-samples/spring-data-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ### Schema
 

--- a/versioned_docs/version-3.11/scalardb-sql/configurations.mdx
+++ b/versioned_docs/version-3.11/scalardb-sql/configurations.mdx
@@ -33,7 +33,7 @@ The configurations for Direct mode are as follows:
 | `scalar.db.sql.statement_cache.size`    | Maximum number of cached statements. | `100`   |
 
 Note that in Direct mode, you need to configure the transaction manager, as well.
-For details about configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations).
+For details about configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations).
 
 In addition, for details about ScalarDB SQL Server, see [ScalarDB SQL Server](sql-server.mdx).
 
@@ -54,7 +54,7 @@ The configurations for Server mode are as follows:
 ScalarDB SQL Server is a gRPC server that implements the ScalarDB SQL interface.
 This section explains the ScalarDB SQL Server configurations.
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), the following configurations are available for ScalarDB SQL Server:
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), the following configurations are available for ScalarDB SQL Server:
 
 | Name                                             | Description                                      | Default                |
 |--------------------------------------------------|--------------------------------------------------|------------------------|

--- a/versioned_docs/version-3.11/scalardb-sql/getting-started-with-jdbc.mdx
+++ b/versioned_docs/version-3.11/scalardb-sql/getting-started-with-jdbc.mdx
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with ScalarDB JDBC with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for ScalarDB exists.
 
@@ -222,7 +222,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how ScalarDB JDBC is used. For more information, please take a look at the following documents.
 
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB JDBC Guide](jdbc-guide.mdx)
 * [ScalarDB SQL Grammar](grammar.mdx)
 * [ScalarDB SQL Command Line interface](command-line-interface.mdx)

--- a/versioned_docs/version-3.11/scalardb-sql/getting-started-with-sql.mdx
+++ b/versioned_docs/version-3.11/scalardb-sql/getting-started-with-sql.mdx
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with ScalarDB SQL with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for ScalarDB exists.
 
@@ -210,7 +210,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how ScalarDB SQL is used. For more information, please take a look at the following documents.
 
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL API Guide](sql-api-guide.mdx)
 * [ScalarDB SQL Grammar](grammar.mdx)
 * [ScalarDB SQL Command Line interface](command-line-interface.mdx)

--- a/versioned_docs/version-3.11/scalardb-sql/grammar.mdx
+++ b/versioned_docs/version-3.11/scalardb-sql/grammar.mdx
@@ -95,7 +95,7 @@ CreateNamespaceStatement statement3 =
 
 The `CREATE TABLE` command creates a table.
 
-For details about the ScalarDB data model, see [ScalarDB Design Document](https://github.com/scalar-labs/scalardb/blob/master/docs/design.mdx).
+For details about the ScalarDB data model, see [ScalarDB Design Document](https://github.com/scalar-labs/scalardb/blob/master/docs/design.md).
 
 #### Grammar
 
@@ -762,7 +762,7 @@ SelectStatement statement4 =
 
 ### SELECT (with cross-partition scan)
 
-By enabling the cross-partition scan option, the `SELECT` command can retrieve all records across partitions without specifying the `WHERE` clause. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
+By enabling the cross-partition scan option, the `SELECT` command can retrieve all records across partitions without specifying the `WHERE` clause. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
 
 :::warning
 
@@ -828,7 +828,7 @@ SelectStatement statement2 =
 
 ### SELECT (with cross-partition scan filtering and ordering)
 
-By enabling the cross-partition scan option with filtering and ordering, the `SELECT` command can flexibly retrieve records across partitions with arbitrary conditions and orderings. Currently, the options are valid only for JDBC databases. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
+By enabling the cross-partition scan option with filtering and ordering, the `SELECT` command can flexibly retrieve records across partitions with arbitrary conditions and orderings. Currently, the options are valid only for JDBC databases. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
 
 #### Grammar
 
@@ -1258,7 +1258,7 @@ UpdateStatement statement2 =
 
 ### UPDATE (with cross-partition scan)
 
-By enabling the cross-partition scan option, the `UPDATE` command can update all records across partitions without specifying the `WHERE` clause. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
+By enabling the cross-partition scan option, the `UPDATE` command can update all records across partitions without specifying the `WHERE` clause. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
 
 :::warning
 
@@ -1315,7 +1315,7 @@ UpdateStatement statement =
 
 ### UPDATE (with cross-partition scan filtering)
 
-By enabling the cross-partition scan option with filtering, the `UPDATE` command can flexibly update records across partitions with arbitrary conditions. Currently, the option is valid only for JDBC databases. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
+By enabling the cross-partition scan option with filtering, the `UPDATE` command can flexibly update records across partitions with arbitrary conditions. Currently, the option is valid only for JDBC databases. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
 
 #### Grammar
 
@@ -1530,7 +1530,7 @@ DeleteStatement statement2 =
 
 ### DELETE (with cross-partition scan)
 
-By enabling the cross-partition scan option, the `DELETE` command can delete all records across partitions without specifying the `WHERE` clause. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
+By enabling the cross-partition scan option, the `DELETE` command can delete all records across partitions without specifying the `WHERE` clause. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
 
 :::warning
 
@@ -1579,7 +1579,7 @@ DeleteStatement statement = StatementBuilder.deleteFrom("ns", "tbl").build();
 
 ### DELETE (with cross-partition scan filtering)
 
-By enabling the cross-partition scan option with filtering, the `DELETE` command can flexibly delete records across partitions with arbitrary conditions. Currently, the option is valid only for JDBC databases. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
+By enabling the cross-partition scan option with filtering, the `DELETE` command can flexibly delete records across partitions with arbitrary conditions. Currently, the option is valid only for JDBC databases. For details about configurations, see [Cross-partition scan configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#cross-partition-scan-configurations) and [ScalarDB SQL Configurations](./configurations.mdx).
 
 #### Grammar
 

--- a/versioned_docs/version-3.11/scalardb-sql/migration-guide.mdx
+++ b/versioned_docs/version-3.11/scalardb-sql/migration-guide.mdx
@@ -37,11 +37,11 @@ BM===>AM
    - Follow the administration guide of your database.
 4. Set up a ScalarDB environment.
    - Prepare a configuration file so that ScalarDB can access target databases.
-   - For details about ScalarDB configurations, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx).
+   - For details about ScalarDB configurations, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md).
 5. Import your database to ScalarDB.
    - Prepare an import schema file that defines target schemas and tables. The schemas and tables will be mapped to ScalarDB namespaces and tables, respectively. Note that "schema" is a synonym for "database" in some database systems.
    - Run the ScalarDB Schema Loader with the import option, the ScalarDB configuration file that you created, and the schema file that you prepared.
-   - For details on how to use Schema Loader, see [Run Schema Loader for importing existing tables](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.mdx#run-schema-loader-for-importing-existing-tables).
+   - For details on how to use Schema Loader, see [Run Schema Loader for importing existing tables](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.md#run-schema-loader-for-importing-existing-tables).
 6. Switch your application and check the behavior.
    - Now, you can switch your application to the ScalarDB-based application.
 
@@ -49,10 +49,10 @@ BM===>AM
 
 Before starting the migration, check the following questions. If the answer to any of these questions is "No", you must address them before proceeding with the migration.
 
-- Are your target database and version one of the [supported relational databases (called JDBC databases in ScalarDB) and versions](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.mdx#jdbc-databases)?
-- Do you have a fully privileged account that can manage the target database? For details, see [Privileges to access the underlying databases](https://github.com/scalar-labs/scalardb/blob/master/docs/requirements.mdx#privileges-to-access-the-underlying-databases).
+- Are your target database and version one of the [supported relational databases (called JDBC databases in ScalarDB) and versions](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md#jdbc-databases)?
+- Do you have a fully privileged account that can manage the target database? For details, see [Privileges to access the underlying databases](https://github.com/scalar-labs/scalardb/blob/master/docs/requirements.md#privileges-to-access-the-underlying-databases).
 - Do all target tables have primary keys?
-- Is the data type of each column supported in ScalarDB? For supported data types and how they are mapped to ScalarDB data types, see [Data-type mapping from JDBC databases to ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.mdx#data-type-mapping-from-jdbc-databases-to-scalardb).
+- Is the data type of each column supported in ScalarDB? For supported data types and how they are mapped to ScalarDB data types, see [Data-type mapping from JDBC databases to ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.md#data-type-mapping-from-jdbc-databases-to-scalardb).
 - Do the functionality and grammar of the queries in your application comply with the [ScalarDB SQL specifications](./grammar.mdx)? Or, for non-compliant queries, can you re-write them for ScalarDB? For examples of re-writes, see [How to migrate your application](#how-to-migrate-your-application).
 - After migrating your applications and databases into ScalarDB applications and ScalarDB-managed databases, respectively, can you stop accessing the databases directly? In other words, is it acceptable for you to always access the databases through ScalarDB?
 
@@ -68,7 +68,7 @@ Depending on your application environment, you may need to migrate your applicat
 
 If your application is based on Java, you can use the ScalarDB JDBC driver when migrating. For details on how to add dependencies for the ScalarDB JDBC driver and rewrite the connection URL, see the [ScalarDB JDBC Guide](./jdbc-guide.mdx).
 
-If your application is not based on Java, you can connect ScalarDB and issue SQL via gRPC. For details, see [ScalarDB Cluster SQL gRPC API Guide](https://github.com/scalar-labs/scalardb-cluster/blob/main/docs/scalardb-cluster-sql-grpc-api-guide.mdx).
+If your application is not based on Java, you can connect ScalarDB and issue SQL via gRPC. For details, see [ScalarDB Cluster SQL gRPC API Guide](https://github.com/scalar-labs/scalardb-cluster/blob/main/docs/scalardb-cluster-sql-grpc-api-guide.md).
 
 ### Modify SQL statements
 
@@ -98,12 +98,12 @@ Although ScalarDB SQL does not provide some functionalities, such as aggregate q
 
 ## Limitations
 
-Due to the difference in data types, ScalarDB will throw an error when writing data larger than the maximum size of the column in the underlying database, even if the size is acceptable for the ScalarDB data type. Conversely, in a few types, the data in the underlying database may be larger than the maximum size in ScalarDB. For details, see [Data-type mapping from JDBC databases to ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.mdx#data-type-mapping-from-jdbc-databases-to-scalardb).
+Due to the difference in data types, ScalarDB will throw an error when writing data larger than the maximum size of the column in the underlying database, even if the size is acceptable for the ScalarDB data type. Conversely, in a few types, the data in the underlying database may be larger than the maximum size in ScalarDB. For details, see [Data-type mapping from JDBC databases to ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.md#data-type-mapping-from-jdbc-databases-to-scalardb).
 
 ## References
 
-- [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.mdx)
+- [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md)
 - [ScalarDB SQL API Guide](./sql-api-guide.mdx)
 - [ScalarDB JDBC Guide](./jdbc-guide.mdx)
 - [ScalarDB SQL Grammar](./grammar.mdx)
-- [Importing Existing Tables to ScalarDB by Using ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.mdx)
+- [Importing Existing Tables to ScalarDB by Using ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader-import.md)

--- a/versioned_docs/version-3.11/scalardb-sql/sql-server.mdx
+++ b/versioned_docs/version-3.11/scalardb-sql/sql-server.mdx
@@ -81,7 +81,7 @@ scalar.db.consensus_commit.isolation_level=SNAPSHOT
 scalar.db.consensus_commit.serializable_strategy=
 ```
 
-For more details about the configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations).
+For more details about the configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations).
 
 In addition, for more details about the configurations for ScalarDB SQL Server, see [ScalarDB SQL Configurations](configurations.mdx).
 
@@ -153,5 +153,5 @@ Please see [ScalarDB SQL Configurations](configurations.mdx) for more details of
 
 * [Getting Started with ScalarDB SQL](getting-started-with-sql.mdx)
 * [Getting Started with ScalarDB JDBC](getting-started-with-jdbc.mdx)
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL Configurations](configurations.mdx)

--- a/versioned_docs/version-3.4/scalardb-samples/scalardb-server-sample/README.mdx
+++ b/versioned_docs/version-3.4/scalardb-samples/scalardb-server-sample/README.mdx
@@ -1,7 +1,7 @@
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.mdx).
-More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.mdx).
+For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md).
+More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
 The sample application is a simple electronic money application that has the following features:
@@ -54,7 +54,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.mdx). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.
@@ -127,7 +127,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 ```
 
 ## Storage abstraction
-ScalarDB Server also supports [Storage API](https://github.com/scalar-labs/scalardb/blob/master/docs/storage-abstraction.mdx).
+ScalarDB Server also supports [Storage API](https://github.com/scalar-labs/scalardb/blob/master/docs/storage-abstraction.md).
 The following describes a sample of Storage API.
 
 ### Set up database schema

--- a/versioned_docs/version-3.4/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
+++ b/versioned_docs/version-3.4/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
@@ -36,7 +36,7 @@ This tutorial describes how to create a sample application for the same use case
 In this tutorial, you will build the application on Cassandra.
 Although Cassandra does not provide ACID transaction capabilities, Cassandra can support ACID transactions by interfacing through ScalarDB SQL (JDBC).
 Please note that application-specific error handling, authentication processing, and similar functions are not included in the sample application, as the focus is on demonstrating the use of ScalarDB SQL (JDBC).
-For detailed information on exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx#handle-sqlexception).
+For detailed information on exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md#handle-sqlexception).
 
 ### Schema
 

--- a/versioned_docs/version-3.4/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.4/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
@@ -2,7 +2,7 @@
 
 This tutorial describes how to create a sample Spring Boot application for microservice transactions by using Spring Data JDBC for ScalarDB.
 
-For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ## Prerequisites
 

--- a/versioned_docs/version-3.4/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.4/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB with Multi-storage Transaction.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB with Multi-storage Transaction.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ![Overview](images/overview.png)
 

--- a/versioned_docs/version-3.4/scalardb-samples/spring-data-sample/README.mdx
+++ b/versioned_docs/version-3.4/scalardb-samples/spring-data-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ### Schema
 

--- a/versioned_docs/version-3.5/scalardb-benchmarks/README.mdx
+++ b/versioned_docs/version-3.5/scalardb-benchmarks/README.mdx
@@ -23,7 +23,7 @@ This tutorial describes how to run benchmarking tools for ScalarDB. Database ben
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.
 - A client to run the benchmarking tools
 - A target database
-  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.mdx).
+  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
 :::note
 
@@ -59,9 +59,9 @@ $ ./gradlew shadowJar
 
 ### Load the schema
 
-Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
+Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
 
-In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx).
+In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md).
 
 After applying the schema and configuring the properties file, select a benchmark and follow the instructions to create the tables.
 

--- a/versioned_docs/version-3.5/scalardb-graphql/aws-deployment-guide.mdx
+++ b/versioned_docs/version-3.5/scalardb-graphql/aws-deployment-guide.mdx
@@ -26,7 +26,7 @@ In this document, a placeholder cluster name `<your-cluster-name>` will be used 
 
 We need to load a database schema to the database before starting ScalarDB GraphQL.
 
-Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx).
+Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md).
 
 1. Create a `database.properties` configuration file for DynamoDB
 

--- a/versioned_docs/version-3.5/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
+++ b/versioned_docs/version-3.5/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/versioned_docs/version-3.5/scalardb-graphql/index.mdx
+++ b/versioned_docs/version-3.5/scalardb-graphql/index.mdx
@@ -12,7 +12,7 @@ To build and install the ScalarDB GraphQL Server, use `./gradlew installDist`, w
 
 ## Run
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), the GraphQL server reads the following:
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), the GraphQL server reads the following:
 
 * `scalar.db.graphql.port` ... Port number for GraphQL server. The default is `8080`.
 * `scalar.db.graphql.path` ... Path component of the URL of the GraphQL endpoint. The default is `/graphql`.

--- a/versioned_docs/version-3.5/scalardb-samples/microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.5/scalardb-samples/microservice-transaction-sample/README.mdx
@@ -4,7 +4,7 @@ This tutorial describes how to create a sample application that supports microse
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) when using ScalarDB.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) when using ScalarDB.
 
 The sample application has two microservices called the *Customer Service* and the *Order Service* based on the [database-per-service pattern](https://microservices.io/patterns/data/database-per-service.html):
 

--- a/versioned_docs/version-3.5/scalardb-samples/scalardb-server-sample/README.mdx
+++ b/versioned_docs/version-3.5/scalardb-samples/scalardb-server-sample/README.mdx
@@ -1,7 +1,7 @@
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx).
-More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.mdx).
+For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
+More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
 The sample application is a simple electronic money application that has the following features:
@@ -54,7 +54,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.
@@ -127,7 +127,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 ```
 
 ## Storage abstraction
-ScalarDB Server also supports [Storage API](https://github.com/scalar-labs/scalardb/blob/master/docs/storage-abstraction.mdx).
+ScalarDB Server also supports [Storage API](https://github.com/scalar-labs/scalardb/blob/master/docs/storage-abstraction.md).
 The following describes a sample of Storage API.
 
 ### Set up database schema

--- a/versioned_docs/version-3.5/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
+++ b/versioned_docs/version-3.5/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
@@ -19,7 +19,7 @@ The database that you will be using in the sample application is Cassandra. Alth
 
 :::note
 
-Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx#handle-sqlexception).
+Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md#handle-sqlexception).
 
 :::
 

--- a/versioned_docs/version-3.5/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.5/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
@@ -2,7 +2,7 @@
 
 This tutorial describes how to create a sample Spring Boot application for microservice transactions by using Spring Data JDBC for ScalarDB.
 
-For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ## Prerequisites
 

--- a/versioned_docs/version-3.5/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.5/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB with Multi-storage Transaction.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB with Multi-storage Transaction.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ![Overview](images/overview.png)
 

--- a/versioned_docs/version-3.5/scalardb-samples/spring-data-sample/README.mdx
+++ b/versioned_docs/version-3.5/scalardb-samples/spring-data-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ### Schema
 

--- a/versioned_docs/version-3.6/releases/release-notes.mdx
+++ b/versioned_docs/version-3.6/releases/release-notes.mdx
@@ -159,7 +159,7 @@ This release has several bug fixes.
 
 ### Summary
 
-This release has a lot of API changes while preserving backward compatibility. Please see [Java API Guide](https://github.com/scalar-labs/scalardb/blob/v3.6.0/docs/api-guide.mdx) for the details of the API.
+This release has a lot of API changes while preserving backward compatibility. Please see [Java API Guide](https://github.com/scalar-labs/scalardb/blob/v3.6.0/docs/api-guide.md) for the details of the API.
 
 Also, it has a lot of enhancements, improvements, bug fixes, vulnerability fixes, and document improvements. Please see the following Change logs for the details.
 

--- a/versioned_docs/version-3.6/scalardb-benchmarks/README.mdx
+++ b/versioned_docs/version-3.6/scalardb-benchmarks/README.mdx
@@ -23,7 +23,7 @@ This tutorial describes how to run benchmarking tools for ScalarDB. Database ben
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.
 - A client to run the benchmarking tools
 - A target database
-  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.mdx).
+  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
 :::note
 
@@ -59,9 +59,9 @@ $ ./gradlew shadowJar
 
 ### Load the schema
 
-Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
+Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
 
-In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx).
+In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md).
 
 After applying the schema and configuring the properties file, select a benchmark and follow the instructions to create the tables.
 

--- a/versioned_docs/version-3.6/scalardb-graphql/aws-deployment-guide.mdx
+++ b/versioned_docs/version-3.6/scalardb-graphql/aws-deployment-guide.mdx
@@ -26,7 +26,7 @@ In this document, a placeholder cluster name `<your-cluster-name>` will be used 
 
 We need to load a database schema to the database before starting ScalarDB GraphQL.
 
-Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx).
+Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md).
 
 1. Create a `database.properties` configuration file for DynamoDB
 

--- a/versioned_docs/version-3.6/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
+++ b/versioned_docs/version-3.6/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/versioned_docs/version-3.6/scalardb-graphql/index.mdx
+++ b/versioned_docs/version-3.6/scalardb-graphql/index.mdx
@@ -12,7 +12,7 @@ To build and install the ScalarDB GraphQL Server, use `./gradlew installDist`, w
 
 ## Run
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), the GraphQL server reads the following:
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), the GraphQL server reads the following:
 
 * `scalar.db.graphql.port` ... Port number for GraphQL server. The default is `8080`.
 * `scalar.db.graphql.path` ... Path component of the URL of the GraphQL endpoint. The default is `/graphql`.

--- a/versioned_docs/version-3.6/scalardb-samples/microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.6/scalardb-samples/microservice-transaction-sample/README.mdx
@@ -4,7 +4,7 @@ This tutorial describes how to create a sample application that supports microse
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) when using ScalarDB.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) when using ScalarDB.
 
 The sample application has two microservices called the *Customer Service* and the *Order Service* based on the [database-per-service pattern](https://microservices.io/patterns/data/database-per-service.html):
 

--- a/versioned_docs/version-3.6/scalardb-samples/scalardb-server-sample/README.mdx
+++ b/versioned_docs/version-3.6/scalardb-samples/scalardb-server-sample/README.mdx
@@ -1,7 +1,7 @@
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx).
-More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.mdx).
+For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
+More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
 The sample application is a simple electronic money application that has the following features:
@@ -54,7 +54,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.
@@ -127,7 +127,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 ```
 
 ## Storage abstraction
-ScalarDB Server also supports [Storage API](https://github.com/scalar-labs/scalardb/blob/master/docs/storage-abstraction.mdx).
+ScalarDB Server also supports [Storage API](https://github.com/scalar-labs/scalardb/blob/master/docs/storage-abstraction.md).
 The following describes a sample of Storage API.
 
 ### Set up database schema

--- a/versioned_docs/version-3.6/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
+++ b/versioned_docs/version-3.6/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
@@ -19,7 +19,7 @@ The database that you will be using in the sample application is Cassandra. Alth
 
 :::note
 
-Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx#handle-sqlexception).
+Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md#handle-sqlexception).
 
 :::
 

--- a/versioned_docs/version-3.6/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.6/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
@@ -2,7 +2,7 @@
 
 This tutorial describes how to create a sample Spring Boot application for microservice transactions by using Spring Data JDBC for ScalarDB.
 
-For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ## Prerequisites
 

--- a/versioned_docs/version-3.6/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.6/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB with Multi-storage Transaction.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB with Multi-storage Transaction.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ![Overview](images/overview.png)
 

--- a/versioned_docs/version-3.6/scalardb-samples/spring-data-sample/README.mdx
+++ b/versioned_docs/version-3.6/scalardb-samples/spring-data-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ### Schema
 

--- a/versioned_docs/version-3.6/scalardb-sql/configurations.mdx
+++ b/versioned_docs/version-3.6/scalardb-sql/configurations.mdx
@@ -29,7 +29,7 @@ The configurations for Direct mode are as follows:
 | scalar.db.sql.statement_cache.size | The maximum number of cached statement. | 100 |
 
 Note that in the Direct mode, you need to configure underlining storage/database, as well.
-Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of the underlining storage/database configurations.
+Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of the underlining storage/database configurations.
 
 Please see also [Scalar DB SQL Server](sql-server.mdx) for the details of Scalar DB SQL Server.
 
@@ -104,7 +104,7 @@ This setting is recommended for production use.
 This is because Scalar DB Server implements [scalar-admin](https://github.com/scalar-labs/scalar-admin) interface, which enables you to take transactionally-consistent backups for Scalar DB by pausing the Scalar DB Server.
 
 Let's assume Scalar DB Server is already set up.
-Please see [Scalar DB server](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-server.mdx) for the details of configurations of Scalar DB Server.
+Please see [Scalar DB server](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-server.md) for the details of configurations of Scalar DB Server.
 
 In this case, an example of configurations for App is as follows:
 ```properties

--- a/versioned_docs/version-3.6/scalardb-sql/getting-started-with-jdbc.mdx
+++ b/versioned_docs/version-3.6/scalardb-sql/getting-started-with-jdbc.mdx
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with Scalar DB JDBC with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for Scalar DB exists.
 
@@ -222,7 +222,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how Scalar DB JDBC is used. For more information, please take a look at the following documents.
 
-* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [Scalar DB JDBC Guide](jdbc-guide.mdx)
 * [Scalar DB SQL Grammar](grammar.mdx)
 * [Scalar DB SQL Command Line interface](command-line-interface.mdx)

--- a/versioned_docs/version-3.6/scalardb-sql/getting-started-with-sql.mdx
+++ b/versioned_docs/version-3.6/scalardb-sql/getting-started-with-sql.mdx
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with Scalar DB SQL with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for Scalar DB exists.
 
@@ -210,7 +210,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how Scalar DB SQL is used. For more information, please take a look at the following documents.
 
-* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [Scalar DB SQL API Guide](sql-api-guide.mdx)
 * [Scalar DB SQL Grammar](grammar.mdx)
 * [Scalar DB SQL Command Line interface](command-line-interface.mdx)

--- a/versioned_docs/version-3.6/scalardb-sql/grammar.mdx
+++ b/versioned_docs/version-3.6/scalardb-sql/grammar.mdx
@@ -83,7 +83,7 @@ CreateNamespaceStatement statement3 =
 
 `CREATE TABLE` command creates a table.
 
-Please see [Scalar DB design document - Data Model](https://github.com/scalar-labs/scalardb/blob/master/docs/design.mdx#data-model) for the details of the Scalar DB Data Model.
+Please see [Scalar DB design document - Data Model](https://github.com/scalar-labs/scalardb/blob/master/docs/design.md#data-model) for the details of the Scalar DB Data Model.
 
 #### Grammar
 

--- a/versioned_docs/version-3.6/scalardb-sql/sql-server.mdx
+++ b/versioned_docs/version-3.6/scalardb-sql/sql-server.mdx
@@ -148,5 +148,5 @@ scalar.db.sql.default_transaction_mode=TRANSACTION
 
 * [Getting Started with Scalar DB SQL](getting-started-with-sql.mdx)
 * [Getting Started with Scalar DB JDBC](getting-started-with-jdbc.mdx)
-* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [Scalar DB SQL Configurations](configurations.mdx)

--- a/versioned_docs/version-3.7/releases/release-notes.mdx
+++ b/versioned_docs/version-3.7/releases/release-notes.mdx
@@ -148,8 +148,8 @@ This release has several enhancements, improvements, bug fixes, vulnerability fi
 
 Highlights of this release are as follows:
 
-- Add namespace prefix support for Dynamo (The configuration name is `scalar.db.dynamo.namespace.prefix`. Please see [this document](https://github.com/scalar-labs/scalardb/blob/v3.7.0/docs/getting-started-with-scalardb-on-dynamodb.mdx) for the details
-- Add alter table command to Schema Loader tool (Please see [this document](https://github.com/scalar-labs/scalardb/blob/v3.7.0/schema-loader/README.mdx#alter-tables) for the details)
+- Add namespace prefix support for Dynamo (The configuration name is `scalar.db.dynamo.namespace.prefix`. Please see [this document](https://github.com/scalar-labs/scalardb/blob/v3.7.0/docs/getting-started-with-scalardb-on-dynamodb.md) for the details
+- Add alter table command to Schema Loader tool (Please see [this document](https://github.com/scalar-labs/scalardb/blob/v3.7.0/schema-loader/README.md#alter-tables) for the details)
 
 ### Change logs
 

--- a/versioned_docs/version-3.7/scalardb-benchmarks/README.mdx
+++ b/versioned_docs/version-3.7/scalardb-benchmarks/README.mdx
@@ -23,7 +23,7 @@ This tutorial describes how to run benchmarking tools for ScalarDB. Database ben
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.
 - A client to run the benchmarking tools
 - A target database
-  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.mdx).
+  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
 :::note
 
@@ -59,9 +59,9 @@ $ ./gradlew shadowJar
 
 ### Load the schema
 
-Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
+Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
 
-In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx).
+In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md).
 
 After applying the schema and configuring the properties file, select a benchmark and follow the instructions to create the tables.
 

--- a/versioned_docs/version-3.7/scalardb-graphql/aws-deployment-guide.mdx
+++ b/versioned_docs/version-3.7/scalardb-graphql/aws-deployment-guide.mdx
@@ -26,7 +26,7 @@ In this document, a placeholder cluster name `<your-cluster-name>` will be used 
 
 We need to load a database schema to the database before starting ScalarDB GraphQL.
 
-Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx).
+Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md).
 
 1. Create a `database.properties` configuration file for DynamoDB
 

--- a/versioned_docs/version-3.7/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
+++ b/versioned_docs/version-3.7/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/versioned_docs/version-3.7/scalardb-graphql/index.mdx
+++ b/versioned_docs/version-3.7/scalardb-graphql/index.mdx
@@ -12,7 +12,7 @@ To build and install the ScalarDB GraphQL Server, use `./gradlew installDist`, w
 
 ## Run
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), the GraphQL server reads the following:
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), the GraphQL server reads the following:
 
 * `scalar.db.graphql.port` ... Port number for GraphQL server. The default is `8080`.
 * `scalar.db.graphql.path` ... Path component of the URL of the GraphQL endpoint. The default is `/graphql`.

--- a/versioned_docs/version-3.7/scalardb-samples/microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.7/scalardb-samples/microservice-transaction-sample/README.mdx
@@ -4,7 +4,7 @@ This tutorial describes how to create a sample application that supports microse
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) when using ScalarDB.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) when using ScalarDB.
 
 The sample application has two microservices called the *Customer Service* and the *Order Service* based on the [database-per-service pattern](https://microservices.io/patterns/data/database-per-service.html):
 

--- a/versioned_docs/version-3.7/scalardb-samples/scalardb-server-sample/README.mdx
+++ b/versioned_docs/version-3.7/scalardb-samples/scalardb-server-sample/README.mdx
@@ -1,7 +1,7 @@
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx).
-More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.mdx).
+For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
+More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
 The sample application is a simple electronic money application that has the following features:
@@ -54,7 +54,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.
@@ -127,7 +127,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 ```
 
 ## Storage abstraction
-ScalarDB Server also supports [Storage API](https://github.com/scalar-labs/scalardb/blob/master/docs/storage-abstraction.mdx).
+ScalarDB Server also supports [Storage API](https://github.com/scalar-labs/scalardb/blob/master/docs/storage-abstraction.md).
 The following describes a sample of Storage API.
 
 ### Set up database schema

--- a/versioned_docs/version-3.7/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
+++ b/versioned_docs/version-3.7/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
@@ -19,7 +19,7 @@ The database that you will be using in the sample application is Cassandra. Alth
 
 :::note
 
-Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx#handle-sqlexception).
+Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md#handle-sqlexception).
 
 :::
 

--- a/versioned_docs/version-3.7/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.7/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
@@ -2,7 +2,7 @@
 
 This tutorial describes how to create a sample Spring Boot application for microservice transactions by using Spring Data JDBC for ScalarDB.
 
-For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ## Prerequisites
 

--- a/versioned_docs/version-3.7/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.7/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB with Multi-storage Transaction.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB with Multi-storage Transaction.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ![Overview](images/overview.png)
 

--- a/versioned_docs/version-3.7/scalardb-samples/spring-data-sample/README.mdx
+++ b/versioned_docs/version-3.7/scalardb-samples/spring-data-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ### Schema
 

--- a/versioned_docs/version-3.7/scalardb-sql/configurations.mdx
+++ b/versioned_docs/version-3.7/scalardb-sql/configurations.mdx
@@ -29,7 +29,7 @@ The configurations for Direct mode are as follows:
 | scalar.db.sql.statement_cache.size | The maximum number of cached statement. | 100 |
 
 Note that in the Direct mode, you need to configure underlining storage/database, as well.
-Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of the underlining storage/database configurations.
+Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of the underlining storage/database configurations.
 
 Please see also [Scalar DB SQL Server](sql-server.mdx) for the details of Scalar DB SQL Server.
 
@@ -104,7 +104,7 @@ This setting is recommended for production use.
 This is because Scalar DB Server implements [scalar-admin](https://github.com/scalar-labs/scalar-admin) interface, which enables you to take transactionally-consistent backups for Scalar DB by pausing the Scalar DB Server.
 
 Let's assume Scalar DB Server is already set up.
-Please see [Scalar DB server](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-server.mdx) for the details of configurations of Scalar DB Server.
+Please see [Scalar DB server](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-server.md) for the details of configurations of Scalar DB Server.
 
 In this case, an example of configurations for App is as follows:
 ```properties

--- a/versioned_docs/version-3.7/scalardb-sql/getting-started-with-jdbc.mdx
+++ b/versioned_docs/version-3.7/scalardb-sql/getting-started-with-jdbc.mdx
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with Scalar DB JDBC with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for Scalar DB exists.
 
@@ -222,7 +222,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how Scalar DB JDBC is used. For more information, please take a look at the following documents.
 
-* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [Scalar DB JDBC Guide](jdbc-guide.mdx)
 * [Scalar DB SQL Grammar](grammar.mdx)
 * [Scalar DB SQL Command Line interface](command-line-interface.mdx)

--- a/versioned_docs/version-3.7/scalardb-sql/getting-started-with-sql.mdx
+++ b/versioned_docs/version-3.7/scalardb-sql/getting-started-with-sql.mdx
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with Scalar DB SQL with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for Scalar DB exists.
 
@@ -210,7 +210,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how Scalar DB SQL is used. For more information, please take a look at the following documents.
 
-* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [Scalar DB SQL API Guide](sql-api-guide.mdx)
 * [Scalar DB SQL Grammar](grammar.mdx)
 * [Scalar DB SQL Command Line interface](command-line-interface.mdx)

--- a/versioned_docs/version-3.7/scalardb-sql/grammar.mdx
+++ b/versioned_docs/version-3.7/scalardb-sql/grammar.mdx
@@ -83,7 +83,7 @@ CreateNamespaceStatement statement3 =
 
 `CREATE TABLE` command creates a table.
 
-Please see [Scalar DB design document - Data Model](https://github.com/scalar-labs/scalardb/blob/master/docs/design.mdx#data-model) for the details of the Scalar DB Data Model.
+Please see [Scalar DB design document - Data Model](https://github.com/scalar-labs/scalardb/blob/master/docs/design.md#data-model) for the details of the Scalar DB Data Model.
 
 #### Grammar
 

--- a/versioned_docs/version-3.7/scalardb-sql/sql-server.mdx
+++ b/versioned_docs/version-3.7/scalardb-sql/sql-server.mdx
@@ -148,5 +148,5 @@ scalar.db.sql.default_transaction_mode=TRANSACTION
 
 * [Getting Started with Scalar DB SQL](getting-started-with-sql.mdx)
 * [Getting Started with Scalar DB JDBC](getting-started-with-jdbc.mdx)
-* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [Scalar DB SQL Configurations](configurations.mdx)

--- a/versioned_docs/version-3.8/scalardb-benchmarks/README.mdx
+++ b/versioned_docs/version-3.8/scalardb-benchmarks/README.mdx
@@ -23,7 +23,7 @@ This tutorial describes how to run benchmarking tools for ScalarDB. Database ben
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.
 - A client to run the benchmarking tools
 - A target database
-  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.mdx).
+  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
 :::note
 
@@ -59,9 +59,9 @@ $ ./gradlew shadowJar
 
 ### Load the schema
 
-Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
+Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
 
-In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx).
+In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md).
 
 After applying the schema and configuring the properties file, select a benchmark and follow the instructions to create the tables.
 

--- a/versioned_docs/version-3.8/scalardb-cluster/index.mdx
+++ b/versioned_docs/version-3.8/scalardb-cluster/index.mdx
@@ -273,7 +273,7 @@ To add a dependency using Maven:
 
 To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster).
 
-The usage of Schema Loader for Cluster is basically the same as [Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except for the name of the jar file.
+The usage of Schema Loader for Cluster is basically the same as [Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except for the name of the jar file.
 For example, you can run Schema Loader for Cluster with the following command:
 
 ```shell
@@ -282,7 +282,7 @@ java -jar scalardb-cluster-schema-loader-<version>-all.jar --config <PATH_TO_CON
 
 The release versions of Schema Loader for Cluster can be downloaded from [the releases page](https://github.com/scalar-labs/scalardb-cluster/releases).
 
-See [this](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) for the details.
+See [this](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) for the details.
 
 ## Configurations
 

--- a/versioned_docs/version-3.8/scalardb-graphql/aws-deployment-guide.mdx
+++ b/versioned_docs/version-3.8/scalardb-graphql/aws-deployment-guide.mdx
@@ -26,7 +26,7 @@ In this document, a placeholder cluster name `<your-cluster-name>` will be used 
 
 We need to load a database schema to the database before starting ScalarDB GraphQL.
 
-Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx).
+Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md).
 
 1. Create a `database.properties` configuration file for DynamoDB
 

--- a/versioned_docs/version-3.8/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
+++ b/versioned_docs/version-3.8/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/versioned_docs/version-3.8/scalardb-graphql/index.mdx
+++ b/versioned_docs/version-3.8/scalardb-graphql/index.mdx
@@ -12,7 +12,7 @@ To build and install the ScalarDB GraphQL Server, use `./gradlew installDist`, w
 
 ## Run
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), the GraphQL server reads the following:
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), the GraphQL server reads the following:
 
 * `scalar.db.graphql.port` ... Port number for GraphQL server. The default is `8080`.
 * `scalar.db.graphql.path` ... Path component of the URL of the GraphQL endpoint. The default is `/graphql`.

--- a/versioned_docs/version-3.8/scalardb-samples/microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.8/scalardb-samples/microservice-transaction-sample/README.mdx
@@ -4,7 +4,7 @@ This tutorial describes how to create a sample application that supports microse
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) when using ScalarDB.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) when using ScalarDB.
 
 The sample application has two microservices called the *Customer Service* and the *Order Service* based on the [database-per-service pattern](https://microservices.io/patterns/data/database-per-service.html):
 

--- a/versioned_docs/version-3.8/scalardb-samples/scalardb-server-sample/README.mdx
+++ b/versioned_docs/version-3.8/scalardb-samples/scalardb-server-sample/README.mdx
@@ -1,7 +1,7 @@
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx).
-More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.mdx).
+For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
+More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
 The sample application is a simple electronic money application that has the following features:
@@ -54,7 +54,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.
@@ -127,7 +127,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 ```
 
 ## Storage abstraction
-ScalarDB Server also supports [Storage API](https://github.com/scalar-labs/scalardb/blob/master/docs/storage-abstraction.mdx).
+ScalarDB Server also supports [Storage API](https://github.com/scalar-labs/scalardb/blob/master/docs/storage-abstraction.md).
 The following describes a sample of Storage API.
 
 ### Set up database schema

--- a/versioned_docs/version-3.8/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
+++ b/versioned_docs/version-3.8/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
@@ -19,7 +19,7 @@ The database that you will be using in the sample application is Cassandra. Alth
 
 :::note
 
-Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx#handle-sqlexception).
+Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md#handle-sqlexception).
 
 :::
 

--- a/versioned_docs/version-3.8/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.8/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
@@ -2,7 +2,7 @@
 
 This tutorial describes how to create a sample Spring Boot application for microservice transactions by using Spring Data JDBC for ScalarDB.
 
-For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ## Prerequisites
 

--- a/versioned_docs/version-3.8/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.8/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB with Multi-storage Transaction.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB with Multi-storage Transaction.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ![Overview](images/overview.png)
 

--- a/versioned_docs/version-3.8/scalardb-samples/spring-data-sample/README.mdx
+++ b/versioned_docs/version-3.8/scalardb-samples/spring-data-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ### Schema
 

--- a/versioned_docs/version-3.8/scalardb-sql/configurations.mdx
+++ b/versioned_docs/version-3.8/scalardb-sql/configurations.mdx
@@ -29,7 +29,7 @@ The configurations for Direct mode are as follows:
 | scalar.db.sql.statement_cache.size | The maximum number of cached statement. | 100 |
 
 Note that in the Direct mode, you need to configure underlining storage/database, as well.
-Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of the underlining storage/database configurations.
+Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of the underlining storage/database configurations.
 
 Please see also [ScalarDB SQL Server](sql-server.mdx) for the details of ScalarDB SQL Server.
 
@@ -104,7 +104,7 @@ This setting is recommended for production use.
 This is because ScalarDB Server implements [scalar-admin](https://github.com/scalar-labs/scalar-admin) interface, which enables you to take transactionally-consistent backups for ScalarDB by pausing the ScalarDB Server.
 
 Let's assume ScalarDB Server is already set up.
-Please see [ScalarDB server](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-server.mdx) for the details of configurations of ScalarDB Server.
+Please see [ScalarDB server](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-server.md) for the details of configurations of ScalarDB Server.
 
 In this case, an example of configurations for App is as follows:
 ```properties

--- a/versioned_docs/version-3.8/scalardb-sql/getting-started-with-jdbc.mdx
+++ b/versioned_docs/version-3.8/scalardb-sql/getting-started-with-jdbc.mdx
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with ScalarDB JDBC with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for ScalarDB exists.
 
@@ -222,7 +222,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how ScalarDB JDBC is used. For more information, please take a look at the following documents.
 
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB JDBC Guide](jdbc-guide.mdx)
 * [ScalarDB SQL Grammar](grammar.mdx)
 * [ScalarDB SQL Command Line interface](command-line-interface.mdx)

--- a/versioned_docs/version-3.8/scalardb-sql/getting-started-with-sql.mdx
+++ b/versioned_docs/version-3.8/scalardb-sql/getting-started-with-sql.mdx
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with ScalarDB SQL with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for ScalarDB exists.
 
@@ -210,7 +210,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how ScalarDB SQL is used. For more information, please take a look at the following documents.
 
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL API Guide](sql-api-guide.mdx)
 * [ScalarDB SQL Grammar](grammar.mdx)
 * [ScalarDB SQL Command Line interface](command-line-interface.mdx)

--- a/versioned_docs/version-3.8/scalardb-sql/grammar.mdx
+++ b/versioned_docs/version-3.8/scalardb-sql/grammar.mdx
@@ -84,7 +84,7 @@ CreateNamespaceStatement statement3 =
 
 `CREATE TABLE` command creates a table.
 
-Please see [ScalarDB design document - Data Model](https://github.com/scalar-labs/scalardb/blob/master/docs/design.mdx#data-model) for the details of the ScalarDB Data Model.
+Please see [ScalarDB design document - Data Model](https://github.com/scalar-labs/scalardb/blob/master/docs/design.md#data-model) for the details of the ScalarDB Data Model.
 
 #### Grammar
 

--- a/versioned_docs/version-3.8/scalardb-sql/sql-server.mdx
+++ b/versioned_docs/version-3.8/scalardb-sql/sql-server.mdx
@@ -148,5 +148,5 @@ scalar.db.sql.default_transaction_mode=TRANSACTION
 
 * [Getting Started with ScalarDB SQL](getting-started-with-sql.mdx)
 * [Getting Started with ScalarDB JDBC](getting-started-with-jdbc.mdx)
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL Configurations](configurations.mdx)

--- a/versioned_docs/version-3.9/scalardb-benchmarks/README.mdx
+++ b/versioned_docs/version-3.9/scalardb-benchmarks/README.mdx
@@ -23,7 +23,7 @@ This tutorial describes how to run benchmarking tools for ScalarDB. Database ben
   - Kelpie is a framework for performing end-to-end testing, such as system benchmarking and verification. Get the latest version from [Kelpie Releases](https://github.com/scalar-labs/kelpie), and unzip the archive file.
 - A client to run the benchmarking tools
 - A target database
-  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.mdx).
+  - For a list of databases that ScalarDB supports, see [Supported Databases](https://github.com/scalar-labs/scalardb/blob/master/docs/scalardb-supported-databases.md).
 
 :::note
 
@@ -59,9 +59,9 @@ $ ./gradlew shadowJar
 
 ### Load the schema
 
-Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
+Before loading the initial data, the tables must be defined by using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md). To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you are using to the `scalardb-benchmarks` root folder.
 
-In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx).
+In addition, you need a properties file that contains database configurations for ScalarDB. For details about configuring the ScalarDB properties file, see [ScalarDB Configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md).
 
 After applying the schema and configuring the properties file, select a benchmark and follow the instructions to create the tables.
 

--- a/versioned_docs/version-3.9/scalardb-cluster/developer-guide-for-scalardb-cluster-with-java-api.mdx
+++ b/versioned_docs/version-3.9/scalardb-cluster/developer-guide-for-scalardb-cluster-with-java-api.mdx
@@ -214,7 +214,7 @@ scalar.db.contact_points=direct-kubernetes:ns/scalardb-cluster
 ### Schema Loader for Cluster
 
 To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster).
-Using the Schema Loader for Cluster is basically the same as using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different.
+Using the Schema Loader for Cluster is basically the same as using the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different.
 You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.9.4).
 After downloading the JAR file, you can run Schema Loader for Cluster with the following command:
 
@@ -251,7 +251,7 @@ This section describes how to use ScalarDB Cluster SQL though JDBC and Spring Da
 
 ### ScalarDB Cluster SQL via JDBC
 
-Using ScalarDB Cluster SQL via JDBC is almost the same using [ScalarDB JDBC](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx) except for how to add the JDBC driver to your project.
+Using ScalarDB Cluster SQL via JDBC is almost the same using [ScalarDB JDBC](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md) except for how to add the JDBC driver to your project.
 
 In addition to adding ScalarDB Cluster Client as described in [Add ScalarDB Cluster Client to your build](#add-scalardb-cluster-client-to-your-build), you need to add the following dependencies to your project:
 
@@ -282,11 +282,11 @@ To add the dependencies by using Maven, use the following:
 ```
 
 Other than that, using ScalarDB Cluster SQL via JDBC is the same as using ScalarDB JDBC.
-For details about ScalarDB JDBC, see [ScalarDB JDBC Guide](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx).
+For details about ScalarDB JDBC, see [ScalarDB JDBC Guide](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md).
 
 ### ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB
 
-Similar to ScalarDB Cluster SQL via JDBC, using ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB is almost the same as using [Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx) except for how to add it to your project.
+Similar to ScalarDB Cluster SQL via JDBC, using ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB is almost the same as using [Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md) except for how to add it to your project.
 
 In addition to adding ScalarDB Cluster Client as described in [Add ScalarDB Cluster Client to your build](#add-scalardb-cluster-client-to-your-build), you need to add the following dependencies to your project:
 
@@ -317,7 +317,7 @@ To add the dependencies by using Maven, use the following:
 ```
 
 Other than that, using ScalarDB Cluster SQL via Spring Data JDBC for ScalarDB is the same as using Spring Data JDBC for ScalarDB.
-For details about Spring Data JDBC for ScalarDB, see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details about Spring Data JDBC for ScalarDB, see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ### Client configurations
 
@@ -345,16 +345,16 @@ scalar.db.sql.connection_mode=cluster
 scalar.db.sql.cluster_mode.contact_points=direct-kubernetes:ns/scalardb-cluster
 ```
 
-For details about how to configure ScalarDB JDBC, see [JDBC connection URL](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx#jdbc-connection-url).
+For details about how to configure ScalarDB JDBC, see [JDBC connection URL](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md#jdbc-connection-url).
 
-For details about how to configure Spring Data JDBC for ScalarDB, see [Configurations](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx#configurations).
+For details about how to configure Spring Data JDBC for ScalarDB, see [Configurations](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md#configurations).
 
 
 ### SQL CLI for Cluster
 
 You need to use the dedicated SQL CLI for ScalarDB Cluster (SQL CLI for Cluster).
 
-Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.mdx) except the name of the JAR file is different.
+Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.md) except the name of the JAR file is different.
 You can download the SQL CLI for Cluster from [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.9.4).
 After downloading the JAR file, you can run SQL CLI for Cluster with the following command:
 

--- a/versioned_docs/version-3.9/scalardb-cluster/getting-started-with-scalardb-cluster-graphql.mdx
+++ b/versioned_docs/version-3.9/scalardb-cluster/getting-started-with-scalardb-cluster-graphql.mdx
@@ -99,7 +99,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 ## Step 3. Load a schema
 
 To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster).
-Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different.
+Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different.
 You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.9.4).
 After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
 

--- a/versioned_docs/version-3.9/scalardb-cluster/getting-started-with-scalardb-cluster-sql-jdbc.mdx
+++ b/versioned_docs/version-3.9/scalardb-cluster/getting-started-with-scalardb-cluster-sql-jdbc.mdx
@@ -132,7 +132,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 ## Step 4. Load a schema
 
 To load a schema via ScalarDB Cluster SQL, you need to use the dedicated SQL CLI for ScalarDB Cluster (SQL CLI for Cluster).
-Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.mdx) except the name of the JAR file is different.
+Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.md) except the name of the JAR file is different.
 You can download the SQL CLI for Cluster from [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.9.4).
 After downloading the JAR file, you can use SQL CLI for Cluster by running the following command:
 

--- a/versioned_docs/version-3.9/scalardb-cluster/getting-started-with-scalardb-cluster-sql-spring-data-jdbc.mdx
+++ b/versioned_docs/version-3.9/scalardb-cluster/getting-started-with-scalardb-cluster-sql-spring-data-jdbc.mdx
@@ -132,7 +132,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 ## Step 4. Load a schema
 
 To load a schema via ScalarDB Cluster SQL, you need to use the dedicated SQL CLI for ScalarDB Cluster (SQL CLI for Cluster).
-Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.mdx) except the name of the JAR file is different.
+Using the SQL CLI for Cluster is basically the same as using the [ScalarDB SQL Command Line Interface](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/command-line-interface.md) except the name of the JAR file is different.
 You can download the SQL CLI for Cluster from [Releases](https://github.com/scalar-labs/scalardb-cluster/releases/tag/v3.9.4).
 After downloading the JAR file, you can run SQL CLI for Cluster with the following command:
 

--- a/versioned_docs/version-3.9/scalardb-cluster/getting-started-with-scalardb-cluster.mdx
+++ b/versioned_docs/version-3.9/scalardb-cluster/getting-started-with-scalardb-cluster.mdx
@@ -7,7 +7,7 @@ This tutorial describes how to create a sample application that uses [ScalarDB C
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample/README.mdx) but takes advantage of ScalarDB Cluster.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample/README.md) but takes advantage of ScalarDB Cluster.
 
 The following diagram shows the system architecture of the sample application:
 

--- a/versioned_docs/version-3.9/scalardb-cluster/getting-started-with-using-go-for-scalardb-cluster.mdx
+++ b/versioned_docs/version-3.9/scalardb-cluster/getting-started-with-using-go-for-scalardb-cluster.mdx
@@ -67,7 +67,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 
 ## Step 3. Load a schema
 
-To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
+To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
 
 ```shell
 $ java -jar scalardb-cluster-schema-loader-3.9.4-all.jar --config database.properties -f schema.json --coordinator

--- a/versioned_docs/version-3.9/scalardb-cluster/getting-started-with-using-python-for-scalardb-cluster.mdx
+++ b/versioned_docs/version-3.9/scalardb-cluster/getting-started-with-using-python-for-scalardb-cluster.mdx
@@ -67,7 +67,7 @@ For details about the client modes, see [Developer Guide for ScalarDB Cluster wi
 
 ## Step 3. Load a schema
 
-To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
+To load a schema via ScalarDB Cluster, you need to use the dedicated Schema Loader for ScalarDB Cluster (Schema Loader for Cluster). Using the Schema Loader for Cluster is basically the same as using the [Schema Loader for ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md) except the name of the JAR file is different. You can download the Schema Loader for Cluster at [Releases](https://github.com/scalar-labs/scalardb-cluster/releases). After downloading the JAR file, you can run the Schema Loader for Cluster with the following command:
 
 ```shell
 $ java -jar scalardb-cluster-schema-loader-3.9.4-all.jar --config database.properties -f schema.json --coordinator

--- a/versioned_docs/version-3.9/scalardb-cluster/scalardb-cluster-configurations.mdx
+++ b/versioned_docs/version-3.9/scalardb-cluster/scalardb-cluster-configurations.mdx
@@ -3,7 +3,7 @@
 This document describes the configurations for ScalarDB Cluster.
 ScalarDB Cluster consists of multiple cluster nodes, and you need to configure each cluster node.
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), you can configure the following configurations for each cluster node.
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), you can configure the following configurations for each cluster node.
 
 ## Basic configurations
 

--- a/versioned_docs/version-3.9/scalardb-cluster/scalardb-cluster-sql-grpc-api-guide.mdx
+++ b/versioned_docs/version-3.9/scalardb-cluster/scalardb-cluster-sql-grpc-api-guide.mdx
@@ -51,7 +51,7 @@ By calling `Begin`, you receive a transaction ID in the response, which you can 
 Also, you can call `Execute` without a transaction ID to execute a one-shot transaction.
 In this case, the transaction is automatically committed after it is executed.
 You can use this method to execute DDL statements as well.
-For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.mdx).
+For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.md).
 Please note, however, that `Execute` supports only DML and DDL statements.
 
 When you call `Begin`, you can optionally specify a transaction ID.
@@ -126,7 +126,7 @@ By calling `Begin` or `Join`, you receive a transaction ID in the response, whic
 
 In addition, you can call `Execute` without a transaction ID to execute a one-shot transaction.
 In this case, the transaction is automatically committed after it is executed.
-You can use this method to execute DDL statements as well. For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.mdx).
+You can use this method to execute DDL statements as well. For details on the supported SQL statements, refer to [ScalarDB SQL Grammar](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/grammar.md).
 Please note, however, that `Execute` supports only DML and DDL statements.
 
 When you call `Begin`, you can optionally specify a transaction ID.

--- a/versioned_docs/version-3.9/scalardb-graphql/aws-deployment-guide.mdx
+++ b/versioned_docs/version-3.9/scalardb-graphql/aws-deployment-guide.mdx
@@ -26,7 +26,7 @@ In this document, a placeholder cluster name `<your-cluster-name>` will be used 
 
 We need to load a database schema to the database before starting ScalarDB GraphQL.
 
-Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.mdx).
+Here is an example for DynamoDB. For other databases and more detailed instructions, please refer to the [ScalarDB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/docs/schema-loader.md).
 
 1. Create a `database.properties` configuration file for DynamoDB
 

--- a/versioned_docs/version-3.9/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
+++ b/versioned_docs/version-3.9/scalardb-graphql/getting-started-with-scalardb-graphql.mdx
@@ -6,7 +6,7 @@ In this Getting Started guide, you will run a GraphQL server on your local machi
 
 ## Prerequisites
 
-We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) if you have not set them up yet.
+We assume you have already installed Docker and have access to a ScalarDB-supported database such as Cassandra. Please configure them first by following [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) if you have not set them up yet.
 
 You need a Personal Access Token (PAT) to access the Docker image of ScalarDB GraphQL in GitHub Container registry since the image is private. Ask a person in charge to get your account ready. Please read [the official document](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more detail.
 

--- a/versioned_docs/version-3.9/scalardb-graphql/index.mdx
+++ b/versioned_docs/version-3.9/scalardb-graphql/index.mdx
@@ -12,7 +12,7 @@ To build and install the ScalarDB GraphQL Server, use `./gradlew installDist`, w
 
 ## Run
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), the GraphQL server reads the following:
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), the GraphQL server reads the following:
 
 * `scalar.db.graphql.port` ... Port number for GraphQL server. The default is `8080`.
 * `scalar.db.graphql.path` ... Path component of the URL of the GraphQL endpoint. The default is `/graphql`.

--- a/versioned_docs/version-3.9/scalardb-samples/microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.9/scalardb-samples/microservice-transaction-sample/README.mdx
@@ -4,7 +4,7 @@ This tutorial describes how to create a sample application that supports microse
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) when using ScalarDB.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample/README.mdx) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) when using ScalarDB.
 
 The sample application has two microservices called the *Customer Service* and the *Order Service* based on the [database-per-service pattern](https://microservices.io/patterns/data/database-per-service.html):
 

--- a/versioned_docs/version-3.9/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
+++ b/versioned_docs/version-3.9/scalardb-samples/scalardb-sql-jdbc-sample/README.mdx
@@ -19,7 +19,7 @@ The database that you will be using in the sample application is Cassandra. Alth
 
 :::note
 
-Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.mdx#handle-sqlexception).
+Since the focus of the sample application is to demonstrate using ScalarDB SQL (JDBC), application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB SQL (JDBC), see [Handle SQLException](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/jdbc-guide.md#handle-sqlexception).
 
 :::
 

--- a/versioned_docs/version-3.9/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.9/scalardb-samples/spring-data-microservice-transaction-sample/README.mdx
@@ -2,7 +2,7 @@
 
 This tutorial describes how to create a sample Spring Boot application for microservice transactions by using Spring Data JDBC for ScalarDB.
 
-For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.mdx) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details about these features, see [Two-phase Commit Transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) and [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ## Prerequisites
 

--- a/versioned_docs/version-3.9/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
+++ b/versioned_docs/version-3.9/scalardb-samples/spring-data-multi-storage-transaction-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB with Multi-storage Transaction.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB with Multi-storage Transaction.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ![Overview](images/overview.png)
 

--- a/versioned_docs/version-3.9/scalardb-samples/spring-data-sample/README.mdx
+++ b/versioned_docs/version-3.9/scalardb-samples/spring-data-sample/README.mdx
@@ -34,7 +34,7 @@ For more details, see [Install - ScalarDB SQL](https://github.com/scalar-labs/sc
 
 This tutorial describes how to create a sample Spring Boot application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using Spring Data JDBC for ScalarDB.
 Please note that application-specific error handling, authentication processing, etc. are omitted in the sample application since this tutorial focuses on explaining how to use Spring Data JDBC for ScalarDB.
-For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.mdx).
+For details, please see [Guide of Spring Data JDBC for ScalarDB](https://github.com/scalar-labs/scalardb-sql/blob/main/docs/spring-data-guide.md).
 
 ### Schema
 

--- a/versioned_docs/version-3.9/scalardb-sql/configurations.mdx
+++ b/versioned_docs/version-3.9/scalardb-sql/configurations.mdx
@@ -33,7 +33,7 @@ The configurations for Direct mode are as follows:
 | `scalar.db.sql.statement_cache.size`    | Maximum number of cached statements. | `100`   |
 
 Note that in Direct mode, you need to configure the transaction manager, as well.
-For details about configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations).
+For details about configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations).
 
 In addition, for details about ScalarDB SQL Server, see [ScalarDB SQL Server](sql-server.mdx).
 
@@ -54,7 +54,7 @@ The configurations for Server mode are as follows:
 ScalarDB SQL Server is a gRPC server that implements the ScalarDB SQL interface.
 This section explains the ScalarDB SQL Server configurations.
 
-In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#other-configurations), the following configurations are available for ScalarDB SQL Server:
+In addition to the configurations described in [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations) and [Other configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#other-configurations), the following configurations are available for ScalarDB SQL Server:
 
 | Name                                             | Description                                      | Default                |
 |--------------------------------------------------|--------------------------------------------------|------------------------|

--- a/versioned_docs/version-3.9/scalardb-sql/getting-started-with-jdbc.mdx
+++ b/versioned_docs/version-3.9/scalardb-sql/getting-started-with-jdbc.mdx
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with ScalarDB JDBC with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for ScalarDB exists.
 
@@ -222,7 +222,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how ScalarDB JDBC is used. For more information, please take a look at the following documents.
 
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB JDBC Guide](jdbc-guide.mdx)
 * [ScalarDB SQL Grammar](grammar.mdx)
 * [ScalarDB SQL Command Line interface](command-line-interface.mdx)

--- a/versioned_docs/version-3.9/scalardb-sql/getting-started-with-sql.mdx
+++ b/versioned_docs/version-3.9/scalardb-sql/getting-started-with-sql.mdx
@@ -2,7 +2,7 @@
 
 This document briefly explains how you can get started with ScalarDB SQL with a simple electronic money application.
 Here we assume Oracle JDK 8 and the underlying storage/database such as Cassandra are properly configured.
-Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx) for the details of how to configure the underlying storage/database.
+Please see [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md) for the details of how to configure the underlying storage/database.
 
 From this point forward, we will assume that **scalardb.properties** that holds the configuration for ScalarDB exists.
 
@@ -210,7 +210,7 @@ $ ./gradlew run --args="-action getBalance -id merchant1"
 
 These are just simple examples of how ScalarDB SQL is used. For more information, please take a look at the following documents.
 
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL API Guide](sql-api-guide.mdx)
 * [ScalarDB SQL Grammar](grammar.mdx)
 * [ScalarDB SQL Command Line interface](command-line-interface.mdx)

--- a/versioned_docs/version-3.9/scalardb-sql/grammar.mdx
+++ b/versioned_docs/version-3.9/scalardb-sql/grammar.mdx
@@ -86,7 +86,7 @@ CreateNamespaceStatement statement3 =
 
 `CREATE TABLE` command creates a table.
 
-Please see [ScalarDB design document - Data Model](https://github.com/scalar-labs/scalardb/blob/master/docs/design.mdx#data-model) for the details of the ScalarDB Data Model.
+Please see [ScalarDB design document - Data Model](https://github.com/scalar-labs/scalardb/blob/master/docs/design.md#data-model) for the details of the ScalarDB Data Model.
 
 #### Grammar
 

--- a/versioned_docs/version-3.9/scalardb-sql/sql-server.mdx
+++ b/versioned_docs/version-3.9/scalardb-sql/sql-server.mdx
@@ -81,7 +81,7 @@ scalar.db.consensus_commit.isolation_level=SNAPSHOT
 scalar.db.consensus_commit.serializable_strategy=
 ```
 
-For more details about the configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.mdx#transaction-manager-configurations).
+For more details about the configurations for the transaction manager, see [Transaction manager configurations](https://github.com/scalar-labs/scalardb/blob/master/docs/configurations.md#transaction-manager-configurations).
 
 In addition, for more details about the configurations for ScalarDB SQL Server, see [ScalarDB SQL Configurations](configurations.mdx).
 
@@ -153,5 +153,5 @@ Please see [ScalarDB SQL Configurations](configurations.mdx) for more details of
 
 * [Getting Started with ScalarDB SQL](getting-started-with-sql.mdx)
 * [Getting Started with ScalarDB JDBC](getting-started-with-jdbc.mdx)
-* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.mdx)
+* [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md)
 * [ScalarDB SQL Configurations](configurations.mdx)


### PR DESCRIPTION
## Description

This PR fixes links that weren't changed when doing a find and replace (by using VS Code) before publishing the new docs site.

## Related issues and/or PRs

N/A

## Changes made

- Used IntelliJ IDEA to do a find and replace for Markdown files in GitHub links, changing the extension from `.mdx` to `.md`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A