### PR TITLE
Hide unsupported from versions dropdown menu; add single page for navigating to unsupported versions

### DIFF
--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-pages/unsupported-versions.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-pages/unsupported-versions.mdx
@@ -1,0 +1,16 @@
+---
+---
+
+# サポートされていないバージョン
+
+import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
+
+<TranslationBanner />
+
+ScalarDB の次のバージョンはサポートされなくなりました。
+
+- [ScalarDB 3.8](/docs/3.8/)
+- [ScalarDB 3.7](/docs/3.7/)
+- [ScalarDB 3.6](/docs/3.6/)
+- [ScalarDB 3.5](/docs/3.5/)
+- [ScalarDB 3.4](/docs/3.4/)

--- a/src/pages/unsupported-versions.mdx
+++ b/src/pages/unsupported-versions.mdx
@@ -1,11 +1,12 @@
 ---
-toc: false
 ---
 
 # Unsupported Versions
 
 The following versions of ScalarDB are no longer supported:
 
+- [ScalarDB 3.8](/docs/3.8/)
+- [ScalarDB 3.7](/docs/3.7/)
 - [ScalarDB 3.6](/docs/3.6/)
 - [ScalarDB 3.5](/docs/3.5/)
 - [ScalarDB 3.4](/docs/3.4/)

--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import {
+  useVersions,
+  useActiveDocContext,
+  useDocsVersionCandidates,
+  useDocsPreferredVersion,
+} from '@docusaurus/plugin-content-docs/client';
+import {translate} from '@docusaurus/Translate';
+import {useLocation} from '@docusaurus/router';
+import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
+import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';
+function getVersionMainDoc(version) {
+  return version.docs.find((doc) => doc.id === version.mainDocId);
+}
+function getVersionTargetDoc(version, activeDocContext) {
+  // We try to link to the same doc, in another version
+  // When not possible, fallback to the "main doc" of the version
+  return (
+    activeDocContext.alternateDocVersions[version.name] ??
+    getVersionMainDoc(version)
+  );
+}
+export default function DocsVersionDropdownNavbarItem({
+  mobile,
+  docsPluginId,
+  dropdownActiveClassDisabled,
+  dropdownItemsBefore,
+  dropdownItemsAfter,
+  ...props
+}) {
+  const {search, hash} = useLocation();
+  const activeDocContext = useActiveDocContext(docsPluginId);
+  const versions = useVersions(docsPluginId);
+  const {savePreferredVersionName} = useDocsPreferredVersion(docsPluginId);
+  function versionToLink(version) {
+    const targetDoc = getVersionTargetDoc(version, activeDocContext);
+    return {
+      label: version.label,
+      // preserve ?search#hash suffix on version switches
+      to: `${targetDoc.path}${search}${hash}`,
+      isActive: () => version === activeDocContext.activeVersion,
+      onClick: () => savePreferredVersionName(version.name),
+    };
+  }
+  const items = [
+    ...dropdownItemsBefore,
+    ...versions.map(versionToLink),
+    ...dropdownItemsAfter,
+  ];
+  const dropdownVersion = useDocsVersionCandidates(docsPluginId)[0];
+  // Mobile dropdown is handled a bit differently
+  const dropdownLabel =
+    mobile && items.length > 1
+      ? translate({
+          id: 'theme.navbar.mobileVersionsDropdown.label',
+          message: 'Versions',
+          description:
+            'The label for the navbar versions dropdown on mobile view',
+        })
+      : dropdownVersion.label;
+  const dropdownTo =
+    mobile && items.length > 1
+      ? undefined
+      : getVersionTargetDoc(dropdownVersion, activeDocContext).path;
+  // We don't want to render a version dropdown with 0 or 1 item. If we build
+  // the site with a single docs version (onlyIncludeVersions: ['1.0.0']),
+  // We'd rather render a button instead of a dropdown
+  if (items.length <= 1) {
+    return (
+      <DefaultNavbarItem
+        {...props}
+        mobile={mobile}
+        label={dropdownLabel}
+        to={dropdownTo}
+        isActive={dropdownActiveClassDisabled ? () => false : undefined}
+      />
+    );
+  }
+  return (
+    <DropdownNavbarItem
+      {...props}
+      mobile={mobile}
+      label={dropdownLabel}
+      to={dropdownTo}
+      items={items}
+      isActive={dropdownActiveClassDisabled ? () => false : undefined}
+    />
+  );
+}

