### PR TITLE
Update ScalarDB Cluster .NET Client SDK docs in sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -433,11 +433,6 @@ const sidebars = {
                 },
                 {
                   type: 'doc',
-                  id: 'scalardb-cluster-dotnet-client-sdk/getting-started-with-two-phase-commit-transactions',
-                  label: 'Two-Phase Commit Transactions',
-                },
-                {
-                  type: 'doc',
                   id: 'scalardb-cluster-dotnet-client-sdk/getting-started-with-distributed-transactions',
                   label: 'Distributed Transactions',
                 },
@@ -453,13 +448,13 @@ const sidebars = {
                 },
                 {
                   type: 'doc',
-                  id: 'scalardb-cluster-dotnet-client-sdk/getting-started-with-auth',
-                  label: 'ScalarDB Auth',
+                  id: 'scalardb-cluster-dotnet-client-sdk/getting-started-with-scalardb-tables-as-csharp-classes',
+                  label: 'Tables as C# Classes',
                 },
                 {
                   type: 'doc',
-                  id: 'scalardb-cluster-dotnet-client-sdk/getting-started-with-scalardb-tables-as-csharp-classes',
-                  label: 'Tables as C# Classes',
+                  id: 'scalardb-cluster-dotnet-client-sdk/getting-started-with-aspnet-and-di',
+                  label: 'ASP.NET Core and Dependency Injection',
                 },
                 {
                   type: 'doc',
@@ -468,8 +463,13 @@ const sidebars = {
                 },
                 {
                   type: 'doc',
-                  id: 'scalardb-cluster-dotnet-client-sdk/getting-started-with-aspnet-and-di',
-                  label: 'ASP.NET Core and Dependency Injection',
+                  id: 'scalardb-cluster-dotnet-client-sdk/getting-started-with-two-phase-commit-transactions',
+                  label: 'Two-Phase Commit Transactions',
+                },
+                {
+                  type: 'doc',
+                  id: 'scalardb-cluster-dotnet-client-sdk/getting-started-with-auth',
+                  label: 'ScalarDB Auth',
                 },
                 {
                   type: 'doc',

--- a/sidebars.js
+++ b/sidebars.js
@@ -428,6 +428,11 @@ const sidebars = {
               items: [
                 {
                   type: 'doc',
+                  id: 'scalardb-cluster-dotnet-client-sdk/overview',
+                  label: 'Overview',
+                },
+                {
+                  type: 'doc',
                   id: 'scalardb-cluster-dotnet-client-sdk/getting-started-with-two-phase-commit-transactions',
                   label: 'Two-Phase Commit Transactions',
                 },

--- a/versioned_sidebars/version-3.12-sidebars.json
+++ b/versioned_sidebars/version-3.12-sidebars.json
@@ -414,11 +414,6 @@
                 },
                 {
                   "type": "doc",
-                  "id": "scalardb-cluster-dotnet-client-sdk/getting-started-with-two-phase-commit-transactions",
-                  "label": "Two-Phase Commit Transactions"
-                },
-                {
-                  "type": "doc",
                   "id": "scalardb-cluster-dotnet-client-sdk/getting-started-with-distributed-transactions",
                   "label": "Distributed Transactions"
                 },
@@ -434,13 +429,13 @@
                 },
                 {
                   "type": "doc",
-                  "id": "scalardb-cluster-dotnet-client-sdk/getting-started-with-auth",
-                  "label": "ScalarDB Auth"
+                  "id": "scalardb-cluster-dotnet-client-sdk/getting-started-with-scalardb-tables-as-csharp-classes",
+                  "label": "Tables as C# Classes"
                 },
                 {
                   "type": "doc",
-                  "id": "scalardb-cluster-dotnet-client-sdk/getting-started-with-scalardb-tables-as-csharp-classes",
-                  "label": "Tables as C# Classes"
+                  "id": "scalardb-cluster-dotnet-client-sdk/getting-started-with-aspnet-and-di",
+                  "label": "ASP.NET Core and Dependency Injection"
                 },
                 {
                   "type": "doc",
@@ -449,8 +444,13 @@
                 },
                 {
                   "type": "doc",
-                  "id": "scalardb-cluster-dotnet-client-sdk/getting-started-with-aspnet-and-di",
-                  "label": "ASP.NET Core and Dependency Injection"
+                  "id": "scalardb-cluster-dotnet-client-sdk/getting-started-with-two-phase-commit-transactions",
+                  "label": "Two-Phase Commit Transactions"
+                },
+                {
+                  "type": "doc",
+                  "id": "scalardb-cluster-dotnet-client-sdk/getting-started-with-auth",
+                  "label": "ScalarDB Auth"
                 }
               ]
             }

--- a/versioned_sidebars/version-3.12-sidebars.json
+++ b/versioned_sidebars/version-3.12-sidebars.json
@@ -409,6 +409,11 @@
               "items": [
                 {
                   "type": "doc",
+                  "id": "scalardb-cluster-dotnet-client-sdk/overview",
+                  "label": "Overview"
+                },
+                {
+                  "type": "doc",
                   "id": "scalardb-cluster-dotnet-client-sdk/getting-started-with-two-phase-commit-transactions",
                   "label": "Two-Phase Commit Transactions"
                 },


### PR DESCRIPTION
## Description

This PR updates ScalarDB Cluster .NET Client SDK docs in the sidebar navigation. 

## Related issues and/or PRs

N/A

## Changes made

- Added the ScalarDB Cluster .NET Client SDK overview doc to the sidebar, which was missing from the latest version (3.13) and 3.12.
- Rearrange the ScalarDB Cluster .NET Client SDK docs in the sidebar navigation to match the structure shown in the overview doc.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.). `N/A`
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A