### PR TITLE
Update English homepage cards; add Japanese homepages with cards

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -7,7 +7,7 @@ tags:
 
 # ScalarDB
 
-import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.14';
+import { CardRowAbout, CardRowQuickstart, CardRowDevelop, CardRowDeploy, CardRowMigrate, CardRowManage, CardRowReference } from '/src/components/Cards/3.14';
 
 ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real-time analytics across diverse databases to simplify the complexity of managing multiple databases.
 
@@ -15,13 +15,9 @@ ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real
 
 <CardRowAbout />
 
-**Getting started**
+**Quickstart**
 
-<CardRowGettingStarted />
-
-**Samples**
-
-<CardRowSamples />
+<CardRowQuickstart />
 
 **Develop**
 
@@ -31,10 +27,14 @@ ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real
 
 <CardRowDeploy />
 
+**Migrate**
+
+<CardRowMigrate />
+
 **Manage**
 
 <CardRowManage />
 
-**Reference**
+**Troubleshoot & Reference**
 
 <CardRowReference />

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/index.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/index.mdx
@@ -1,0 +1,40 @@
+---
+tags:
+  - Community
+  - Enterprise Standard
+  - Enterprise Premium
+---
+
+# ScalarDB
+
+import { CardRowAbout, CardRowQuickstart, CardRowDevelop, CardRowDeploy, CardRowMigrate, CardRowManage, CardRowReference } from '/src/components/Cards/ja-jp/3.14';
+
+ScalarDB は、さまざまなデータベース向けのハイブリッドトランザクション/分析処理 (HTAP) エンジンです。データベース上でミドルウェアとして実行され、ACID トランザクションとリアルタイム分析を実現することでさまざまなデータベースを仮想的に統合し、複数のデータベースまたは単一のデータベースの複数のインスタンスの管理の複雑さを簡素化します。
+
+**ScalarDB について**
+
+<CardRowAbout />
+
+**はじめる**
+
+<CardRowQuickstart />
+
+**開発**
+
+<CardRowDevelop />
+
+**デプロイ**
+
+<CardRowDeploy />
+
+**移行**
+
+<CardRowMigrate />
+
+**管理**
+
+<CardRowManage />
+
+**トラブルシューティングと参照**
+
+<CardRowReference />

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/scalar-licensing/README.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/scalar-licensing/README.mdx
@@ -6,6 +6,8 @@ tags:
 
 # 製品ライセンスキーの設定方法
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 <TranslationBanner />

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/index.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/index.mdx
@@ -1,0 +1,40 @@
+---
+tags:
+  - Community
+  - Enterprise Standard
+  - Enterprise Premium
+---
+
+# ScalarDB
+
+import { CardRowAbout, CardRowQuickstart, CardRowDevelop, CardRowDeploy, CardRowMigrate, CardRowManage, CardRowReference } from '/src/components/Cards/ja-jp/3.14';
+
+ScalarDB は、さまざまなデータベース向けのハイブリッドトランザクション/分析処理 (HTAP) エンジンです。データベース上でミドルウェアとして実行され、ACID トランザクションとリアルタイム分析を実現することでさまざまなデータベースを仮想的に統合し、複数のデータベースまたは単一のデータベースの複数のインスタンスの管理の複雑さを簡素化します。
+
+**ScalarDB について**
+
+<CardRowAbout />
+
+**はじめる**
+
+<CardRowQuickstart />
+
+**開発**
+
+<CardRowDevelop />
+
+**デプロイ**
+
+<CardRowDeploy />
+
+**移行**
+
+<CardRowMigrate />
+
+**管理**
+
+<CardRowManage />
+
+**トラブルシューティングと参照**
+
+<CardRowReference />

--- a/src/components/Cards/3.12.tsx
+++ b/src/components/Cards/3.12.tsx
@@ -39,7 +39,7 @@ const CardsAbout = [
   },
 ]
 
