### PR TITLE
Add home pages for each version

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 # ScalarDB
 
-import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards';
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.13';
 
 ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real-time analytics across diverse databases to simplify the complexity of managing multiple databases.
 

--- a/src/components/Cards/3.10.tsx
+++ b/src/components/Cards/3.10.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'overview',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Overview
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-supported-databases',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Supported databases
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-cluster/getting-started-with-scalardb-cluster',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB Cluster
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/multi-storage-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application with multi-storage transaction support
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/microservice-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application that supports microservice transactions
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'add-scalardb-to-your-build',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Add ScalarDB to your build
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        ScalarDB Schema Loader
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Set up a database for ScalarDB on AWS
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDBCluster',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        See the ScalarDB Cluster production checklist
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Monitor ScalarDB in a Kubernetes cluster
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Back up and restore in a Kubernetes environment
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Benchmarking tools
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'storage-abstraction',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Storage abstraction and API guide
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/3.11.tsx
+++ b/src/components/Cards/3.11.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'overview',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Overview
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-supported-databases',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Supported databases
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-cluster/getting-started-with-scalardb-cluster',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB Cluster
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/multi-storage-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application with multi-storage transaction support
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/microservice-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application that supports microservice transactions
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'add-scalardb-to-your-build',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Add ScalarDB to your build
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        ScalarDB Schema Loader
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Set up a database for ScalarDB on AWS
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDBCluster',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        See the ScalarDB Cluster production checklist
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Monitor ScalarDB in a Kubernetes cluster
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Back up and restore in a Kubernetes environment
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Benchmarking tools
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'storage-abstraction',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Storage abstraction and API guide
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/3.12.tsx
+++ b/src/components/Cards/3.12.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'overview',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Overview
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-supported-databases',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Supported databases
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-cluster/getting-started-with-scalardb-cluster',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB Cluster
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/multi-storage-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application with multi-storage transaction support
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/microservice-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application that supports microservice transactions
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'add-scalardb-to-your-build',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Add ScalarDB to your build
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        ScalarDB Schema Loader
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Set up a database for ScalarDB on AWS
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDBCluster',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        See the ScalarDB Cluster production checklist
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Monitor ScalarDB in a Kubernetes cluster
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Back up and restore in a Kubernetes environment
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Benchmarking tools
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'storage-abstraction',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Storage abstraction and API guide
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/3.13.tsx
+++ b/src/components/Cards/3.13.tsx
@@ -17,7 +17,7 @@ const CardsAbout = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'overview/',
+      page: 'overview',
     },
     description: (
       <Translate id="home.about.description">
@@ -29,7 +29,7 @@ const CardsAbout = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalardb-supported-databases/',
+      page: 'scalardb-supported-databases',
     },
     description: (
       <Translate id="home.about.description">
@@ -44,7 +44,7 @@ const CardsGettingStarted = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'getting-started-with-scalardb/',
+      page: 'getting-started-with-scalardb',
     },
     description: (
       <Translate id="home.gettingStarted.description">
@@ -56,7 +56,7 @@ const CardsGettingStarted = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalardb-cluster/getting-started-with-scalardb-cluster/',
+      page: 'scalardb-cluster/getting-started-with-scalardb-cluster',
     },
     description: (
       <Translate id="home.gettingStarted.description">
@@ -71,11 +71,11 @@ const CardsSamples = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalardb-samples/scalardb-sample/',
+      page: 'scalardb-samples/multi-storage-transaction-sample',
     },
     description: (
       <Translate id="home.samples.description">
-        Create a basic e-commerce sample application that uses ScalarDB
+        Create a sample application with multi-storage transaction support
       </Translate>
     ),
   },
@@ -83,11 +83,11 @@ const CardsSamples = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalardb-samples/multi-storage-transaction-sample/',
+      page: 'scalardb-samples/microservice-transaction-sample',
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application with multi-storage transaction support
+        Create a sample application that supports microservice transactions
       </Translate>
     ),
   },
