### PR TITLE
Add workflow to auto-create PRs when Scalar Manager docs are updated

### DIFF
--- a/.github/workflows/auto-create-pr-scalar-manager.yml
+++ b/.github/workflows/auto-create-pr-scalar-manager.yml
@@ -1,0 +1,39 @@
+# This workflow auto-creates PRs for Scalar Manager docs that come from the centralized private docs repository where we update our docs.
+name: ✨ Auto-create pull request - Scalar Manager docs
+
+on:
+  push:
+    branches:
+      - scalar-manager/**
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const result = await github.rest.pulls.create({
+              title: 'AUTO: Docs repo sync - Scalar Manager',
+              owner,
+              repo,
+              head: '${{ github.ref_name }}',
+              base: 'main',
+              body: [
+                'This is an automated pull request (PR) to sync changes to Scalar Manager docs in the centralized private docs repo to this public docs site repo.',
+                '',
+                'Before merging this PR, confirm the following:',
+                '',
+                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary).',
+                '- [ ] I have confirmed that this PR can be merged without waiting (if necessary).',
+                '  - An example of when a PR must wait to be merged is when the docs are part of a pending release of a new product version.'
+              ].join('\n')
+            });
+            github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: result.data.number,
+              labels: ['documentation', 'scalar-manager', 'triage']
+            });


### PR DESCRIPTION
## Description

This PR adds a workflow to auto-create PRs when Scalar Manager docs are updated. The docs are synced across branches of docs that are currently under product Maintenance Support.

## Related issues and/or PRs

N/A

## Changes made

- Created a workflow `.yml` file that auto-creates a PR when Scalar Manager docs are updated.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A