-const CardsGettingStarted = [
+const CardsQuickstart = [
   {
     // name: '',
     // image: '<LINK_TO>.png',
@@ -47,7 +47,7 @@ const CardsGettingStarted = [
       page: 'getting-started-with-scalardb',
     },
     description: (
-      <Translate id="home.gettingStarted.description">
+      <Translate id="home.quickstart.description">
         Getting started with ScalarDB
       </Translate>
     ),
@@ -59,35 +59,8 @@ const CardsGettingStarted = [
       page: 'scalardb-cluster/getting-started-with-scalardb-cluster',
     },
     description: (
-      <Translate id="home.gettingStarted.description">
+      <Translate id="home.quickstart.description">
         Getting started with ScalarDB Cluster
-      </Translate>
-    ),
-  },
-]
-
-const CardsSamples = [
-  {
-    // name: '',
-    // image: '<LINK_TO>.png',
-    url: {
-      page: 'scalardb-samples/multi-storage-transaction-sample',
-    },
-    description: (
-      <Translate id="home.samples.description">
-        Run a sample application with multi-storage transaction support
-      </Translate>
-    ),
-  },
-  {
-    // name: '',
-    // image: '<LINK_TO>.png',
-    url: {
-      page: 'scalardb-samples/microservice-transaction-sample',
-    },
-    description: (
-      <Translate id="home.samples.description">
-        Run a sample application that supports microservice transactions
       </Translate>
     ),
   },
@@ -125,11 +98,11 @@ const CardsDeploy = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDBCluster',
     },
     description: (
       <Translate id="home.deploy.description">
-        Set up a database for ScalarDB on AWS
+        See the ScalarDB Cluster production checklist
       </Translate>
     ),
   },
@@ -137,11 +110,38 @@ const CardsDeploy = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/ProductionChecklistForScalarDBCluster',
+      page: 'scalar-kubernetes/ManualDeploymentGuideScalarDBClusterOnEKS',
     },
     description: (
       <Translate id="home.deploy.description">
-        See the ScalarDB Cluster production checklist
+        Deploy ScalarDB Cluster on Amazon EKS
+      </Translate>
+    ),
+  },
+]
+
+const CardsMigrate = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader-import',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Import Existing Tables by Using ScalarDB Schema Loader
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-sql/migration-guide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Migrate Your Applications and Databases
       </Translate>
     ),
   },
@@ -155,7 +155,7 @@ const CardsManage = [
       page: 'scalar-kubernetes/K8sMonitorGuide',
     },
     description: (
-      <Translate id="home.manage.description">
+      <Translate id="home.migrate.description">
         Monitor ScalarDB in a Kubernetes cluster
       </Translate>
     ),
@@ -164,11 +164,11 @@ const CardsManage = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/BackupRestoreGuide',
+      page: 'scalar-kubernetes/BackupNoSQL',
     },
     description: (
-      <Translate id="home.manage.description">
-        Back up and restore in a Kubernetes environment
+      <Translate id="home.migrate.description">
+        Back up a NoSQL database in a Kubernetes environment
       </Translate>
     ),
   },
@@ -179,11 +179,11 @@ const CardsReference = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalardb-benchmarks',
+      page: 'scalardb-core-status-codes',
     },
     description: (
       <Translate id="home.reference.description">
-        Benchmarking tools
+        ScalarDB Core Error Codes
       </Translate>
     ),
   },
@@ -191,11 +191,11 @@ const CardsReference = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'storage-abstraction',
+      page: 'scalar-licensing',
     },
     description: (
       <Translate id="home.reference.description">
-        Storage abstraction and API guide
+        How to Configure a Product License Key
       </Translate>
     ),
   },
@@ -247,20 +247,10 @@ export function CardRowAbout(): JSX.Element {
   );
 }
 
