### PR TITLE
Add patch version release notes for `3.13.1`, `3.12.4`, `3.11.4`, `3.10.6`, and `3.9.7`

### DIFF
--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -9,6 +9,50 @@ tags:
 
 This page includes a list of release notes for ScalarDB 3.13.
 
+## v3.13.1
+
+**Release date:** October 13, 2024
+
+### Summary
+
+This release includes several bug fixes, and vulnerability fixes.
+
+### Community edition
+
+#### Enhancements
+
+- Added support for MariaDB 11.4 and Oracle 19. ([#2061](https://github.com/scalar-labs/scalardb/pull/2061))
+
+#### Bug fixes
+
+- Fixed a bug where `NullPointerException` when a table specified in a Get/Scan object is not found in Consensus Commit. ([#2083](https://github.com/scalar-labs/scalardb/pull/2083))
+- Fixed a corner case issue that causes inconsistent Coordinator states when lazy recovery happens before group commit ([#2135](https://github.com/scalar-labs/scalardb/pull/2135))
+- Upgraded the mysql driver to fix security issues. [CVE-2023-22102](https://github.com/advisories/GHSA-m6vm-37g8-gqvh "CVE-2023-22102") ([#2238](https://github.com/scalar-labs/scalardb/pull/2238))
+- Upgraded the gRPC library, the Protocol Buffers library, grpc_health_probe, and scalar-admin to fix security issues. [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8 "CVE-2024-7254"), [CVE-2024-25638](https://github.com/advisories/GHSA-cfxw-4h78-h7fw "CVE-2024-25638"), and [CVE-2024-34156](https://github.com/advisories/GHSA-crqm-pwhx-j97f "CVE-2024-34156") ([#2277](https://github.com/scalar-labs/scalardb/pull/2277))
+
+### Enterprise edition
+
+#### Enhancements
+
+##### ScalarDB Cluster
+
+- Support the group commit feature for Coordinator table in ScalarDB cluster
+
+#### Improvements
+
+##### ScalarDB GraphQL
+
+- With this update, if `scalar.db.graphql.namespaces` is not specified, GraphQL server generates a GraphQL schema for all tables in all ScalarDB-managed namespaces.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Fix a bug where `NullPointerException` occurs when catching an exception without message.
+- Upgraded `grpc_health_probe` to fix a security issue. [CVE-2024-34156](https://github.com/advisories/GHSA-crqm-pwhx-j97f "CVE-2024-34156")
+- Upgraded `scalar-admin` to fix a security issue. [CVE-2024-25638](https://github.com/advisories/GHSA-cfxw-4h78-h7fw "CVE-2024-25638")
+- Upgraded the Protobuf Java library to fix a security issue. [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8 "CVE-2024-7254")
+
 ## v3.13.0
 
 ### Summary

--- a/versioned_docs/version-3.10/releases/release-notes.mdx
+++ b/versioned_docs/version-3.10/releases/release-notes.mdx
@@ -9,6 +9,40 @@ tags:
 
 This page includes a list of release notes for ScalarDB 3.10.
 
+## v3.10.6
+
+**Release date:** October 13, 2024
+
+### Summary
+
+This release includes several bug fixes, and vulnerability fixes.
+
+### Community edition
+
+#### Enhancements
+
+- Added support for MariaDB 11.4 and Oracle 19. ([#2061](https://github.com/scalar-labs/scalardb/pull/2061))
+
+#### Bug fixes
+
+- Fixed a bug where `NullPointerException` when a table specified in a Get/Scan object is not found in Consensus Commit. ([#2083](https://github.com/scalar-labs/scalardb/pull/2083))
+- Upgraded the mysql driver to fix security issues. [CVE-2023-22102](https://github.com/advisories/GHSA-m6vm-37g8-gqvh "CVE-2023-22102") ([#2238](https://github.com/scalar-labs/scalardb/pull/2238))
+- Upgraded the gRPC library, the Protocol Buffers library, grpc_health_probe, and scalar-admin to fix security issues. [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8 "CVE-2024-7254"), [CVE-2024-25638](https://github.com/advisories/GHSA-cfxw-4h78-h7fw "CVE-2024-25638"), and [CVE-2024-34156](https://github.com/advisories/GHSA-crqm-pwhx-j97f "CVE-2024-34156") ([#2277](https://github.com/scalar-labs/scalardb/pull/2277))
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix a security issue. [CVE-2024-34156](https://github.com/advisories/GHSA-crqm-pwhx-j97f "CVE-2024-34156")
+- Upgraded `scalar-admin` to fix a security issue. [CVE-2024-25638](https://github.com/advisories/GHSA-cfxw-4h78-h7fw "CVE-2024-25638")
+- Upgraded the Protobuf Java library to fix a security issue. [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8 "CVE-2024-7254")
+
+##### ScalarDB GraphQL
+
+- Upgraded the GraphQL Java library to fix security issues. [CVE-2024-40094](https://github.com/advisories/GHSA-h9mq-f6q5-6c8m "CVE-2024-40094")
+
 ## v3.10.5
 
 **Release date:** July 3, 2024

--- a/versioned_docs/version-3.11/releases/release-notes.mdx
+++ b/versioned_docs/version-3.11/releases/release-notes.mdx
@@ -9,6 +9,41 @@ tags:
 
 This page includes a list of release notes for ScalarDB 3.11.
 
+## v3.11.4
+
+**Release date:** October 13, 2024
+
+### Summary
+
+This release includes several bug fixes, and vulnerability fixes.
+
+### Community edition
+
+#### Enhancements
+
+- Added support for MariaDB 11.4 and Oracle 19. ([#2061](https://github.com/scalar-labs/scalardb/pull/2061))
+
+#### Bug fixes
+
+- Fixed a bug where `NullPointerException` when a table specified in a Get/Scan object is not found in Consensus Commit. ([#2083](https://github.com/scalar-labs/scalardb/pull/2083))
+- Upgraded the mysql driver to fix security issues. [CVE-2023-22102](https://github.com/advisories/GHSA-m6vm-37g8-gqvh "CVE-2023-22102") ([#2238](https://github.com/scalar-labs/scalardb/pull/2238))
+- Upgraded the gRPC library, the Protocol Buffers library, grpc_health_probe, and scalar-admin to fix security issues. [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8 "CVE-2024-7254"), [CVE-2024-25638](https://github.com/advisories/GHSA-cfxw-4h78-h7fw "CVE-2024-25638"), and [CVE-2024-34156](https://github.com/advisories/GHSA-crqm-pwhx-j97f "CVE-2024-34156") ([#2277](https://github.com/scalar-labs/scalardb/pull/2277))
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Fixed a bug where incorrect results are returned when executing SELECT queries with the same column names.
+- Upgraded `grpc_health_probe` to fix a security issue. [CVE-2024-34156](https://github.com/advisories/GHSA-crqm-pwhx-j97f "CVE-2024-34156")
+- Upgraded `scalar-admin` to fix a security issue. [CVE-2024-25638](https://github.com/advisories/GHSA-cfxw-4h78-h7fw "CVE-2024-25638")
+- Upgraded the Protobuf Java library to fix a security issue. [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8 "CVE-2024-7254")
+
+##### ScalarDB GraphQL
+
+- Upgraded the GraphQL Java library to fix security issues. [CVE-2024-40094](https://github.com/advisories/GHSA-h9mq-f6q5-6c8m "CVE-2024-40094")
+
 ## v3.11.3
 
 **Release date:** July 3, 2024

--- a/versioned_docs/version-3.12/releases/release-notes.mdx
+++ b/versioned_docs/version-3.12/releases/release-notes.mdx
@@ -9,6 +9,42 @@ tags:
 
 This page includes a list of release notes for ScalarDB 3.12.
 
+## v3.12.4
+
+**Release date:** October 13, 2024
+
+### Summary
+
+This release includes several bug fixes, and vulnerability fixes.
+
+### Community edition
+
+#### Enhancements
+
+- Added support for MariaDB 11.4 and Oracle 19. ([#2061](https://github.com/scalar-labs/scalardb/pull/2061))
+
+#### Bug fixes
+
+- Fixed a bug where `NullPointerException` when a table specified in a Get/Scan object is not found in Consensus Commit. ([#2083](https://github.com/scalar-labs/scalardb/pull/2083))
+- Upgraded the mysql driver to fix security issues. [CVE-2023-22102](https://github.com/advisories/GHSA-m6vm-37g8-gqvh "CVE-2023-22102") ([#2238](https://github.com/scalar-labs/scalardb/pull/2238))
+- Upgraded the gRPC library, the Protocol Buffers library, grpc_health_probe, and scalar-admin to fix security issues. [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8 "CVE-2024-7254"), [CVE-2024-25638](https://github.com/advisories/GHSA-cfxw-4h78-h7fw "CVE-2024-25638"), and [CVE-2024-34156](https://github.com/advisories/GHSA-crqm-pwhx-j97f "CVE-2024-34156") ([#2277](https://github.com/scalar-labs/scalardb/pull/2277))
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Fixed a bug where incorrect results are returned when executing SELECT queries with the same column names.
+- Fix a bug where `NullPointerException` occurs when catching an exception without message.
+- Upgraded `grpc_health_probe` to fix a security issue. [CVE-2024-34156](https://github.com/advisories/GHSA-crqm-pwhx-j97f "CVE-2024-34156")
+- Upgraded `scalar-admin` to fix a security issue. [CVE-2024-25638](https://github.com/advisories/GHSA-cfxw-4h78-h7fw "CVE-2024-25638")
+- Upgraded the Protobuf Java library to fix a security issue. [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8 "CVE-2024-7254")
+
+##### ScalarDB GraphQL
+
+- Upgraded the GraphQL Java library to fix security issues. [CVE-2024-40094](https://github.com/advisories/GHSA-h9mq-f6q5-6c8m "CVE-2024-40094")
+
 ## v3.12.3
 
 **Release date:** July 3, 2024

--- a/versioned_docs/version-3.9/releases/release-notes.mdx
+++ b/versioned_docs/version-3.9/releases/release-notes.mdx
@@ -9,6 +9,40 @@ tags:
 
 This page includes a list of release notes for ScalarDB 3.9.
 
+## v3.9.7
+
+**Release date:** October 13, 2024
+
+### Summary
+
+This release includes several bug fixes, and vulnerability fixes.
+
+### Community edition
+
+#### Enhancements
+
+- Added support for MariaDB 11.4 and Oracle 19. ([#2061](https://github.com/scalar-labs/scalardb/pull/2061))
+
+#### Bug fixes
+
+- Fixed a bug where `NullPointerException` when a table specified in a Get/Scan object is not found in Consensus Commit. ([#2083](https://github.com/scalar-labs/scalardb/pull/2083))
+- Upgraded the mysql driver to fix security issues. [CVE-2023-22102](https://github.com/advisories/GHSA-m6vm-37g8-gqvh "CVE-2023-22102") ([#2238](https://github.com/scalar-labs/scalardb/pull/2238))
+- Upgraded the gRPC library, the Protocol Buffers library, grpc_health_probe, and scalar-admin to fix security issues. [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8 "CVE-2024-7254"), [CVE-2024-25638](https://github.com/advisories/GHSA-cfxw-4h78-h7fw "CVE-2024-25638"), and [CVE-2024-34156](https://github.com/advisories/GHSA-crqm-pwhx-j97f "CVE-2024-34156") ([#2277](https://github.com/scalar-labs/scalardb/pull/2277))
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix a security issue. [CVE-2024-34156](https://github.com/advisories/GHSA-crqm-pwhx-j97f "CVE-2024-34156")
+- Upgraded `scalar-admin` to fix a security issue. [CVE-2024-25638](https://github.com/advisories/GHSA-cfxw-4h78-h7fw "CVE-2024-25638")
+- Upgraded the Protobuf Java library to fix a security issue. [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8 "CVE-2024-7254")
+
+##### ScalarDB GraphQL
+
+- Upgraded the GraphQL Java library to fix security issues. [CVE-2024-40094](https://github.com/advisories/GHSA-h9mq-f6q5-6c8m "CVE-2024-40094")
+
 ## v3.9.6
 
 **Release date:** June 28, 2024


### PR DESCRIPTION
## Description

This PR adds patch version release notes for ScalarDB.

## Related issues and/or PRs

N/A

## Changes made

- Added patch version release notes for the following versions:
  - `3.13.1`
  - `3.12.4`
  - `3.11.4`
  - `3.10.6`
  - `3.9.7`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A