### PR TITLE
Remove ScalarDB GraphQL and ScalarDB SQL samples from sidebar navigation in versions 3.9 to 3.12

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -91,8 +91,6 @@ const sidebars = {
         'scalardb-samples/multi-storage-transaction-sample/README',
         'scalardb-samples/microservice-transaction-sample/README',
         'scalardb-samples/scalardb-analytics-postgresql-sample/README',
-        'scalardb-samples/scalardb-graphql-sample/README',
-        'scalardb-samples/scalardb-sql-jdbc-sample/README',
         'scalardb-samples/spring-data-sample/README',
         'scalardb-samples/spring-data-multi-storage-transaction-sample/README',
         'scalardb-samples/spring-data-microservice-transaction-sample/README',

--- a/versioned_sidebars/version-3.10-sidebars.json
+++ b/versioned_sidebars/version-3.10-sidebars.json
@@ -56,8 +56,6 @@
         "scalardb-samples/multi-storage-transaction-sample/README",
         "scalardb-samples/microservice-transaction-sample/README",
         "scalardb-samples/scalardb-analytics-postgresql-sample/README",
-        "scalardb-samples/scalardb-graphql-sample/README",
-        "scalardb-samples/scalardb-sql-jdbc-sample/README",
         "scalardb-samples/spring-data-sample/README",
         "scalardb-samples/spring-data-multi-storage-transaction-sample/README",
         "scalardb-samples/spring-data-microservice-transaction-sample/README"

--- a/versioned_sidebars/version-3.11-sidebars.json
+++ b/versioned_sidebars/version-3.11-sidebars.json
@@ -72,8 +72,6 @@
         "scalardb-samples/multi-storage-transaction-sample/README",
         "scalardb-samples/microservice-transaction-sample/README",
         "scalardb-samples/scalardb-analytics-postgresql-sample/README",
-        "scalardb-samples/scalardb-graphql-sample/README",
-        "scalardb-samples/scalardb-sql-jdbc-sample/README",
         "scalardb-samples/spring-data-sample/README",
         "scalardb-samples/spring-data-multi-storage-transaction-sample/README",
         "scalardb-samples/spring-data-microservice-transaction-sample/README"

--- a/versioned_sidebars/version-3.9-sidebars.json
+++ b/versioned_sidebars/version-3.9-sidebars.json
@@ -56,8 +56,6 @@
         "scalardb-samples/multi-storage-transaction-sample/README",
         "scalardb-samples/microservice-transaction-sample/README",
         "scalardb-samples/scalardb-analytics-postgresql-sample/README",
-        "scalardb-samples/scalardb-graphql-sample/README",
-        "scalardb-samples/scalardb-sql-jdbc-sample/README",
         "scalardb-samples/spring-data-sample/README",
         "scalardb-samples/spring-data-multi-storage-transaction-sample/README",
         "scalardb-samples/spring-data-microservice-transaction-sample/README"


### PR DESCRIPTION
## Description

This PR removes ScalarDB GraphQL and ScalarDB SQL samples from the sidebar navigation in versions 3.9 to 3.12. Since ScalarDB Cluster has replaced the standalone ScalarDB GraphQL and ScalarDB SQL components as of ScalarDB 3.9, the samples have been deprecated.

## Related issues and/or PRs

N/A

## Changes made

- Removed ScalarDB GraphQL and ScalarDB SQL samples from the sidebar navigation in versions 3.9 to 3.12.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A