### PR TITLE
Change background color of cookie consent banner

### DIFF
--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -36,7 +36,7 @@ export default function Root({ children }) {
           location="bottom"
           buttonText="I understand"
           style={{
-            backgroundColor: "#080f53",
+            backgroundColor: "#2673bb",
             padding: "20px",
           }}
           buttonStyle={{


### PR DESCRIPTION
## Description

This PR changes the background color of the cookie consent banner to match Scalar's brand colors.

## Related issues and/or PRs

- This change should have been made in https://github.com/scalar-labs/docs-scalardb/pull/805.

## Changes made

- Changed the background color of the cookie consent banner to Scalar blue (`#2673bb`).

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
