### PR TITLE
Add ScalarDB Analytics with Spark docs for ScalarDB 3.12

### DIFF
--- a/docs/scalardb-analytics-spark/README.mdx
+++ b/docs/scalardb-analytics-spark/README.mdx
@@ -1,0 +1,20 @@
+# ScalarDB Analytics with Spark
+
+ScalarDB, as a universal transaction manager, targets mainly transactional workloads and therefore supports limited subsets of relational queries.
+
+ScalarDB Analytics with Spark extends the functionality of ScalarDB to process analytical queries on ScalarDB-managed data by using Apache Spark and Spark SQL.
+
+Since ScalarDB Analytics with Spark is provided as a Spark catalog plugin, you can read externally managed data sources with its data schema. By using this plugin, you can read data from ScalarDB tables as Spark SQL tables with the same schema.
+
+:::warning
+
+You must have a commercial license to use ScalarDB Analytics with Spark. If you need a commercial license, please [contact us](https://scalar-labs.com/contact_us/).
+
+:::
+
+## Further reading
+
+* To run ad-hoc analytical queries or development applications by using ScalarDB Analytics with Spark, see [Getting Started with ScalarDB Analytics with Spark](getting-started.mdx).
+* For tutorials on how to use ScalarDB Analytics with Spark by using a sample dataset and application, see [Run Analytical Queries on Sample Data by Using ScalarDB Analytics with Spark](../scalardb-samples/scalardb-analytics-spark-sample/README.mdx).
+* For details on how to configure ScalarDB Analytics with Spark, see [Configuration of ScalarDB Analytics with Spark](configuration.mdx).
+* For supported Spark and Scala versions, see [Version Compatibility of ScalarDB Analytics with Spark](version-compatibility.mdx)

--- a/docs/scalardb-analytics-spark/configuration.mdx
+++ b/docs/scalardb-analytics-spark/configuration.mdx
@@ -1,0 +1,120 @@
+# Configuration of ScalarDB Analytics with Spark
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+There are two ways to configure ScalarDB Analytics with Spark:
+
+- By configuring the properties in `spark.conf`
+- By using the helper method that ScalarDB Analytics with Spark provides
+
+Both ways are conceptually equivalent processes, so you can choose either one based on your preference.
+
+## Configure ScalarDB Analytics with Spark by using `spark.conf`
+
+Since ScalarDB Analytics with Spark is provided as a Spark custom catalog plugin, you can enable ScalarDB Analytics with Spark via `spark.conf`.
+
+```properties
+spark.sql.catalog.scalardb_catalog = com.scalar.db.analytics.spark.datasource.ScalarDbCatalog
+spark.sql.catalog.scalardb_catalog.config = /<PATH_TO_YOUR_SCALARDB_PROPERTIES>/config.properties
+spark.sql.catalog.scalardb_catalog.namespaces = <YOUR_NAMESPACE_NAME_2>,<YOUR_NAMESPACE_NAME_2>
+spark.sql.catalog.scalardb_catalog.license.key = {"your":"license", "key":"in", "json":"format"}
+spark.sql.catalog.scalardb_catalog.license.cert_path = /<PATH_TO_YOUR_LICENSE>/cert.pem
+```
+
+:::note
+
+The `scalardb_catalog` part is a configurable catalog name. You may choose any name you prefer.
+
+:::
+
+### Available properties
+
+The following is a list of available properties for ScalarDB Analytics with Spark:
+
+| Property name                                        | Required                                       | Description                                                             |
+|------------------------------------------------------|------------------------------------------------|-------------------------------------------------------------------------|
+| `spark.sql.catalog.{catalog_name}`                   | Yes                                            | Must be `com.scalar.db.analytics.spark.datasource.ScalarDbCatalog`      |
+| `spark.sql.catalog.{catalog_name}.config`            | Yes                                            | Path to the ScalarDB configuration file                                 |
+| `spark.sql.catalog.{catalog_name}.namespaces`        | Yes                                            | Comma-separated list of ScalarDB namespaces to import to the Spark side |
+| `spark.sql.catalog.{catalog_name}.license.key`       | Yes                                            | Your license key in the JSON format                                     |
+| `spark.sql.catalog.{catalog_name}.license.cert_path` | Either this or `license.cert_pem` is required  | Path to your license certificate file                                   |
+| `spark.sql.catalog.{catalog_name}.license.cert_pem`  | Either this or `license.cert_path` is required | Your license certificate in the PEM format                              |
+
+### Importing schemas
+
+After properly setting `spark.conf`, you should have a catalog in your Spark environment, which contains tables connected to the underlying databases of ScalarDB. However, the catalog provides access to raw tables that contain transaction metadata, which is managed by ScalarDB. Instead, you may only be interested in the application-managed data without transaction metadata.
+
+For this purpose, ScalarDB Analytics with Spark provides the `SchemaImporter` class, which creates views that interpret the transaction metadata and show only application-managed data. Those views have an equivalent schema to the ScalarDB tables, and users can use the views as if they were ScalarDB tables. The following is an example of how to run `SchemaImporter` with the properly set catalog.
+
+```java
+import com.scalar.db.analytics.spark.view.SchemaImporter
+
+class YourApp {
+  public static void main(String[] args) {
+    SparkSession spark = SparkSession.builder().appName("<YOUR_APPLICATION_NAME>").getOrCreate()
+    new SchemaImporter(spark, "scalardb_catalog").run() // Import ScalarDB table schemas from the catalog named "scalardb_catalog"
+    spark.sql("select * from <YOUR_NAMESPACE_NAME_1>.<YOUR_TABLE_NAME>").show()
+    spark.stop()
+  }
+}
+```
+
+## Configure ScalarDB Analytics with Spark by using the helper method
+
+You can use a helper method that ScalarDB Analytics with Spark provides to get everything set up to run analytical queries, including configuring the catalog and importing the schemas. In addition, you can use the helper method to set up ScalarDB Analytics with Spark in application code. This would be useful for doing a quick test without prior configuration.
+
+The helper method is provided through Java and Scala. In Java, you can use `ScalarDbAnalyticsInitializer` to specify the options, which are equivalent to the properties in `spark.conf`, as follows:
+
+```java
+import com.scalar.db.analytics.spark.ScalarDbAnalyticsInitializer
+
+class YourApp {
+  public static void main(String[] args) {
+    // Initialize SparkSession as usual
+    SparkSession spark = SparkSession.builder().appName("<YOUR_APPLICATION_NAME>").getOrCreate()
+    // Setup ScalarDB Analytics with Spark via helper class
+    ScalarDbAnalyticsInitializer
+      .builder()
+      .spark(spark)
+      .configPath("/<PATH_TO_YOUR_SCALARDB_PROPERTIES>/config.properties")
+      .namespace("<YOUR_NAMESPACE_NAME_1>")
+      .namespace("<YOUR_NAMESPACE_NAME_2>")
+      .licenseKey("{\"your\":\"license\", \"key\":\"in\", \"json\":\"format\"}")
+      .licenseCertPath("/<PATH_TO_YOUR_LICENSE>/cert.pem")
+      .build()
+      .run()
+    // Run arbitrary queries
+    spark.sql("select * from <YOUR_NAMESPACE_NAME_1>.<YOUR_TABLE_NAME>").show()
+    // Stop SparkSession
+    spark.stop()
+  }
+}
+```
+
+In Scala, the `setupScalarDbAnalytics` method is available as an extension of `SparkSession`:
+
+```scala
+import com.scalar.db.analytics.spark.implicits._
+
+object YourApp {
+  def main(args: Array[String]): Unit = {
+    // Initialize SparkSession as usual
+    val spark = SparkSession.builder.appName("<YOUR_APPLICATION_NAME>").getOrCreate()
+    // Setup ScalarDB Analytics with Spark via helper method
+    spark.setupScalarDbAnalytics(
+      // ScalarDB config file
+      configPath = "/<PATH_TO_YOUR_SCALARDB_PROPERTIES>/config.properties", 
+      // Namespaces in ScalarDB to import
+      namespaces = Set("<YOUR_NAMESPACE_NAME_1>", "<YOUR_NAMESPACE_NAME_2>"),
+      // License information
+      license = License.certPath("""{"your":"license", "key":"in", "json":"format"}""", "/<PATH_TO_YOUR_LICENSE>/cert.pem")
+    )
+    // Run arbitrary queries
+    spark.sql("select * from <YOUR_NAMESPACE_NAME_1>.<YOUR_TABLE_NAME>").show()
+    // Stop SparkSession
+    spark.stop()
+  }
+}
+```
+

--- a/docs/scalardb-analytics-spark/getting-started.mdx
+++ b/docs/scalardb-analytics-spark/getting-started.mdx
@@ -1,0 +1,174 @@
+# Getting Started with ScalarDB Analytics with Spark
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+This guide explains how to get started with ScalarDB Analytics with Spark.
+
+## Prerequisites
+
+Before you can run queries with ScalarDB Analytics with Spark, you'll need to set up ScalarDB tables and install Apache Spark.
+
+### Set up ScalarDB tables
+
+To use ScalarDB Analytics with Spark, you need at least one underlying database in ScalarDB to run analytical queries on. If you have your own underlying database set up in ScalarDB, you can skip this section and use your database instead.
+
+If you don't have your own database set up yet, you can set up ScalarDB with a sample underlying database by following the instructions in [Run Analytical Queries on Sample Data by Using ScalarDB Analytics with Spark](../scalardb-samples/scalardb-analytics-spark-sample/README.mdx).
+
+### Install Apache Spark
+
+You also need a packaged release of Apache Spark. If you already have Spark installed, you can skip this section.
+
+If you need Spark, you can download it from the [Spark website](https://spark.apache.org/downloads.html). After downloading the compressed Spark file, you'll need to uncompress the file by running the following command, replacing `X.X.X` with the version of Spark that you downloaded:
+
+```console
+$ tar xf spark-X.X.X-bin-hadoop3.tgz
+```
+
+Then, enter the directory by running the following command, again replacing `X.X.X` with the version of Spark that you downloaded:
+
+```console
+$ cd spark-X.X.X-bin-hadoop3
+```
+
+## Configure the Spark shell
+
+The following explains how to perform interactive analysis by using the Spark shell.
+
+Since ScalarDB Analytics with Spark is available on the Maven Central Repository, you can use it to enable ScalarDB Analytics with Spark in the Spark shell by using the `--packages` option, replacing `<SPARK_VERSION>_<SCALA_VERSION>:<SCALARDB_ANALYTICS_WITH_SPARK_VERSION>` with the versions that you're using.
+
+```console
+$ ./bin/spark-shell --packages com.scalar-labs:scalardb-analytics-spark-<SPARK_VERSION>_<SCALA_VERSION>:<SCALARDB_ANALYTICS_WITH_SPARK_VERSION>
+```
+
+:::warning
+
+ScalarDB Analytics with Spark offers different artifacts for various Spark and Scala versions, provided in the format `scalardb-analytics-spark-<SPARK_VERSION>_<SCALA_VERSION>`. Make sure that you select the artifact matching the Spark and Scala versions you're using.
+
+For reference, see [Version Compatibility of ScalarDB Analytics with Spark](version-compatibility.mdx).
+
+:::
+
+Next, you'll need to configure the ScalarDB Analytics with Spark environment in the shell. ScalarDB Analytics with Spark provides a helper method for this purpose, which get everything set up to run analytical queries for you.
+
+```scala
+spark-shell> import com.scalar.db.analytics.spark.implicits._
+spark-shell> spark.setupScalarDbAnalytics(
+           | // ScalarDB config file
+           | configPath = "/<PATH_TO_YOUR_SCALARDB_PROPERTIES>/config.properties", 
+           | // Namespaces in ScalarDB to import
+           | namespaces = Set("<YOUR_NAMESPACE_NAME_1>", "<YOUR_NAMESPACE_NAME_2>"),
+           | // License information
+           | license = License.certPath("""{"your":"license", "key":"in", "json":"format"}""", "/<PATH_TO_YOUR_LICENSE>/cert.pem")
+           | )
+```
+
+Now, you can read data from the tables in the underlying databases of ScalarDB and run any arbitrary analytical queries through the Spark Dataset API. For example:
+
+```console
+spark-shell> spark.sql("select * from <YOUR_NAMESPACE_NAME_1>.<YOUR_TABLE_NAME>").show()
+````
+
+## Implement and submit a Spark application
+
+This section explains how to implement a Spark application with ScalarDB Analytics with Spark and submit it to the Spark cluster.
+
+You can integrate ScalarDB Analytics with Spark into your application by using build tools like SBT, Gradle, or Maven. 
+
+<Tabs groupId="implementation" queryString>
+  <TabItem value="gradle" label="Gradle" default>
+    For Gradle projects, add the following to your `build.gradle.kts` file, replacing `<SPARK_VERSION>_<SCALA_VERSION>:<SCALARDB_ANALYTICS_WITH_SPARK_VERSION>` with the versions that you're using:
+
+    ```kotlin
+    implementation("com.scalar-labs:scalardb-analytics-spark-<SPARK_VERSION>_<SCALA_VERSION>:<SCALARDB_ANALYTICS_WITH_SPARK_VERSION>")
+    ```
+  </TabItem>
+  <TabItem value="maven" label="Maven" default>
+    To configure Gradle by using Groovy, add the following to your `build.gradle` file, replacing `<SPARK_VERSION>_<SCALA_VERSION>:<SCALARDB_ANALYTICS_WITH_SPARK_VERSION>` with the versions that you're using:
+
+    ```groovy
+    implementation 'com.scalar-labs:scalardb-analytics-spark-<SPARK_VERSION>_<SCALA_VERSION>:<SCALARDB_ANALYTICS_WITH_SPARK_VERSION>'
+    ```
+  </TabItem>
+  <TabItem value="sbt" label="SBT">
+    To add your application to an SBT project, insert the following into your `build.sbt` file, replacing `<SPARK_VERSION>` and `<SCALA_VERSION>` with the versions that you're using:
+
+    ```scala
+    libraryDependencies += "com.scalar-labs" %% "scalardb-analytics-spark-<SPARK_VERSION>" % "<SCALA_VERSION>"
+    ```
+  </TabItem>
+</Tabs>
+
+After integrating ScalarDB Analytics with Spark into your application, you can use the same helper method explained above to configure ScalarDB Analytics with Spark in your Spark application. 
+
+<Tabs groupId="helper_method" queryString>
+  <TabItem value="Scala" label="Scala" default>
+    The following is a sample application that uses Scala:
+
+    ```scala
+    import com.scalar.db.analytics.spark.implicits._
+
+    object YourApp {
+      def main(args: Array[String]): Unit = {
+        // Initialize SparkSession as usual
+        val spark = SparkSession.builder.appName("<YOUR_APPLICATION_NAME>").getOrCreate()
+        // Setup ScalarDB Analytics with Spark via helper method
+        spark.setupScalarDbAnalytics(
+          // ScalarDB config file
+          configPath = "/<PATH_TO_YOUR_SCALARDB_PROPERTIES>/config.properties", 
+          // Namespaces in ScalarDB to import
+          namespaces = Set("<YOUR_NAMESPACE_NAME_1>", "<YOUR_NAMESPACE_NAME_2>"),
+          // License information
+          license = License.certPath("""{"your":"license", "key":"in", "json":"format"}""", "/<PATH_TO_YOUR_LICENSE>/cert.pem")
+        )
+        // Run arbitrary queries
+        spark.sql("select * from <YOUR_NAMESPACE_NAME_1>.<YOUR_TABLE_NAME>").show()
+        // Stop SparkSession
+        spark.stop()
+      }
+    }
+    ```
+  </TabItem>
+    <TabItem value="Java" label="Java">
+    You can write a Spark application with ScalarDB Analytics with Spark in Java:
+
+    ```java
+    import com.scalar.db.analytics.spark.ScalarDbAnalyticsInitializer
+
+    class YourApp {
+      public static void main(String[] args) {
+        // Initialize SparkSession as usual
+        SparkSession spark = SparkSession.builder().appName("<YOUR_APPLICATION_NAME>").getOrCreate()
+        // Setup ScalarDB Analytics with Spark via helper class
+        ScalarDbAnalyticsInitializer
+          .builder()
+          .spark(spark)
+          .configPath("/<PATH_TO_YOUR_SCALARDB_PROPERTIES>/config.properties")
+          .namespace("<YOUR_NAMESPACE_NAME_1>")
+          .namespace("<YOUR_NAMESPACE_NAME_2>")
+          .licenseKey("{\"your\":\"license\", \"key\":\"in\", \"json\":\"format\"}")
+          .licenseCertPath("/<PATH_TO_YOUR_LICENSE>/cert.pem")
+          .build()
+          .run()
+        // Run arbitrary queries
+        spark.sql("select * from <YOUR_NAMESPACE_NAME_1>.<YOUR_TABLE_NAME>").show()
+        // Stop SparkSession
+        spark.stop()
+      }
+    }
+    ```
+  </TabItem>
+</Tabs>
+
+Then, you need to build a .jar file by using your preferred build tool, like `sbt package` or `./gradlew assemble`.
+
+After building the .jar file, you can submit that .jar file to your Spark cluster by using `spark-submit`, using the `--packages` option to enable the ScalarDB Analytics libraries on your cluster by running the following command, replacing `<SPARK_VERSION>_<SCALA_VERSION>:<SCALARDB_ANALYTICS_WITH_SPARK_VERSION>` with the versions that you're using:
+
+```console
+$ ./bin/spark-submit \
+      --class "YourApp" \
+      --packages com.scalar-labs:scalardb-analytics-spark-<SPARK_VERSION>_<SCALA_VERSION>:<SCALARDB_ANALYTICS_WITH_SPARK_VERSION> \
+      <YOUR_APP_NAME>.jar
+```
+
+For more information about general Spark application development, see the [Apache Spark documentation](https://spark.apache.org/docs/latest/).

--- a/docs/scalardb-analytics-spark/version-compatibility.mdx
+++ b/docs/scalardb-analytics-spark/version-compatibility.mdx
@@ -1,0 +1,11 @@
+# Version Compatibility of ScalarDB Analytics with Spark
+
+Since Spark and Scala may be incompatible among different minor versions, ScalarDB Analytics with Spark offers different artifacts for various Spark and Scala versions, named in the format `scalardb-analytics-spark-<SPARK_VERSION>_<SCALA_VERSION>`. Make sure that you select the artifact matching the Spark and Scala versions you're using. For example, if you're using Spark 3.5 with Scala 2.13, you must specify `scalardb-analytics-spark-3.5_2.13`.
+
+Regarding the Java version, ScalarDB Analytics with Spark supports Java 8 or later.
+
+The following is a list of Spark and Scalar versions supported by each version of ScalarDB Analytics with Spark.
+
+| ScalarDB Analytics with Spark Version | ScalarDB Version | Spark Versions Supported | Scala Versions Supported | Minimum Java Version |
+|:---------------------------------------|:------------------|:--------------------------|:--------------------------|:----------------------|
+| 3.12                                  | 3.12             | 3.5, 3.4                 | 2.13, 2.12               | 8                    |

--- a/docs/scalardb-samples/scalardb-analytics-spark-sample/README.mdx
+++ b/docs/scalardb-samples/scalardb-analytics-spark-sample/README.mdx
@@ -1,0 +1,283 @@
+# Run Analytical Queries on Sample Data by Using ScalarDB Analytics with Spark
+
+This tutorial describes how to run analytical queries on sample data by using ScalarDB Analytics with Spark. The source code is available at https://github.com/scalar-labs/scalardb-samples/scalardb-analytics-spark-sample.
+
+:::warning
+
+You must have a commercial license to use ScalarDB Analytics with Spark. If you need a commercial license, please [contact us](https://scalar-labs.com/contact_us/).
+
+:::
+
+## What you can do in this sample application
+
+This sample tutorial shows how you can run interactive analysis in the Spark shell by using ScalarDB Analytics with Spark. In particular, you'll learn how to run the following two types of queries:
+
+- Read data and calculate summaries.
+- Join tables that span multiple storages.
+
+## Prerequisites
+
+- [Docker](https://www.docker.com/get-started/) 20.10 or later with [Docker Compose](https://docs.docker.com/compose/install/) V2 or later
+
+## Set up ScalarDB Analytics with Spark
+
+### Clone the ScalarDB samples repository
+
+Open **Terminal**, then clone the ScalarDB samples repository by running the following command:
+
+```console
+$ git clone https://github.com/scalar-labs/scalardb-samples
+```
+
+Then, go to the directory that contains the sample application by running the following command:
+
+```console
+$ cd scalardb-samples/scalardb-analytics-spark-sample
+```
+
+### Add your license certificate to the sample directory
+
+Copy your license certificate (`cert.pem`) to the sample directory by running the following command, replacing `<PATH_TO_YOUR_LICENSE>` with the path to your license:
+
+```console
+$ cp /<PATH_TO_YOUR_LICENSE>/cert.pem cert.pem
+```
+:::warning
+
+If you need a commercial license, please [contact us](https://scalar-labs.com/contact_us/).
+
+:::
+
+### Set up the sample underlying databases in ScalarDB
+
+To set up the sample underlying databases for ScalarDB, run the following command:
+
+```console
+$ docker compose up -d --wait
+```
+
+This command starts three services locally for PostgreSQL, Cassandra, and DynamoDB.
+
+Then, set up the sample databases on those services by running the following command:
+
+```console
+$ docker compose run --rm sample-data-loader
+```
+
+This command creates `postgresns`, `cassandrans`, and `dynamons` namespaces, which are mapped to the local PostgreSQL, Cassandra, and DyanmoDB services respectively, creates `postgresns.orders`, `cassandrans.lineitem`, and `dynamons.customer` tables, and loads the sample data into those tables. For details about the table schema, see [Schema details](#schema-details).
+
+### Set up ScalarDB Analytics with Spark in the Spark shell
+
+To launch the Spark shell, run the following command:
+
+```console
+$ docker compose run --rm spark-shell
+```
+
+As you can see in `docker-compose.yml`, this command executes the `spark-shell` command with the `--packages com.scalar-labs:scalardb-analytics-spark-<SPARK_VERSION>_<SCALA_VERSION>:<SCALARDB_ANALYTICS_WITH_SPARK_VERSION>` option. With this option, `spark-shell` automatically downloads ScalarDB Analytics with Spark from the Maven Central Repository and add it to the classpath of `spark-shell`.
+
+In the Spark shell console, you can set up ScalarDB Analytics with Spark by running the following commands:
+
+```console
+scala> import com.scalar.db.analytics.spark.implicits._
+scala> spark.setupScalarDbAnalytics(
+           | configPath = "/etc/scalardb.properties", 
+           | namespaces = Set("postgresns", "cassandrans", "dynamons"),
+           | license = License.certPath("""{"your":"license", "key":"in", "json":"format"}""", "/etc/cert.pem")
+           | )
+````
+
+:::warning
+
+Remember that you must have copied your license certificate to the sample directory as described in [Add your license certificate to the sample directory](#add-your-license-certificate-to-the-sample-directory), since the license is referenced in the JSON string. 
+
+If you need a commercial license, please [contact us](https://scalar-labs.com/contact_us/).
+
+:::
+
+Now, you should have tables for `postgresns.orders`, `cassandrans.lineitem`, and `dynamons.customer` on the Spark side that are equivalent to the tables in ScalarDB. For example:
+
+```console
+scala> sql("DESCRIBE postgresns.orders").show()
++---------------+---------+-------+
+|       col_name|data_type|comment|
++---------------+---------+-------+
+|     o_orderkey|      int|   NULL|
+|      o_custkey|      int|   NULL|
+|  o_orderstatus|   string|   NULL|
+|   o_totalprice|   double|   NULL|
+|    o_orderdate|   string|   NULL|
+|o_orderpriority|   string|   NULL|
+|        o_clerk|   string|   NULL|
+| o_shippriority|      int|   NULL|
+|      o_comment|   string|   NULL|
++---------------+---------+-------+
+```
+
+## Run analytical queries
+
+The following sections describe how to read data, calculate summaries, and join tables that span multiple storages.
+
+### Read data and calculate summaries
+
+You can run a query that reads data from `cassandrans.lineitem`, with the actual data stored in Cassandra, and calculates several summaries of the ordered line items by aggregating the data.
+
+To run the query, run the following command in the Spark shell console:
+
+```scala
+scala> sql("""
+     SELECT
+             l_returnflag,
+             l_linestatus,
+             sum(l_quantity) AS sum_qty,
+             sum(l_extendedprice) AS sum_base_price,
+             sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+             sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+             avg(l_quantity) AS avg_qty,
+             avg(l_extendedprice) AS avg_price,
+             avg(l_discount) AS avg_disc,
+             count(*) AS count_order
+     FROM
+             cassandrans.lineitem
+     WHERE
+             to_date(l_shipdate, 'yyyy-MM-dd') <= date '1998-12-01' - 3
+     GROUP BY
+             l_returnflag,
+             l_linestatus
+     ORDER BY
+             l_returnflag,
+             l_linestatus;
+     """).show()
+```
+
+You should see the following output:
+
+```console
++------------+------------+-------+------------------+------------------+------------------+------------------+------------------+-------------------+-----------+
+|l_returnflag|l_linestatus|sum_qty|    sum_base_price|    sum_disc_price|        sum_charge|           avg_qty|         avg_price|           avg_disc|count_order|
++------------+------------+-------+------------------+------------------+------------------+------------------+------------------+-------------------+-----------+
+|           A|           F|   1519|2374824.6560278563|1387364.2207725341|1962763.4654265852|26.649122807017545|41663.590456629056|0.41501802923479575|         57|
+|           N|           F|     98| 146371.2295412012| 85593.96776336085|121041.55837332775|32.666666666666664|48790.409847067065|0.40984706454007996|          3|
+|           N|           O|   5374| 8007373.247086477| 4685647.785126835| 6624210.945739046|24.427272727272726| 36397.15112312035| 0.4147594809559689|        220|
+|           R|           F|   1461|2190869.9676265526|1284178.4378283697|1814151.2807494882|25.189655172413794| 37773.62013149229|0.41323493790730753|         58|
++------------+------------+-------+------------------+------------------+------------------+------------------+------------------+-------------------+-----------+
+```
+
+### Join tables that span multiple databases
+
+You can also run a query to join tables that are connected to the three back-end databases and calculate the unshipped orders with the highest revenue on a particular date.
+
+To run the query, run the following command in the Spark shell console:
+
+```scala
+scala> sql("""
+     SELECT
+       l_orderkey,
+       sum(l_extendedprice * (1 - l_discount)) AS revenue,
+       o_orderdate,
+       o_shippriority
+     FROM
+       dynamons.customer,
+       postgresns.orders,
+       cassandrans.lineitem
+     WHERE
+       c_mktsegment = 'AUTOMOBILE'
+       AND c_custkey = o_custkey
+       AND l_orderkey = o_orderkey
+       AND o_orderdate < '1995-03-15'
+       AND l_shipdate > '1995-03-15'
+     GROUP BY
+       l_orderkey,
+       o_orderdate,
+       o_shippriority
+     ORDER BY
+       revenue DESC,
+       o_orderdate,
+       l_orderkey
+     LIMIT 10;
+     """).show()
+```
+
+You should see the following output:
+
+```console
++----------+------------------+-----------+--------------+
+|l_orderkey|           revenue|o_orderdate|o_shippriority|
++----------+------------------+-----------+--------------+
+|   1071617|128186.99915996166| 1995-03-10|             0|
+|   1959075| 33104.51278645416| 1994-12-23|             0|
+|    430243|19476.115819260962| 1994-12-24|             0|
++----------+------------------+-----------+--------------+
+```
+
+:::note
+
+You can also run any arbitrary query that Apache Spark and Spark SQL support on the imported tables in this sample tutorial. Since ScalarDB Analytics with Spark supports all queries that Spark SQL supports, you can use not only join, aggregation, filtering, and ordering as shown in the example but also the window function, lateral join, and various analytical operations.
+
+To see which types of queries Spark SQL supports, see the [Spark SQL documentation](https://spark.apache.org/docs/latest/sql-ref.html).
+
+:::
+
+## Stop the sample application
+
+To stop the sample application, stop the Docker container by running the following command:
+
+```console
+$ docker compose down
+```
+
+## Reference - Schema details
+
+In this sample tutorial, you have tables with the following schema in the underlying databases of ScalarDB:
+
+```mermaid
+erDiagram
+    "dynamons.customer" ||--|{ "postgresns.orders" : "custkey"
+    "dynamons.customer" {
+      int c_custkey
+      text c_name
+      text c_address
+      int c_nationkey
+      text c_phone
+      double c_acctbal
+      text c_mktsegment
+      text c_comment
+    }
+    "postgresns.orders"  ||--|{ "cassandrans.lineitem" : "orderkey"
+    "postgresns.orders" {
+      int o_orderkey
+      int o_custkey
+      text o_orderstatus
+      double o_totalprice
+      text o_orderdate
+      text o_orderpriority
+      text o_clerk
+      int o_shippriority
+      text o_comment
+    }
+    "cassandrans.lineitem" {
+     int l_orderkey
+     int l_partkey
+     int l_suppkey
+     int l_linenumber
+     double l_quantity
+     double l_extendedprice
+     double l_discount
+     double l_tax
+     text l_returnflag
+     text l_linestatus
+     text l_shipdate
+     text l_commitdate
+     text l_receiptdate
+     text l_shipinstruct
+     text l_shipmode
+     text l_comment
+    }
+```
+
+For reference, this diagram shows the following:
+
+- `dynamons`, `postgresns`, and `cassandrans`. Namespaces that are mapped to the back-end storages of DynamoDB, PostgreSQL, and Cassandra, respectively.
+- `dynamons.customer`. A table that represents information about customers. This table includes attributes like customer key, name, address, phone number, and account balance.
+- `postgresns.orders`. A table that contains information about orders that customers have placed. This table includes attributes like order key, customer key, order status, order date, and order priority.
+- `cassandrans.lineitem`. A table that represents line items associated with orders. This table includes attributes such as order key, part key, supplier key, quantity, price, and shipping date.

--- a/sidebars.js
+++ b/sidebars.js
@@ -34,6 +34,7 @@ const sidebars = {
         'scalardb-supported-databases',
         'requirements',
         'scalardb-cluster/index',
+        'scalardb-analytics-spark/README',
       ],
     },
     {
@@ -49,6 +50,7 @@ const sidebars = {
             'getting-started-with-scalardb',
             'getting-started-with-scalardb-by-using-kotlin',
             'scalardb-analytics-postgresql/getting-started',
+            'scalardb-analytics-spark/getting-started',
           ],
         },
         {
@@ -91,6 +93,7 @@ const sidebars = {
         'scalardb-samples/multi-storage-transaction-sample/README',
         'scalardb-samples/microservice-transaction-sample/README',
         'scalardb-samples/scalardb-analytics-postgresql-sample/README',
+        'scalardb-samples/scalardb-analytics-spark-sample/README',
         'scalardb-samples/spring-data-sample/README',
         'scalardb-samples/spring-data-multi-storage-transaction-sample/README',
         'scalardb-samples/spring-data-microservice-transaction-sample/README',
@@ -125,6 +128,7 @@ const sidebars = {
             'two-phase-commit-transactions',
             'scalardb-cluster/scalardb-cluster-configurations',
             'scalardb-sql/configurations',
+            'scalardb-analytics-spark/configuration',
           ],
         },
         'add-scalardb-to-your-build',
@@ -291,6 +295,7 @@ const sidebars = {
         'scalardb-benchmarks/README',
         'storage-abstraction',
         'scalardb-sql/grammar',
+        'scalardb-analytics-spark/version-compatibility',
         {
           type: 'category',
           label: 'Status Codes',


### PR DESCRIPTION
## Description

This PR adds ScalarDB Analytics with Spark docs to the ScalarDB 3.12 docs.

## Related issues and/or PRs

N/A

## Changes made

- Added overview, getting started, configuration, compatibility matrix, and sample docs for ScalarDB Analytics with Spark.
- Added the new docs to the sidebar navigation.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A