### PR TITLE
Fix typo on homepage

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -4,7 +4,7 @@ import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, Ca
 
 ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real-time analytics across diverse databases to simplify the complexity of managing multiple databases.
 
-**About ScalarDL**
+**About ScalarDB**
 
 <CardRowAbout />
 


### PR DESCRIPTION
## Description

This PR fixes a typo on the homepage.

## Related issues and/or PRs

N/A

## Changes made

- Fixed a typo (`ScalarDL` instead of `ScalarDB` ) on the homepage.
 
## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A