### PR TITLE
Change announcement to promote ScalarDB 3.14 release

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -492,7 +492,7 @@ const config = {
         id: 'new_version',
         content:
           '<b>Docs for both ScalarDB Community and Enterprise editions now live on this site!</b> Editions that a doc applies to are in tags at the top of each page 🏷️',
-          // '<b>The ScalarDB X.X is now available!🥳 For details on what\'s included in this new version, see the <a target="_self" rel="noopener noreferrer" href="/docs/latest/releases/release-notes">release notes</a>.<b>',
+          // '<b>Announcing the release of ScalarDB X.X!🚀 For details on what\'s included in this new version, see the <a target="_self" rel="noopener noreferrer" href="/docs/latest/releases/release-notes">release notes</a>.<b>',
         backgroundColor: '#2673BB',
         textColor: '#FFFFFF',
         isCloseable: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -491,7 +491,7 @@ const config = {
       announcementBar: {
         id: 'new_version',
         content:
-          '<b>Docs for both ScalarDB Community and Enterprise editions now live on this site!</b> Editions that a doc applies to are in tags at the top of each page 🏷️',
+          '<b>Announcing the release of ScalarDB 3.14!🚀 For details on what\'s included in this new version, see the <a target="_self" rel="noopener noreferrer" href="/docs/latest/releases/release-notes">release notes</a>.',
           // '<b>Announcing the release of ScalarDB X.X!🚀 For details on what\'s included in this new version, see the <a target="_self" rel="noopener noreferrer" href="/docs/latest/releases/release-notes">release notes</a>.<b>',
         backgroundColor: '#2673BB',
         textColor: '#FFFFFF',


### PR DESCRIPTION
## Description

This PR changes the announcement on the docs site to promote the release of ScalarDB 3.14.
 
## Related issues and/or PRs

- **PR for the previous announcement:** https://github.com/scalar-labs/docs-scalardb/pull/595

## Changes made

- Changed the wording in the announcement:
  - **Before:** Announcing the combination of the Community and Enterprise docs site
  - **After:** Announcing the release of ScalarDB 3.14

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A