### PR TITLE
Add link to doc about how to scale ScalarDB in sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -709,6 +709,11 @@ const sidebars = {
       collapsible: true,
       items: [
         {
+          type: 'doc',
+          id: 'scalar-kubernetes/HowToScaleScalarDB',
+          label: 'Scale',
+        },
+        {
           type: 'category',
           label: 'Monitor',
           collapsible: true,

--- a/versioned_sidebars/version-3.10-sidebars.json
+++ b/versioned_sidebars/version-3.10-sidebars.json
@@ -236,6 +236,7 @@
           ]
         },
         "backup-restore",
+        "scalar-kubernetes/HowToScaleScalarDB",
         "scalar-manager/overview"
       ]
     },

--- a/versioned_sidebars/version-3.11-sidebars.json
+++ b/versioned_sidebars/version-3.11-sidebars.json
@@ -255,6 +255,7 @@
           ]
         },
         "backup-restore",
+        "scalar-kubernetes/HowToScaleScalarDB",
         "scalar-manager/overview"
       ]
     },

--- a/versioned_sidebars/version-3.12-sidebars.json
+++ b/versioned_sidebars/version-3.12-sidebars.json
@@ -680,6 +680,11 @@
       "collapsible": true,
       "items": [
         {
+          "type": "doc",
+          "id": "scalar-kubernetes/HowToScaleScalarDB",
+          "label": "Scale"
+        },
+        {
           "type": "category",
           "label": "Monitor",
           "collapsible": true,

--- a/versioned_sidebars/version-3.9-sidebars.json
+++ b/versioned_sidebars/version-3.9-sidebars.json
@@ -236,6 +236,7 @@
           ]
         },
         "backup-restore",
+        "scalar-kubernetes/HowToScaleScalarDB",
         "scalar-manager/overview"
       ]
     },


### PR DESCRIPTION
## Description

This PR adds a link to a new doc about how to scale ScalarDB in the sidebar navigation.

## Related issues and/or PRs

- #471 
- #472
- #473
- #474 
- #475

## Changes made

- Added the doc about how to scale ScalarDB to the sidebar navigation of versions that are under Maintenance Support.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.). `N/A`
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published. `N/A`

## Additional notes (optional)

N/A