### PR TITLE
Add Google Translate widget to navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -190,6 +190,11 @@ const config = {
             dropdownActiveClassDisabled: true,
           },
           {
+            type: 'html',
+            position: 'right',
+            value: '<div id="google_translate_element"></div>',
+          },
+          {
             href: 'https://developers.scalar-labs.com/docs/',
             position: 'right',
             label: 'Scalar Docs Home',

--- a/src/helper/google-translate.js
+++ b/src/helper/google-translate.js
@@ -1,0 +1,7 @@
+
+function googleTranslateElementInit() {
+  new google.translate.TranslateElement(
+      {pageLanguage: 'en'},
+      'google_translate_element'
+  );
+}

--- a/src/theme/NavbarItem/HtmlNavbarItem.tsx
+++ b/src/theme/NavbarItem/HtmlNavbarItem.tsx
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {useEffect} from 'react';
+import clsx from 'clsx';
+
+import type {Props} from '@theme/NavbarItem/HtmlNavbarItem';
+
+function loadGoogleTranslateScript() {
+  if (typeof window !== "undefined" && typeof document !== "undefined") {
+    const addScript = document.createElement('script');
+    addScript.src = '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+    addScript.async = true;
+    document.body.appendChild(addScript);
+    window.googleTranslateElementInit = async function () {
+      // Function to initialize the Google Translate widget
+      const initGoogleTranslate = () => {
+        new google.translate.TranslateElement(
+          { pageLanguage: 'en', includedLanguages : 'ja' },
+          'google_translate_element'
+        );
+      };
+
+      // Function will wait for element id to be available
+      const waitForElement = () => {
+        return new Promise<void>((resolve) => {
+          const checkElement = () => {
+            const targetElement = document.getElementById('google_translate_element');
+            if (targetElement) {
+              // If the target element is available, resolve the Promise
+              resolve();
+            } else {
+              // If the target element is not available, wait and check again
+              setTimeout(checkElement, 100); // Adjust the time delay as needed
+            }
+          };
+          checkElement(); // Start checking for the element
+        });
+      };
+    
+      // Wait for the target element to be available before initializing the widget
+      await waitForElement();
+      initGoogleTranslate();
+    };
+    
+  }
+}
+export default function HtmlNavbarItem({
+  value,
+  className,
+  mobile = false,
+  isDropdownItem = false,
+}: Props): JSX.Element {
+  const Comp = isDropdownItem ? 'li' : 'div';
+  useEffect(() => {
+    if(process.env.NODE_ENV !== 'production') {
+    loadGoogleTranslateScript();
+    } else {
+      console.log('Google Translate Not loaded in Dev');
+    }
+  },[]);
+  return (
+    <Comp
+      className={clsx(
+        {
+          navbar__item: !mobile && !isDropdownItem,
+          'menu__list-item': mobile,
+        },
+        className,
+      )}
+      dangerouslySetInnerHTML={{__html: value}}
+    />
+  );
+}

--- a/src/theme/NavbarItem/HtmlNavbarItem.tsx
+++ b/src/theme/NavbarItem/HtmlNavbarItem.tsx
@@ -20,7 +20,7 @@ function loadGoogleTranslateScript() {
       // Function to initialize the Google Translate widget
       const initGoogleTranslate = () => {
         new google.translate.TranslateElement(
-          { pageLanguage: 'en', includedLanguages : 'ja' },
+          { pageLanguage: 'en', includedLanguages: 'ja' },
           'google_translate_element'
         );
       };


### PR DESCRIPTION
## Description

This PR adds a Google Translate widget to the navigation bar (navbar) so that users can translate pages into Japanese.

## Related issues and/or PRs

N/A

## Changes made

- [Swizzled](https://docusaurus.io/docs/swizzling) the navbar (`NavbarItem`) component, and added code for the Google Translate widget.
- Added a helper, which is used for rendering the widget in the navbar.
- Added the widget as an item in the navbar.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A