### PR TITLE
Add new Helm Charts doc about cert-manager to sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -215,6 +215,7 @@ const sidebars = {
               items: [
                 'helm-charts/getting-started-scalar-helm-charts',
                 'helm-charts/getting-started-scalardb-cluster-tls',
+                'helm-charts/getting-started-scalardb-cluster-tls-cert-manager',
                 'helm-charts/getting-started-scalardb-analytics-postgresql',
                 'helm-charts/getting-started-monitoring',
                 'helm-charts/getting-started-logging',


### PR DESCRIPTION
## Description

This PR adds a link to the new doc `Getting Started with Helm Charts (ScalarDB Cluster with TLS by Using cert-manager)` to the sidebar navigation.

## Related issues and/or PRs

N/A

## Changes made

- Added a link to the new doc `Getting Started with Helm Charts (ScalarDB Cluster with TLS by Using cert-manager)` to the sidebar navigation.

> [!NOTE]
>
> TLS is supported in ScalarDB 3.12 or later, so I've updated the sidebar navigation only for that version.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A