### PR TITLE
Add border to Cards

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -49,11 +49,17 @@ div[class^='announcementBar'] {
   padding: 20px 0;
 }
 
-div[class='card'] a {
+/* Home page cards */
+
+.card {
+  border: 1px solid #ebedf0;
+}
+
+.card a {
   color: var(--ifm-color-content);
 }
 
-div[class='card'] a:hover {
+.card a:hover {
   background-color: #2673BB;
   color: white;
   text-decoration: none;


### PR DESCRIPTION
## Description

This PR adds a border to Cards so that they are easier to see when they are not being hovered over.

## Related issues and/or PRs

N/A

## Changes made

- Added a light gray border to the style for Cards in `custom.css`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A