### PR TITLE
Change link on version home pages from `Supported databases` to `Requirements`

### DIFF
--- a/src/components/Cards/3.10.tsx
+++ b/src/components/Cards/3.10.tsx
@@ -29,11 +29,11 @@ const CardsAbout = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalardb-supported-databases',
+      page: 'requirements',
     },
     description: (
       <Translate id="home.about.description">
-        Supported databases
+        Requirements
       </Translate>
     ),
   },

--- a/src/components/Cards/3.11.tsx
+++ b/src/components/Cards/3.11.tsx
@@ -29,11 +29,11 @@ const CardsAbout = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalardb-supported-databases',
+      page: 'requirements',
     },
     description: (
       <Translate id="home.about.description">
-        Supported databases
+        Requirements
       </Translate>
     ),
   },

--- a/src/components/Cards/3.12.tsx
+++ b/src/components/Cards/3.12.tsx
@@ -29,11 +29,11 @@ const CardsAbout = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalardb-supported-databases',
+      page: 'requirements',
     },
     description: (
       <Translate id="home.about.description">
-        Supported databases
+        Requirements
       </Translate>
     ),
   },

--- a/src/components/Cards/3.13.tsx
+++ b/src/components/Cards/3.13.tsx
@@ -29,11 +29,11 @@ const CardsAbout = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalardb-supported-databases',
+      page: 'requirements',
     },
     description: (
       <Translate id="home.about.description">
-        Supported databases
+        Requirements
       </Translate>
     ),
   },

--- a/src/components/Cards/3.9.tsx
+++ b/src/components/Cards/3.9.tsx
@@ -29,11 +29,11 @@ const CardsAbout = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalardb-supported-databases',
+      page: 'requirements',
     },
     description: (
       <Translate id="home.about.description">
-        Supported databases
+        Requirements
       </Translate>
     ),
   },


### PR DESCRIPTION
## Description

This PR changes the link on the version home pages from the `Supported databases` doc to the `Requirements` doc. This change is necessary because the `Supported databases` doc will soon be deleted since the contents have been added to the `Requirements` doc.

## Related issues and/or PRs

N/A

## Changes made

- Changed the link from `scalardb-supported-databases.mdx` to `requirements.mdx` on the home page for each version.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.). `N/A`
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A