### PR TITLE
Remove links to the `scalardb-sample` and `spring-data-sample` docs

### DIFF
--- a/versioned_sidebars/version-3.10-sidebars.json
+++ b/versioned_sidebars/version-3.10-sidebars.json
@@ -52,11 +52,9 @@
       "label": "Samples",
       "collapsible": true,
       "items": [
-        "scalardb-samples/scalardb-sample/README",
         "scalardb-samples/multi-storage-transaction-sample/README",
         "scalardb-samples/microservice-transaction-sample/README",
         "scalardb-samples/scalardb-analytics-postgresql-sample/README",
-        "scalardb-samples/spring-data-sample/README",
         "scalardb-samples/spring-data-multi-storage-transaction-sample/README",
         "scalardb-samples/spring-data-microservice-transaction-sample/README"
       ]

--- a/versioned_sidebars/version-3.11-sidebars.json
+++ b/versioned_sidebars/version-3.11-sidebars.json
@@ -68,11 +68,9 @@
       "label": "Samples",
       "collapsible": true,
       "items": [
-        "scalardb-samples/scalardb-sample/README",
         "scalardb-samples/multi-storage-transaction-sample/README",
         "scalardb-samples/microservice-transaction-sample/README",
         "scalardb-samples/scalardb-analytics-postgresql-sample/README",
-        "scalardb-samples/spring-data-sample/README",
         "scalardb-samples/spring-data-multi-storage-transaction-sample/README",
         "scalardb-samples/spring-data-microservice-transaction-sample/README"
       ]

--- a/versioned_sidebars/version-3.12-sidebars.json
+++ b/versioned_sidebars/version-3.12-sidebars.json
@@ -71,12 +71,10 @@
       "label": "Samples",
       "collapsible": true,
       "items": [
-        "scalardb-samples/scalardb-sample/README",
         "scalardb-samples/multi-storage-transaction-sample/README",
         "scalardb-samples/microservice-transaction-sample/README",
         "scalardb-samples/scalardb-analytics-postgresql-sample/README",
         "scalardb-samples/scalardb-analytics-spark-sample/README",
-        "scalardb-samples/spring-data-sample/README",
         "scalardb-samples/spring-data-multi-storage-transaction-sample/README",
         "scalardb-samples/spring-data-microservice-transaction-sample/README"
       ]

--- a/versioned_sidebars/version-3.9-sidebars.json
+++ b/versioned_sidebars/version-3.9-sidebars.json
@@ -52,11 +52,9 @@
       "label": "Samples",
       "collapsible": true,
       "items": [
-        "scalardb-samples/scalardb-sample/README",
         "scalardb-samples/multi-storage-transaction-sample/README",
         "scalardb-samples/microservice-transaction-sample/README",
         "scalardb-samples/scalardb-analytics-postgresql-sample/README",
-        "scalardb-samples/spring-data-sample/README",
         "scalardb-samples/spring-data-multi-storage-transaction-sample/README",
         "scalardb-samples/spring-data-microservice-transaction-sample/README"
       ]


### PR DESCRIPTION
## Description

This PR removes the samples for the following:

- `scalardb-sample`: This sample has been consolidated into the getting started tutorial.
- `spring-data-sample`: Users should refer to the other Spring Data samples for specific use cases.

## Related issues and/or PRs

- #390 
- #389
- #388
- #387
- #386

## Changes made

- Remove links to the `scalardb-sample` and `spring-data-sample` docs.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A