-export function CardRowGettingStarted(): JSX.Element {
+export function CardRowQuickstart(): JSX.Element {
   return (
     <div className="row">
-      {CardsGettingStarted.map((special) => (
-        <Card key={special.name} {...special} />
-      ))}
-    </div>
-  );
-}
-
-export function CardRowSamples(): JSX.Element {
-  return (
-    <div className="row">
-      {CardsSamples.map((special) => (
+      {CardsQuickstart.map((special) => (
         <Card key={special.name} {...special} />
       ))}
     </div>
@@ -281,6 +271,16 @@ export function CardRowDeploy(): JSX.Element {
   return (
     <div className="row">
       {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowMigrate(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsMigrate.map((special) => (
         <Card key={special.name} {...special} />
       ))}
     </div>

--- a/src/components/Cards/3.13.tsx
+++ b/src/components/Cards/3.13.tsx
@@ -39,7 +39,7 @@ const CardsAbout = [
   },
 ]
 
-const CardsGettingStarted = [
+const CardsQuickstart = [
   {
     // name: '',
     // image: '<LINK_TO>.png',
@@ -47,7 +47,7 @@ const CardsGettingStarted = [
       page: 'getting-started-with-scalardb',
     },
     description: (
-      <Translate id="home.gettingStarted.description">
+      <Translate id="home.quickstart.description">
         Getting started with ScalarDB
       </Translate>
     ),
@@ -59,35 +59,8 @@ const CardsGettingStarted = [
       page: 'scalardb-cluster/getting-started-with-scalardb-cluster',
     },
     description: (
-      <Translate id="home.gettingStarted.description">
+      <Translate id="home.quickstart.description">
         Getting started with ScalarDB Cluster
-      </Translate>
-    ),
-  },
-]
-
-const CardsSamples = [
-  {
-    // name: '',
-    // image: '<LINK_TO>.png',
-    url: {
-      page: 'scalardb-samples/multi-storage-transaction-sample',
-    },
-    description: (
-      <Translate id="home.samples.description">
-        Run a sample application with multi-storage transaction support
-      </Translate>
-    ),
-  },
-  {
-    // name: '',
-    // image: '<LINK_TO>.png',
-    url: {
-      page: 'scalardb-samples/microservice-transaction-sample',
-    },
-    description: (
-      <Translate id="home.samples.description">
-        Run a sample application that supports microservice transactions
       </Translate>
     ),
   },
@@ -125,11 +98,11 @@ const CardsDeploy = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDBCluster',
     },
     description: (
       <Translate id="home.deploy.description">
-        Set up a database for ScalarDB on AWS
+        See the ScalarDB Cluster production checklist
       </Translate>
     ),
   },
@@ -137,11 +110,38 @@ const CardsDeploy = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/ProductionChecklistForScalarDBCluster',
+      page: 'scalar-kubernetes/ManualDeploymentGuideScalarDBClusterOnEKS',
     },
     description: (
       <Translate id="home.deploy.description">
-        See the ScalarDB Cluster production checklist
+        Deploy ScalarDB Cluster on Amazon EKS
+      </Translate>
+    ),
+  },
+]
+
+const CardsMigrate = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader-import',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Import Existing Tables by Using ScalarDB Schema Loader
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-sql/migration-guide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Migrate Your Applications and Databases
       </Translate>
     ),
   },
@@ -155,7 +155,7 @@ const CardsManage = [
       page: 'scalar-kubernetes/K8sMonitorGuide',
     },
     description: (
-      <Translate id="home.manage.description">
+      <Translate id="home.migrate.description">
         Monitor ScalarDB in a Kubernetes cluster
       </Translate>
     ),
@@ -164,11 +164,11 @@ const CardsManage = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/BackupRestoreGuide',
+      page: 'scalar-kubernetes/BackupNoSQL',
     },
     description: (
-      <Translate id="home.manage.description">
-        Back up and restore in a Kubernetes environment
+      <Translate id="home.migrate.description">
+        Back up a NoSQL database in a Kubernetes environment
       </Translate>
     ),
   },
@@ -179,11 +179,11 @@ const CardsReference = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalardb-benchmarks',
+      page: 'scalardb-core-status-codes',
     },
     description: (
       <Translate id="home.reference.description">
-        Benchmarking tools
+        ScalarDB Core Error Codes
       </Translate>
     ),
   },
