### PR TITLE
Reword sample applications category and version home page cards

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -275,7 +275,7 @@ const sidebars = {
         },
         {
           type: 'category',
-          label: 'Create Sample Applications',
+          label: 'Run Sample Applications',
           collapsible: true,
           items: [
             {

--- a/src/components/Cards/3.10.tsx
+++ b/src/components/Cards/3.10.tsx
@@ -75,7 +75,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application with multi-storage transaction support
+        Run a sample application with multi-storage transaction support
       </Translate>
     ),
   },
@@ -87,7 +87,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application that supports microservice transactions
+        Run a sample application that supports microservice transactions
       </Translate>
     ),
   },

--- a/src/components/Cards/3.11.tsx
+++ b/src/components/Cards/3.11.tsx
@@ -75,7 +75,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application with multi-storage transaction support
+        Run a sample application with multi-storage transaction support
       </Translate>
     ),
   },
@@ -87,7 +87,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application that supports microservice transactions
+        Run a sample application that supports microservice transactions
       </Translate>
     ),
   },

--- a/src/components/Cards/3.12.tsx
+++ b/src/components/Cards/3.12.tsx
@@ -75,7 +75,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application with multi-storage transaction support
+        Run a sample application with multi-storage transaction support
       </Translate>
     ),
   },
@@ -87,7 +87,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application that supports microservice transactions
+        Run a sample application that supports microservice transactions
       </Translate>
     ),
   },

--- a/src/components/Cards/3.13.tsx
+++ b/src/components/Cards/3.13.tsx
@@ -75,7 +75,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application with multi-storage transaction support
+        Run a sample application with multi-storage transaction support
       </Translate>
     ),
   },
@@ -87,7 +87,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application that supports microservice transactions
+        Run a sample application that supports microservice transactions
       </Translate>
     ),
   },

--- a/src/components/Cards/3.4.tsx
+++ b/src/components/Cards/3.4.tsx
@@ -75,7 +75,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application with multi-storage transaction support
+        Run a sample application with multi-storage transaction support
       </Translate>
     ),
   },
@@ -87,7 +87,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application that supports microservice transactions
+        Run a sample application that supports microservice transactions
       </Translate>
     ),
   },

--- a/src/components/Cards/3.5.tsx
+++ b/src/components/Cards/3.5.tsx
@@ -75,7 +75,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application with multi-storage transaction support
+        Run a sample application with multi-storage transaction support
       </Translate>
     ),
   },
@@ -87,7 +87,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application that supports microservice transactions
+        Run a sample application that supports microservice transactions
       </Translate>
     ),
   },

--- a/src/components/Cards/3.6.tsx
+++ b/src/components/Cards/3.6.tsx
@@ -75,7 +75,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application with multi-storage transaction support
+        Run a sample application with multi-storage transaction support
       </Translate>
     ),
   },
@@ -87,7 +87,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application that supports microservice transactions
+        Run a sample application that supports microservice transactions
       </Translate>
     ),
   },

--- a/src/components/Cards/3.7.tsx
+++ b/src/components/Cards/3.7.tsx
@@ -75,7 +75,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application with multi-storage transaction support
+        Run a sample application with multi-storage transaction support
       </Translate>
     ),
   },
@@ -87,7 +87,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application that supports microservice transactions
+        Run a sample application that supports microservice transactions
       </Translate>
     ),
   },

--- a/src/components/Cards/3.8.tsx
+++ b/src/components/Cards/3.8.tsx
@@ -75,7 +75,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application with multi-storage transaction support
+        Run a sample application with multi-storage transaction support
       </Translate>
     ),
   },
@@ -87,7 +87,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application that supports microservice transactions
+        Run a sample application that supports microservice transactions
       </Translate>
     ),
   },

--- a/src/components/Cards/3.9.tsx
+++ b/src/components/Cards/3.9.tsx
@@ -75,7 +75,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application with multi-storage transaction support
+        Run a sample application with multi-storage transaction support
       </Translate>
     ),
   },
@@ -87,7 +87,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a sample application that supports microservice transactions
+        Run a sample application that supports microservice transactions
       </Translate>
     ),
   },

--- a/versioned_sidebars/version-3.12-sidebars.json
+++ b/versioned_sidebars/version-3.12-sidebars.json
@@ -256,7 +256,7 @@
         },
         {
           "type": "category",
-          "label": "Create Sample Applications",
+          "label": "Run Sample Applications",
           "collapsible": true,
           "items": [
             {


### PR DESCRIPTION
## Description

This PR rewords the sample applications category and samples cards on version home pages. Rather than creating applications, users are running pre-created applications.

## Related issues and/or PRs

N/A

## Changes made

- Changed the category name `Create Sample Applications` to `Run Sample Applications` across applicable versions.
- Changed the description of samples cards on the version home pages from `Create a sample application ...` to `Run a sample application ...`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A