### PR TITLE
Add Scalar Manager overview doc to sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -287,6 +287,7 @@ const sidebars = {
           ],
         },
         'backup-restore',
+        'scalar-manager/overview',
       ],
     },
     {

--- a/versioned_sidebars/version-3.10-sidebars.json
+++ b/versioned_sidebars/version-3.10-sidebars.json
@@ -241,7 +241,8 @@
             }
           ]
         },
-        "backup-restore"
+        "backup-restore",
+        "scalar-manager/overview"
       ]
     },
     {

--- a/versioned_sidebars/version-3.11-sidebars.json
+++ b/versioned_sidebars/version-3.11-sidebars.json
@@ -260,7 +260,8 @@
             }
           ]
         },
-        "backup-restore"
+        "backup-restore",
+        "scalar-manager/overview"
       ]
     },
     {

--- a/versioned_sidebars/version-3.8-sidebars.json
+++ b/versioned_sidebars/version-3.8-sidebars.json
@@ -202,7 +202,8 @@
             }
           ]
         },
-        "backup-restore"
+        "backup-restore",
+        "scalar-manager/overview"
       ]
     },
     {

--- a/versioned_sidebars/version-3.9-sidebars.json
+++ b/versioned_sidebars/version-3.9-sidebars.json
@@ -241,7 +241,8 @@
             }
           ]
         },
-        "backup-restore"
+        "backup-restore",
+        "scalar-manager/overview"
       ]
     },
     {


### PR DESCRIPTION
## Description

Since the Scalar Manager is now available in the AWS Marketplace, this PR adds the Scalar Manager overview doc to the sidebar navigation.

## Related issues and/or PRs

- #291
- #292 
- #293
- #295 
- #296 

## Changes made

- Added the Scalar Manager overview doc to the Manage category in the sidebar navigation for versions that are still under support.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A