@@ -98,7 +98,7 @@ const CardsDevelop = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'add-scalardb-to-your-build/',
+      page: 'add-scalardb-to-your-build',
     },
     description: (
       <Translate id="home.develop.description">
@@ -110,7 +110,7 @@ const CardsDevelop = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'schema-loader/',
+      page: 'schema-loader',
     },
     description: (
       <Translate id="home.develop.description">
@@ -125,7 +125,7 @@ const CardsDeploy = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/SetupDatabaseForAWS/',
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
     },
     description: (
       <Translate id="home.deploy.description">
@@ -137,7 +137,7 @@ const CardsDeploy = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/ProductionChecklistForScalarDBCluster/',
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDBCluster',
     },
     description: (
       <Translate id="home.deploy.description">
@@ -152,7 +152,7 @@ const CardsManage = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/K8sMonitorGuide/',
+      page: 'scalar-kubernetes/K8sMonitorGuide',
     },
     description: (
       <Translate id="home.manage.description">
@@ -164,7 +164,7 @@ const CardsManage = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/BackupRestoreGuide/',
+      page: 'scalar-kubernetes/BackupRestoreGuide',
     },
     description: (
       <Translate id="home.manage.description">
@@ -179,7 +179,7 @@ const CardsReference = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalardb-benchmarks/',
+      page: 'scalardb-benchmarks',
     },
     description: (
       <Translate id="home.reference.description">
@@ -191,7 +191,7 @@ const CardsReference = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'storage-abstraction/',
+      page: 'storage-abstraction',
     },
     description: (
       <Translate id="home.reference.description">

--- a/src/components/Cards/3.4.tsx
+++ b/src/components/Cards/3.4.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'design',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Design
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-supported-databases',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Supported databases
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'requirements',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Requirements in underlying databases
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/multi-storage-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application with multi-storage transaction support
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/microservice-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application that supports microservice transactions
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'add-scalardb-to-your-build',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Add ScalarDB to your build
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        ScalarDB Schema Loader
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Set up a database for ScalarDB on AWS
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/AccessScalarProducts',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Make ScalarDB in a Kubernetes cluster environment available from applications
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Monitor ScalarDB in a Kubernetes cluster
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Back up and restore in a Kubernetes environment
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Benchmarking tools
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'releases/release-notes',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        ScalarDB 3.4 Release Notes
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/3.5.tsx
+++ b/src/components/Cards/3.5.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'design',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Design
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-supported-databases',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Supported databases
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb-by-using-kotlin',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB by using Kotlin
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/multi-storage-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application with multi-storage transaction support
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/microservice-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application that supports microservice transactions
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'add-scalardb-to-your-build',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Add ScalarDB to your build
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        ScalarDB Schema Loader
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Set up a database for ScalarDB on AWS
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/AccessScalarProducts',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Make ScalarDB in a Kubernetes cluster environment available from applications
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Monitor ScalarDB in a Kubernetes cluster
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Back up and restore in a Kubernetes environment
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Benchmarking tools
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'releases/release-notes',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        ScalarDB 3.5 Release Notes
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/3.6.tsx
+++ b/src/components/Cards/3.6.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'design',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Design
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-supported-databases',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Supported databases
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb-by-using-kotlin',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB by using Kotlin
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/multi-storage-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application with multi-storage transaction support
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/microservice-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application that supports microservice transactions
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'add-scalardb-to-your-build',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Add ScalarDB to your build
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        ScalarDB Schema Loader
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Set up a database for ScalarDB on AWS
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/AccessScalarProducts',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Make ScalarDB in a Kubernetes cluster environment available from applications
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Monitor ScalarDB in a Kubernetes cluster
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Back up and restore in a Kubernetes environment
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Benchmarking tools
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'storage-abstraction',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Storage abstraction and API guide
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/3.7.tsx
+++ b/src/components/Cards/3.7.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'design',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Design
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-supported-databases',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Supported databases
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb-by-using-kotlin',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB by using Kotlin
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/multi-storage-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application with multi-storage transaction support
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/microservice-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application that supports microservice transactions
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'add-scalardb-to-your-build',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Add ScalarDB to your build
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        ScalarDB Schema Loader
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Set up a database for ScalarDB on AWS
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/AccessScalarProducts',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Make ScalarDB in a Kubernetes cluster environment available from applications
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Monitor ScalarDB in a Kubernetes cluster
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Back up and restore in a Kubernetes environment
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Benchmarking tools
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'storage-abstraction',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Storage abstraction and API guide
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/3.8.tsx
+++ b/src/components/Cards/3.8.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'overview',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Overview
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-supported-databases',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Supported databases
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb-by-using-kotlin',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB by using Kotlin
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/multi-storage-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application with multi-storage transaction support
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/microservice-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application that supports microservice transactions
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'add-scalardb-to-your-build',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Add ScalarDB to your build
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        ScalarDB Schema Loader
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Set up a database for ScalarDB on AWS
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/AccessScalarProducts',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Make ScalarDB in a Kubernetes cluster environment available from applications
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Monitor ScalarDB in a Kubernetes cluster
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Back up and restore in a Kubernetes environment
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Benchmarking tools
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'storage-abstraction',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Storage abstraction and API guide
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/3.9.tsx
+++ b/src/components/Cards/3.9.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'overview',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Overview
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-supported-databases',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Supported databases
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-cluster/getting-started-with-scalardb-cluster',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDB Cluster
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/multi-storage-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application with multi-storage transaction support
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-samples/microservice-transaction-sample',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Create a sample application that supports microservice transactions
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'add-scalardb-to-your-build',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Add ScalarDB to your build
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        ScalarDB Schema Loader
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Set up a database for ScalarDB on AWS
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDBCluster',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        See the ScalarDB Cluster production checklist
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Monitor ScalarDB in a Kubernetes cluster
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Back up and restore in a Kubernetes environment
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Benchmarking tools
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'storage-abstraction',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Storage abstraction and API guide
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/versioned_docs/version-3.10/index.mdx
+++ b/versioned_docs/version-3.10/index.mdx
@@ -1,0 +1,33 @@
+# ScalarDB
+
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.10';
+
+ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real-time analytics across diverse databases to simplify the complexity of managing multiple databases.
+
+**About ScalarDB**
+
+<CardRowAbout />
+
+**Getting started**
+
+<CardRowGettingStarted />
+
+**Samples**
+
+<CardRowSamples />
+
+**Develop**
+
+<CardRowDevelop />
+
+**Deploy**
+
+<CardRowDeploy />
+
+**Manage**
+
+<CardRowManage />
+
+**Reference**
+
+<CardRowReference />

--- a/versioned_docs/version-3.11/index.mdx
+++ b/versioned_docs/version-3.11/index.mdx
@@ -1,0 +1,33 @@
+# ScalarDB
+
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.11';
+
+ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real-time analytics across diverse databases to simplify the complexity of managing multiple databases.
+
+**About ScalarDB**
+
+<CardRowAbout />
+
+**Getting started**
+
+<CardRowGettingStarted />
+
+**Samples**
+
+<CardRowSamples />
+
+**Develop**
+
+<CardRowDevelop />
+
+**Deploy**
+
+<CardRowDeploy />
+
+**Manage**
+
+<CardRowManage />
+
+**Reference**
+
+<CardRowReference />

--- a/versioned_docs/version-3.12/index.mdx
+++ b/versioned_docs/version-3.12/index.mdx
@@ -1,0 +1,33 @@
+# ScalarDB
+
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.12';
+
+ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real-time analytics across diverse databases to simplify the complexity of managing multiple databases.
+
+**About ScalarDB**
+
+<CardRowAbout />
+
+**Getting started**
+
+<CardRowGettingStarted />
+
+**Samples**
+
+<CardRowSamples />
+
+**Develop**
+
+<CardRowDevelop />
+
+**Deploy**
+
+<CardRowDeploy />
+
+**Manage**
+
+<CardRowManage />
+
+**Reference**
+
+<CardRowReference />

--- a/versioned_docs/version-3.4/index.mdx
+++ b/versioned_docs/version-3.4/index.mdx
@@ -1,0 +1,33 @@
+# ScalarDB
+
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.4';
+
+ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real-time analytics across diverse databases to simplify the complexity of managing multiple databases.
+
+**About ScalarDB**
+
+<CardRowAbout />
+
+**Getting started**
+
+<CardRowGettingStarted />
+
+**Samples**
+
+<CardRowSamples />
+
+**Develop**
+
+<CardRowDevelop />
+
+**Deploy**
+
+<CardRowDeploy />
+
+**Manage**
+
+<CardRowManage />
+
+**Reference**
+
+<CardRowReference />

--- a/versioned_docs/version-3.5/index.mdx
+++ b/versioned_docs/version-3.5/index.mdx
@@ -1,0 +1,33 @@
+# ScalarDB
+
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.5';
+
+ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real-time analytics across diverse databases to simplify the complexity of managing multiple databases.
+
+**About ScalarDB**
+
+<CardRowAbout />
+
+**Getting started**
+
+<CardRowGettingStarted />
+
+**Samples**
+
+<CardRowSamples />
+
+**Develop**
+
+<CardRowDevelop />
+
+**Deploy**
+
+<CardRowDeploy />
+
+**Manage**
+
+<CardRowManage />
+
+**Reference**
+
+<CardRowReference />

--- a/versioned_docs/version-3.6/index.mdx
+++ b/versioned_docs/version-3.6/index.mdx
@@ -1,0 +1,33 @@
+# ScalarDB
+
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.6';
+
+ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real-time analytics across diverse databases to simplify the complexity of managing multiple databases.
+
+**About ScalarDB**
+
+<CardRowAbout />
+
+**Getting started**
+
+<CardRowGettingStarted />
+
+**Samples**
+
+<CardRowSamples />
+
+**Develop**
+
+<CardRowDevelop />
+
+**Deploy**
+
+<CardRowDeploy />
+
+**Manage**
+
+<CardRowManage />
+
+**Reference**
+
+<CardRowReference />

--- a/versioned_docs/version-3.7/index.mdx
+++ b/versioned_docs/version-3.7/index.mdx
@@ -1,0 +1,33 @@
+# ScalarDB
+
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.7';
+
+ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real-time analytics across diverse databases to simplify the complexity of managing multiple databases.
+
+**About ScalarDB**
+
+<CardRowAbout />
+
+**Getting started**
+
+<CardRowGettingStarted />
+
+**Samples**
+
+<CardRowSamples />
+
+**Develop**
+
+<CardRowDevelop />
+
+**Deploy**
+
+<CardRowDeploy />
+
+**Manage**
+
+<CardRowManage />
+
+**Reference**
+
+<CardRowReference />

--- a/versioned_docs/version-3.8/index.mdx
+++ b/versioned_docs/version-3.8/index.mdx
@@ -1,0 +1,33 @@
+# ScalarDB
+
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.8';
+
+ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real-time analytics across diverse databases to simplify the complexity of managing multiple databases.
+
+**About ScalarDB**
+
+<CardRowAbout />
+
+**Getting started**
+
+<CardRowGettingStarted />
+
+**Samples**
+
+<CardRowSamples />
+
+**Develop**
+
+<CardRowDevelop />
+
+**Deploy**
+
+<CardRowDeploy />
+
+**Manage**
+
+<CardRowManage />
+
+**Reference**
+
+<CardRowReference />

--- a/versioned_docs/version-3.9/index.mdx
+++ b/versioned_docs/version-3.9/index.mdx
@@ -1,0 +1,33 @@
+# ScalarDB
+
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.9';
+
+ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real-time analytics across diverse databases to simplify the complexity of managing multiple databases.
+
+**About ScalarDB**
+
+<CardRowAbout />
+
+**Getting started**
+
+<CardRowGettingStarted />
+
+**Samples**
+
+<CardRowSamples />
+
+**Develop**
+
+<CardRowDevelop />
+
+**Deploy**
+
+<CardRowDeploy />
+
+**Manage**
+
+<CardRowManage />
+
+**Reference**
+
+<CardRowReference />

--- a/versioned_sidebars/version-3.10-sidebars.json
+++ b/versioned_sidebars/version-3.10-sidebars.json
@@ -1,9 +1,9 @@
 {
   "docs": [
     {
-      "type": "link",
+      "type": "doc",
       "label": "ScalarDB Docs Home",
-      "href": "/docs/latest/"
+      "id": "index"
     },
     {
       "type": "category",

--- a/versioned_sidebars/version-3.11-sidebars.json
+++ b/versioned_sidebars/version-3.11-sidebars.json
@@ -1,9 +1,9 @@
 {
   "docs": [
     {
-      "type": "link",
+      "type": "doc",
       "label": "ScalarDB Docs Home",
-      "href": "/docs/latest/"
+      "id": "index"
     },
     {
       "type": "category",

--- a/versioned_sidebars/version-3.12-sidebars.json
+++ b/versioned_sidebars/version-3.12-sidebars.json
@@ -1,9 +1,9 @@
 {
   "docs": [
     {
-      "type": "link",
+      "type": "doc",
       "label": "ScalarDB Docs Home",
-      "href": "/docs/latest/"
+      "id": "index"
     },
     {
       "type": "category",

--- a/versioned_sidebars/version-3.4-sidebars.json
+++ b/versioned_sidebars/version-3.4-sidebars.json
@@ -1,9 +1,9 @@
 {
   "docs": [
     {
-      "type": "link",
+      "type": "doc",
       "label": "ScalarDB Docs Home",
-      "href": "/docs/latest/"
+      "id": "index"
     },
     {
       "type": "category",

--- a/versioned_sidebars/version-3.5-sidebars.json
+++ b/versioned_sidebars/version-3.5-sidebars.json
@@ -1,9 +1,9 @@
 {
   "docs": [
     {
-      "type": "link",
+      "type": "doc",
       "label": "ScalarDB Docs Home",
-      "href": "/docs/latest/"
+      "id": "index"
     },
     {
       "type": "category",

--- a/versioned_sidebars/version-3.6-sidebars.json
+++ b/versioned_sidebars/version-3.6-sidebars.json
@@ -1,9 +1,9 @@
 {
   "docs": [
     {
-      "type": "link",
+      "type": "doc",
       "label": "ScalarDB Docs Home",
-      "href": "/docs/latest/"
+      "id": "index"
     },
     {
       "type": "category",
@@ -174,6 +174,7 @@
         "design",
         "scalardb-supported-databases",
         "requirements",
+        "storage-abstraction",
         "scalardb-benchmarks/README"
       ]
     },

--- a/versioned_sidebars/version-3.7-sidebars.json
+++ b/versioned_sidebars/version-3.7-sidebars.json
@@ -1,9 +1,9 @@
 {
   "docs": [
     {
-      "type": "link",
+      "type": "doc",
       "label": "ScalarDB Docs Home",
-      "href": "/docs/latest/"
+      "id": "index"
     },
     {
       "type": "category",

--- a/versioned_sidebars/version-3.8-sidebars.json
+++ b/versioned_sidebars/version-3.8-sidebars.json
@@ -1,9 +1,9 @@
 {
   "docs": [
     {
-      "type": "link",
+      "type": "doc",
       "label": "ScalarDB Docs Home",
-      "href": "/docs/latest/"
+      "id": "index"
     },
     {
       "type": "category",

--- a/versioned_sidebars/version-3.9-sidebars.json
+++ b/versioned_sidebars/version-3.9-sidebars.json
@@ -1,9 +1,9 @@
 {
   "docs": [
     {
-      "type": "link",
+      "type": "doc",
       "label": "ScalarDB Docs Home",
-      "href": "/docs/latest/"
+      "id": "index"
     },
     {
       "type": "category",


### PR DESCRIPTION
## Description

This PR adds an index (home page) page for each version.

Previously, there was only one home page, which directed to the latest version of the docs. Because of this, if a visitor selected `ScalarDB Docs Home` at the top of the sidebar navigation, they would be taken to the home page of the latest version of the docs. In this case, the expected behavior would be to navigate to the home page for the version that the user is currently on.

## Related issues and/or PRs

N/A

## Changes made

- Added an index page to each version of the docs.
- Added a component with links to available docs for that version.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.). `N/A`
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published. `N/A`

## Additional notes (optional)

N/A