### PR TITLE
Add link to ScalarDB Cluster custom values doc in sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -642,6 +642,11 @@ const sidebars = {
                 },
                 {
                   type: 'doc',
+                  id: 'helm-charts/configure-custom-values-scalardb-cluster',
+                  label: 'Configure a custom values file for ScalarDB Cluster',
+                },
+                {
+                  type: 'doc',
                   id: 'helm-charts/configure-custom-values-scalardb-analytics-postgresql',
                   label: 'Configure a Custom Values File for ScalarDB Analytics with PostgreSQL',
                 },

--- a/versioned_sidebars/version-3.12-sidebars.json
+++ b/versioned_sidebars/version-3.12-sidebars.json
@@ -613,6 +613,11 @@
                 },
                 {
                   "type": "doc",
+                  "id": "helm-charts/configure-custom-values-scalardb-cluster",
+                  "label": "Configure a custom values file for ScalarDB Cluster"
+                },
+                {
+                  "type": "doc",
                   "id": "helm-charts/configure-custom-values-scalardb-analytics-postgresql",
                   "label": "Configure a Custom Values File for ScalarDB Analytics with PostgreSQL"
                 },


### PR DESCRIPTION
## Description

This PR adds a missing doc to the sidebar navigation for 3.13 and 3.12.

## Related issues and/or PRs

N/A

## Changes made

- Added the ScalarDB Cluster custom values doc in sidebar navigation for versions 3.13 and 3.12.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.). `N/A`
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A