### PR TITLE
Fix docs site build error

### DIFF
--- a/versioned_sidebars/version-3.10-sidebars.json
+++ b/versioned_sidebars/version-3.10-sidebars.json
@@ -188,7 +188,7 @@
                 "helm-charts/configure-custom-values-scalardb-analytics-postgresql",
                 "helm-charts/configure-custom-values-scalar-admin-for-kubernetes",
                 "helm-charts/configure-custom-values-scalar-manager",
-                "helm-charts/configure-custom-values-envoy",
+                "helm-charts/configure-custom-values-envoy"
               ]
             },
             "helm-charts/how-to-deploy-scalar-products",
@@ -201,7 +201,7 @@
           ]
         },
         "scalardb-analytics-postgresql/installation",
-        "scalardb-graphql/aws-deployment-guide",
+        "scalardb-graphql/aws-deployment-guide"
       ]
     },
     {

--- a/versioned_sidebars/version-3.11-sidebars.json
+++ b/versioned_sidebars/version-3.11-sidebars.json
@@ -206,7 +206,7 @@
                 "helm-charts/configure-custom-values-scalardb-analytics-postgresql",
                 "helm-charts/configure-custom-values-scalar-admin-for-kubernetes",
                 "helm-charts/configure-custom-values-scalar-manager",
-                "helm-charts/configure-custom-values-envoy",
+                "helm-charts/configure-custom-values-envoy"
               ]
             },
             "helm-charts/how-to-deploy-scalar-products",
@@ -220,7 +220,7 @@
         },
         "scalardb-cluster/standalone-mode",
         "scalardb-analytics-postgresql/installation",
-        "scalardb-graphql/aws-deployment-guide",
+        "scalardb-graphql/aws-deployment-guide"
       ]
     },
     {

--- a/versioned_sidebars/version-3.9-sidebars.json
+++ b/versioned_sidebars/version-3.9-sidebars.json
@@ -188,7 +188,7 @@
                 "helm-charts/configure-custom-values-scalardb-analytics-postgresql",
                 "helm-charts/configure-custom-values-scalar-admin-for-kubernetes",
                 "helm-charts/configure-custom-values-scalar-manager",
-                "helm-charts/configure-custom-values-envoy",
+                "helm-charts/configure-custom-values-envoy"
               ]
             },
             "helm-charts/how-to-deploy-scalar-products",
@@ -201,7 +201,7 @@
           ]
         },
         "scalardb-analytics-postgresql/installation",
-        "scalardb-graphql/aws-deployment-guide",
+        "scalardb-graphql/aws-deployment-guide"
       ]
     },
     {


### PR DESCRIPTION
## Description

This PR fixes an error with the docs site not building in GitHub Pages.

## Related issues and/or PRs

- #344

## Changes made

- Removed trailing commas from versions of the sidebar navigation. These commas weren't removed when removing docs from the sidebar navigation in #344.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
