### PR TITLE
Add missing doc to sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -720,6 +720,11 @@ const sidebars = {
                 },
                 {
                   type: 'doc',
+                  id: 'scalar-manager/overview',
+                  label: 'Scalar Manager Overview',
+                },
+                {
+                  type: 'doc',
                   id: 'helm-charts/how-to-deploy-scalar-manager',
                   label: 'Deploy Scalar Manager',
                 },

--- a/versioned_sidebars/version-3.12-sidebars.json
+++ b/versioned_sidebars/version-3.12-sidebars.json
@@ -691,6 +691,11 @@
                 },
                 {
                   "type": "doc",
+                  "id": "scalar-manager/overview",
+                  "label": "Scalar Manager Overview"
+                },
+                {
+                  "type": "doc",
                   "id": "helm-charts/how-to-deploy-scalar-manager",
                   "label": "Deploy Scalar Manager"
                 },


### PR DESCRIPTION
## Description

This PR adds the missing Scalar Manager overview doc to the sidebar navigation.

## Related issues and/or PRs

This doc should have been added when we re-organized the sidebar navigation in https://github.com/scalar-labs/docs-scalardb/pull/441.

## Changes made

- Added the Scalar Manager overview doc to the sidebar navigation for versions of the sidebar (`3.13` and `3.12`) that had been re-organized.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.). `N/A`
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published. `N/A`

## Additional notes (optional)

N/A