### PR TITLE
Fix issue where clicking links on version home pages results in blank pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -150,7 +150,7 @@ const config = {
         redirects: [
           // This redirect takes the user to the latest version of the English docs when they land on the English versions of the docs site.
           {
-            to: '/docs/latest',
+            to: '/docs/latest/',
             from: ['/', '/docs'],
           },
           {


### PR DESCRIPTION
## Description

This PR fixes an issue where the links on the version home pages would direct visitors to a blank page. This was caused by the lack of a trailing slash in the version URL.

## Related issues and/or PRs

N/A

## Changes made

- Added trailing slash to the redirect in `docusaurus.config.js`.
 
## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.). `N/A`
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published. `N/A`

## Additional notes (optional)

N/A