--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -36,9 +36,13 @@ export default function DocsVersionDropdownNavbarItem({
   const versions = useVersions(docsPluginId);
   const {savePreferredVersionName} = useDocsPreferredVersion(docsPluginId);
 
-  // Filter out versions with "unsupported" in the label
+  // Filter out versions with "unsupported" or "サポートされていない" in the label
   const supportedVersions = versions.filter((version) => {
-    return !version.label.toLowerCase().includes('unsupported');
+    const label = version.label.toLowerCase();
+    return (
+      !label.includes('(unsupported)') &&
+      !label.includes('(サポートされていない)')
+    );
   });
 
   function versionToLink(version) {

--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -9,9 +9,11 @@ import {translate} from '@docusaurus/Translate';
 import {useLocation} from '@docusaurus/router';
 import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
 import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';
+
 function getVersionMainDoc(version) {
   return version.docs.find((doc) => doc.id === version.mainDocId);
 }
+
 function getVersionTargetDoc(version, activeDocContext) {
   // We try to link to the same doc, in another version
   // When not possible, fallback to the "main doc" of the version
@@ -20,18 +22,25 @@ function getVersionTargetDoc(version, activeDocContext) {
     getVersionMainDoc(version)
   );
 }
+
 export default function DocsVersionDropdownNavbarItem({
   mobile,
   docsPluginId,
   dropdownActiveClassDisabled,
-  dropdownItemsBefore,
-  dropdownItemsAfter,
+  dropdownItemsBefore = [],
+  dropdownItemsAfter = [],
   ...props
 }) {
   const {search, hash} = useLocation();
   const activeDocContext = useActiveDocContext(docsPluginId);
   const versions = useVersions(docsPluginId);
   const {savePreferredVersionName} = useDocsPreferredVersion(docsPluginId);
+
+  // Filter out versions with "unsupported" in the label
+  const supportedVersions = versions.filter((version) => {
+    return !version.label.toLowerCase().includes('unsupported');
+  });
+
   function versionToLink(version) {
     const targetDoc = getVersionTargetDoc(version, activeDocContext);
     return {
@@ -42,11 +51,20 @@ export default function DocsVersionDropdownNavbarItem({
       onClick: () => savePreferredVersionName(version.name),
     };
   }
+
   const items = [
     ...dropdownItemsBefore,
-    ...versions.map(versionToLink),
+    ...supportedVersions.map(versionToLink),
     ...dropdownItemsAfter,
+    {
+      label: translate({
+        id: 'navbar.unsupportedVersions',
+        message: 'Unsupported Versions',
+      }),
+      to: '/unsupported-versions',
+    },
   ];
+
   const dropdownVersion = useDocsVersionCandidates(docsPluginId)[0];
   // Mobile dropdown is handled a bit differently
   const dropdownLabel =
@@ -58,6 +76,7 @@ export default function DocsVersionDropdownNavbarItem({
             'The label for the navbar versions dropdown on mobile view',
         })
       : dropdownVersion.label;
+
   const dropdownTo =
     mobile && items.length > 1
       ? undefined
@@ -65,6 +84,7 @@ export default function DocsVersionDropdownNavbarItem({
   // We don't want to render a version dropdown with 0 or 1 item. If we build
   // the site with a single docs version (onlyIncludeVersions: ['1.0.0']),
   // We'd rather render a button instead of a dropdown
+
   if (items.length <= 1) {
     return (
       <DefaultNavbarItem
@@ -76,6 +96,7 @@ export default function DocsVersionDropdownNavbarItem({
       />
     );
   }
+
   return (
     <DropdownNavbarItem
       {...props}


### PR DESCRIPTION
## Description

This PR adds the following:

- A feature to hide unsupported from versions dropdown menu.
- A single page for navigating to unsupported versions.

As we've continued to release versions of ScalarDB, the version dropdown menu has become long, with most items showing as `X.X unsupported`. By keeping the version dropdown short, we can continue to release new versions and keep the dropdown menu focused only one the versions that we support.

This feature automatically detects when a version includes `(unsupported)` in its label in the **docusaurus.config.js** file. However, when a version is no longer supported, we need to add that version to **/src/pages/unsupported-versions.mdx** so that visitors can still navigate to that version of docs. 

## Related issues and/or PRs

N/A

## Changes made

- Implemented a feature that automatically detects when a version is no longer supported (when the version label in **docusaurus.config.js** includes `(unsupported)`.
- Added a single page for visitors to navigate to unsupported versions of ScalarDB docs.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A