### PR TITLE
Mark ScalarDB 3.7 as no longer supported

### DIFF
--- a/docs/releases/release-support-policy.mdx
+++ b/docs/releases/release-support-policy.mdx
@@ -57,11 +57,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a></td>
-      <td>2022-09-03</td>
-      <td>2024-01-17</td>
-      <td>2024-07-15</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>*</td>
+      <td class="version-out-of-support">2022-09-03</td>
+      <td class="version-out-of-support">2024-01-17</td>
+      <td class="version-out-of-support">2024-07-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>**</td>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,9 +97,9 @@ const config = {
                 banner: 'none',
               },
               "3.7": {
-                label: '3.7',
+                label: '3.7 (unsupported)',
                 path: '3.7',
-                banner: 'none',
+                banner: 'unmaintained',
               },
               "3.6": {
                 label: '3.6 (unsupported)',

--- a/versioned_docs/version-3.10/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.10/releases/release-support-policy.mdx
@@ -43,11 +43,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a></td>
-      <td>2022-09-03</td>
-      <td>2024-01-17</td>
-      <td>2024-07-15</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>*</td>
+      <td class="version-out-of-support">2022-09-03</td>
+      <td class="version-out-of-support">2024-01-17</td>
+      <td class="version-out-of-support">2024-07-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>*</td>

--- a/versioned_docs/version-3.11/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.11/releases/release-support-policy.mdx
@@ -50,11 +50,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a></td>
-      <td>2022-09-03</td>
-      <td>2024-01-17</td>
-      <td>2024-07-15</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>*</td>
+      <td class="version-out-of-support">2022-09-03</td>
+      <td class="version-out-of-support">2024-01-17</td>
+      <td class="version-out-of-support">2024-07-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>*</td>

--- a/versioned_docs/version-3.7/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.7/releases/release-support-policy.mdx
@@ -22,11 +22,11 @@ This page describes Scalar's support policy for major and minor version releases
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a></td>
-      <td>2022-09-03</td>
-      <td>2024-01-17</td>
-      <td>2024-07-15</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>*</td>
+      <td class="version-out-of-support">2022-09-03</td>
+      <td class="version-out-of-support">2024-01-17</td>
+      <td class="version-out-of-support">2024-07-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>*</td>

--- a/versioned_docs/version-3.8/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.8/releases/release-support-policy.mdx
@@ -29,11 +29,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a></td>
-      <td>2022-09-03</td>
-      <td>2024-01-17</td>
-      <td>2024-07-15</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>*</td>
+      <td class="version-out-of-support">2022-09-03</td>
+      <td class="version-out-of-support">2024-01-17</td>
+      <td class="version-out-of-support">2024-07-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>*</td>

--- a/versioned_docs/version-3.9/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.9/releases/release-support-policy.mdx
@@ -36,11 +36,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a></td>
-      <td>2022-09-03</td>
-      <td>2024-01-17</td>
-      <td>2024-07-15</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>*</td>
+      <td class="version-out-of-support">2022-09-03</td>
+      <td class="version-out-of-support">2024-01-17</td>
+      <td class="version-out-of-support">2024-07-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>*</td>


### PR DESCRIPTION
## Description

This PR marks ScalarDB 3.7 as no longer supported since Assistance Support ended on July 15, 2024.

## Related issues and/or PRs

N/A

## Changes made

- In each version of the Release Support Policy docs:
  - Added an asterisk to 3.7.
  - Added the `out-of-support` style to the cells in the table.
- In `docusaurus.config.js`:
  - Added `(unsupported)` to 3.7 in the version selector.
  - Added the `unmaintained` banner, which automatically adds a banner to each page for version 3.7 that states the version is no longer supported.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A