### PR TITLE
Change environment for Google Translate widget from `production` to `development`

### DIFF
--- a/src/theme/NavbarItem/HtmlNavbarItem.tsx
+++ b/src/theme/NavbarItem/HtmlNavbarItem.tsx
@@ -57,7 +57,7 @@ export default function HtmlNavbarItem({
 }: Props): JSX.Element {
   const Comp = isDropdownItem ? 'li' : 'div';
   useEffect(() => {
-    if(process.env.NODE_ENV !== 'production') {
+    if(process.env.NODE_ENV !== 'development') {
     loadGoogleTranslateScript();
     } else {
       console.log('Google Translate Not loaded in Dev');


### PR DESCRIPTION
## Description

This PR fixes an issue with the Google Translate widget not appearing on the live site. For testing purposes, `production` was specified so that the widget would appear when testing on my local machine. However, when making the widget available on the live site, the environment needs to be `development`.

## Related issues and/or PRs

#298 

## Changes made

- Changed the environment in which the widget should not load in from `production` to `development`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A