@@ -191,11 +191,11 @@ const CardsReference = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'storage-abstraction',
+      page: 'scalar-licensing',
     },
     description: (
       <Translate id="home.reference.description">
-        Storage abstraction and API guide
+        How to Configure a Product License Key
       </Translate>
     ),
   },
@@ -247,20 +247,10 @@ export function CardRowAbout(): JSX.Element {
   );
 }
 
-export function CardRowGettingStarted(): JSX.Element {
+export function CardRowQuickstart(): JSX.Element {
   return (
     <div className="row">
-      {CardsGettingStarted.map((special) => (
-        <Card key={special.name} {...special} />
-      ))}
-    </div>
-  );
-}
-
-export function CardRowSamples(): JSX.Element {
-  return (
-    <div className="row">
-      {CardsSamples.map((special) => (
+      {CardsQuickstart.map((special) => (
         <Card key={special.name} {...special} />
       ))}
     </div>
@@ -287,6 +277,16 @@ export function CardRowDeploy(): JSX.Element {
   );
 }
 
+export function CardRowMigrate(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsMigrate.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
 export function CardRowManage(): JSX.Element {
   return (
     <div className="row">
@@ -296,6 +296,7 @@ export function CardRowManage(): JSX.Element {
     </div>
   );
 }
+
 export function CardRowReference(): JSX.Element {
   return (
     <div className="row">

--- a/src/components/Cards/3.14.tsx
+++ b/src/components/Cards/3.14.tsx
@@ -39,7 +39,7 @@ const CardsAbout = [
   },
 ]
 
-const CardsGettingStarted = [
+const CardsQuickstart = [
   {
     // name: '',
     // image: '<LINK_TO>.png',
@@ -47,7 +47,7 @@ const CardsGettingStarted = [
       page: 'getting-started-with-scalardb',
     },
     description: (
-      <Translate id="home.gettingStarted.description">
+      <Translate id="home.quickstart.description">
         Getting started with ScalarDB
       </Translate>
     ),
@@ -59,7 +59,7 @@ const CardsGettingStarted = [
       page: 'scalardb-cluster/getting-started-with-scalardb-cluster',
     },
     description: (
-      <Translate id="home.gettingStarted.description">
+      <Translate id="home.quickstart.description">
         Getting started with ScalarDB Cluster
       </Translate>
     ),
@@ -125,11 +125,11 @@ const CardsDeploy = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDBCluster',
     },
     description: (
       <Translate id="home.deploy.description">
-        Set up a database for ScalarDB on AWS
+        See the ScalarDB Cluster production checklist
       </Translate>
     ),
   },
@@ -137,11 +137,38 @@ const CardsDeploy = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/ProductionChecklistForScalarDBCluster',
+      page: 'scalar-kubernetes/ManualDeploymentGuideScalarDBClusterOnEKS',
     },
     description: (
       <Translate id="home.deploy.description">
-        See the ScalarDB Cluster production checklist
+        Deploy ScalarDB Cluster on Amazon EKS
+      </Translate>
+    ),
+  },
+]
+
+const CardsMigrate = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader-import',
+    },
+    description: (
+      <Translate id="home.migrate.description">
+        Import Existing Tables by Using ScalarDB Schema Loader
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-sql/migration-guide',
+    },
+    description: (
+      <Translate id="home.migrate.description">
+        Migrate Your Applications and Databases
       </Translate>
     ),
   },
@@ -164,11 +191,11 @@ const CardsManage = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/BackupRestoreGuide',
+      page: 'scalar-kubernetes/BackupNoSQL',
     },
     description: (
       <Translate id="home.manage.description">
-        Back up and restore in a Kubernetes environment
+        Back up a NoSQL database in a Kubernetes environment
       </Translate>
     ),
   },
@@ -179,11 +206,11 @@ const CardsReference = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalardb-benchmarks',
+      page: 'scalardb-core-status-codes',
     },
     description: (
       <Translate id="home.reference.description">
-        Benchmarking tools
+        ScalarDB Core Error Codes
       </Translate>
     ),
   },
