### PR TITLE
Clarify lack of support end dates for latest release in Release Support Policy

### DIFF
--- a/docs/releases/release-support-policy.mdx
+++ b/docs/releases/release-support-policy.mdx
@@ -24,8 +24,8 @@ This page describes Scalar's support policy for major and minor version releases
     <tr>
       <td><a href="https://scalardb.scalar-labs.com/docs/3.12/releases/release-notes#v3120">3.12</a></td>
       <td>2024-02-17</td>
-      <td>-</td>
-      <td>-</td>
+      <td>TBD*</td>
+      <td>TBD*</td>
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
@@ -64,21 +64,21 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>*</td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>**</td>
       <td class="version-out-of-support">2022-07-08</td>
       <td class="version-out-of-support">2023-09-03</td>
       <td class="version-out-of-support">2024-03-01</td>
       <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a>**</td>
       <td class="version-out-of-support">2022-02-16</td>
       <td class="version-out-of-support">2023-07-08</td>
       <td class="version-out-of-support">2024-01-04</td>
       <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a>**</td>
       <td class="version-out-of-support">2021-12-02</td>
       <td class="version-out-of-support">2023-02-16</td>
       <td class="version-out-of-support">2023-08-15</td>
@@ -87,4 +87,5 @@ This page describes Scalar's support policy for major and minor version releases
   </tbody>
 </table>
 
-&#42; This product version is no longer supported under Maintenance Support or Assistance Support.
+\* "TBD" will be replaced with a date after the next minor version is released.<br />
+\*\* This product version is no longer supported under Maintenance Support or Assistance Support.


### PR DESCRIPTION
## Description

This PR aims to clarify the lack of end dates for Maintenance Support and Assistance Support for the latest version of ScalarDB in the Release Support Policy. Since we don't add the dates until the next version is released, we should clarify why there aren't dates listed rather than marking the cells as `-`, which is unclear.

## Related issues and/or PRs

N/A

## Changes made

- Replaced `-` with `TBD*` to clarify why the latest version doesn't have dates listed in the Maintenance Support and Assistance Support cells.
- Added a note below the table that describes what `TBD` means.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A