### PR TITLE
Remove the ability to click on tags in docs header

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -133,9 +133,9 @@ a[class^='tag_'] {
   color: white;
   font-weight: bold;
 
-  &:hover {
+  /* &:hover {
     border: 2px solid #78C740;
-  }
+  } */
 }
 
 html[data-theme="dark"] .badge {
@@ -150,9 +150,9 @@ html[data-theme="dark"] a[class^='tag_'] {
   color: white;
   font-weight: bold;
 
-  &:hover {
+  /* &:hover {
     border: 2px solid #78C740;
-  }
+  } */
 }
 
 /* The following Font Awesome-related styles are for the question mark next to the Editions tags. These styles are currently not being used but might be useful later. */

--- a/src/theme/TagsListInline/index.tsx
+++ b/src/theme/TagsListInline/index.tsx
@@ -18,8 +18,8 @@ export default function TagsListInline({tags}: Props): JSX.Element {
       </b> */}
       <ul className={clsx(styles.tags, 'padding--none', 'margin-left--sm')}>
         {tags.map(({label, permalink: tagPermalink}) => (
-          <li key={tagPermalink} className={styles.tag}>
-            <Tag label={label} permalink={tagPermalink} />
+          <li className={styles.tag}>
+            <Tag label={label} />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Description

This PR removes the ability to click on tags at the top of docs.

> [!NOTE]
>
> By default, tags are clickable in Docusaurus.

Clicking links at the top of the docs results in the visitor seeing a page that lists pages for that version in alphabetical order, which isn't helpful as users navigate through the docs. In addition, for pages that start with non-alphanumeric characters, like `(Deprecated)`, those docs are shown at the top of the list, which is confusing.

Since the tags are currently just informational, making the tags not clickable is a better experience.

## Related issues and/or PRs

- Added tags in #469.

## Changes made

- Removed the permalink attribute from the tags.
- Disabled style change when hovering over tags.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.). `N/A`
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published. `N/A`

## Additional notes (optional)

In the future, we might re-enable links in tags if we can better customize the list page for each tag or otherwise provide a better experience.