@@ -191,11 +218,11 @@ const CardsReference = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'storage-abstraction',
+      page: 'scalar-licensing',
     },
     description: (
       <Translate id="home.reference.description">
-        Storage abstraction and API guide
+        How to Configure a Product License Key
       </Translate>
     ),
   },
@@ -247,10 +274,10 @@ export function CardRowAbout(): JSX.Element {
   );
 }
 
-export function CardRowGettingStarted(): JSX.Element {
+export function CardRowQuickstart(): JSX.Element {
   return (
     <div className="row">
-      {CardsGettingStarted.map((special) => (
+      {CardsQuickstart.map((special) => (
         <Card key={special.name} {...special} />
       ))}
     </div>
@@ -287,6 +314,16 @@ export function CardRowDeploy(): JSX.Element {
   );
 }
 
+export function CardRowMigrate(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsMigrate.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
 export function CardRowManage(): JSX.Element {
   return (
     <div className="row">
@@ -296,6 +333,7 @@ export function CardRowManage(): JSX.Element {
     </div>
   );
 }
+
 export function CardRowReference(): JSX.Element {
   return (
     <div className="row">

--- a/src/components/Cards/ja-jp/3.13.tsx
+++ b/src/components/Cards/ja-jp/3.13.tsx
@@ -1,0 +1,308 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'overview',
+    },
+    description: (
+      <Translate id="home.about.description">
+        概要
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'requirements',
+    },
+    description: (
+      <Translate id="home.about.description">
+        要件
+      </Translate>
+    ),
+  },
+]
+
+const CardsQuickstart = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb',
+    },
+    description: (
+      <Translate id="home.quickstart.description">
+        ScalarDB をはじめよう
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-cluster/getting-started-with-scalardb-cluster',
+    },
+    description: (
+      <Translate id="home.quickstart.description">
+        ScalarDB Cluster をはじめよう
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'add-scalardb-to-your-build',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        ビルドに ScalarDB を追加する
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        ScalarDB Schema Loader
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDBCluster',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        ScalarDB Cluster の運用チェックリストを参照する
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ManualDeploymentGuideScalarDBClusterOnEKS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Amazon EKS に ScalarDB Cluster をデプロイする
+      </Translate>
+    ),
+  },
+]
+
+const CardsMigrate = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader-import',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        ScalarDB Schema Loader を使用して既存のテーブルをインポートする
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-sql/migration-guide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        アプリケーションとデータベースの移行
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.migrate.description">
+        Kubernetes クラスター上の Scalar 製品の監視
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupNoSQL',
+    },
+    description: (
+      <Translate id="home.migrate.description">
+        Kubernetes 環境で NoSQL データベースをバックアップする
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-core-status-codes',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        ScalarDB Core エラーコード
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-licensing',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        製品ライセンスキーの設定方法
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowQuickstart(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsQuickstart.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowMigrate(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsMigrate.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/ja-jp/3.14.tsx
+++ b/src/components/Cards/ja-jp/3.14.tsx
@@ -1,0 +1,308 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'overview',
+    },
+    description: (
+      <Translate id="home.about.description">
+        概要
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'requirements',
+    },
+    description: (
+      <Translate id="home.about.description">
+        要件
+      </Translate>
+    ),
+  },
+]
+
+const CardsQuickstart = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-with-scalardb',
+    },
+    description: (
+      <Translate id="home.quickstart.description">
+        ScalarDB をはじめよう
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-cluster/getting-started-with-scalardb-cluster',
+    },
+    description: (
+      <Translate id="home.quickstart.description">
+        ScalarDB Cluster をはじめよう
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'add-scalardb-to-your-build',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        ビルドに ScalarDB を追加する
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        ScalarDB Schema Loader
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDBCluster',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        ScalarDB Cluster の運用チェックリストを参照する
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ManualDeploymentGuideScalarDBClusterOnEKS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Amazon EKS に ScalarDB Cluster をデプロイする
+      </Translate>
+    ),
+  },
+]
+
+const CardsMigrate = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader-import',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        ScalarDB Schema Loader を使用して既存のテーブルをインポートする
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-sql/migration-guide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        アプリケーションとデータベースの移行
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.migrate.description">
+        Kubernetes クラスター上の Scalar 製品の監視
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupNoSQL',
+    },
+    description: (
+      <Translate id="home.migrate.description">
+        Kubernetes 環境で NoSQL データベースをバックアップする
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardb-core-status-codes',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        ScalarDB Core エラーコード
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-licensing',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        製品ライセンスキーの設定方法
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowQuickstart(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsQuickstart.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowMigrate(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsMigrate.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/versioned_docs/version-3.12/index.mdx
+++ b/versioned_docs/version-3.12/index.mdx
@@ -7,7 +7,7 @@ tags:
 
 # ScalarDB
 
-import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.12';
+import { CardRowAbout, CardRowQuickstart, CardRowDevelop, CardRowDeploy, CardRowMigrate, CardRowManage, CardRowReference } from '/src/components/Cards/3.12';
 
 ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real-time analytics across diverse databases to simplify the complexity of managing multiple databases.
 
@@ -15,13 +15,9 @@ ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real
 
 <CardRowAbout />
 
-**Getting started**
+**Quickstart**
 
-<CardRowGettingStarted />
-
-**Samples**
-
-<CardRowSamples />
+<CardRowQuickstart />
 
 **Develop**
 
@@ -31,10 +27,14 @@ ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real
 
 <CardRowDeploy />
 
+**Migrate**
+
+<CardRowMigrate />
+
 **Manage**
 
 <CardRowManage />
 
-**Reference**
+**Troubleshoot & Reference**
 
 <CardRowReference />

--- a/versioned_docs/version-3.13/index.mdx
+++ b/versioned_docs/version-3.13/index.mdx
@@ -7,7 +7,7 @@ tags:
 
 # ScalarDB
 
-import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.13';
+import { CardRowAbout, CardRowQuickstart, CardRowDevelop, CardRowDeploy, CardRowMigrate, CardRowManage, CardRowReference } from '/src/components/Cards/3.13';
 
 ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real-time analytics across diverse databases to simplify the complexity of managing multiple databases.
 
@@ -15,13 +15,9 @@ ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real
 
 <CardRowAbout />
 
-**Getting started**
+**Quickstart**
 
-<CardRowGettingStarted />
-
-**Samples**
-
-<CardRowSamples />
+<CardRowQuickstart />
 
 **Develop**
 
@@ -31,10 +27,14 @@ ScalarDB is a cross-database HTAP engine. It achieves ACID transactions and real
 
 <CardRowDeploy />
 
+**Migrate**
+
+<CardRowMigrate />
+
 **Manage**
 
 <CardRowManage />
 
-**Reference**
+**Troubleshoot & Reference**
 
 <CardRowReference />


### PR DESCRIPTION
## Description

This PR updates the homepage cards on the English part of the docs site and adds homepage cards to the Japanese part of the docs site.

## Related issues and/or PRs

N/A

## Changes made

- Updated the English cards on the English homepage for versions 3.12, 3.13, and 3.14.
- Added Japanese cards for the Japanese homepage for versions 3.13 and 3.14.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A