### PR TITLE
Add dynamic linking feature that generates links to versioned Javadocs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -69,27 +69,32 @@ const config = {
                 label: '<VERSION_NUMBER>',
                 path: 'latest', // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 banner: 'none',
+                className: 'X.X.X', // This should be the most recent version (major.minor.patch) so that the Javadoc links point to the latest version based on the major.minor version that the visitor is viewing on the docs site.
               },
               */
               current: { // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 label: '3.14',
                 path: 'latest', // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 banner: 'none',
+                className: '3.14.0',
               },
               "3.13": {
                 label: '3.13',
                 path: '3.13',
                 banner: 'none',
+                className: '3.13.1',
               },
               "3.12": {
                 label: '3.12',
                 path: '3.12',
                 banner: 'none',
+                className: '3.12.4',
               },
               "3.11": {
                 label: '3.11',
                 path: '3.11',
                 banner: 'none',
+                className: '3.11.4',
               },
               "3.10": {
                 label: '3.10',

--- a/src/theme/JavadocLink.js
+++ b/src/theme/JavadocLink.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useActiveVersion } from '@docusaurus/plugin-content-docs/client';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+export default function JavadocLink({ packageName, path, className }) {
+  const { siteConfig } = useDocusaurusContext();
+  const activeVersion = useActiveVersion();
+
+  // Retrieve className from siteConfig based on the active version.
+  const docsClassName =
+    siteConfig.presets?.[0]?.[1]?.docs?.versions?.[activeVersion.name]?.className;
+
+  // Log for debugging
+  console.log('Active Version:', activeVersion?.name);
+  console.log('Docs ClassName:', docsClassName);
+
+  // The link in the <a> code below is generated based on the following JavadocLink component that must be added in place of a static Javadoc link in the doc:
+  // <JavadocLink packageName="scalardl-common" path="com/scalar/dl/ledger/config" className="LedgerConfig" />
+  return (
+    <a
+      href={`https://javadoc.io/static/com.scalar-labs/${packageName}/${docsClassName}/${path}/${className}.html`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {className}
+    </a>
+  );
+}

--- a/src/theme/JavadocLink.js
+++ b/src/theme/JavadocLink.js
@@ -15,7 +15,9 @@ export default function JavadocLink({ packageName, path, className }) {
   console.log('Docs ClassName:', docsClassName);
 
   // The link in the <a> code below is generated based on the following JavadocLink component that must be added in place of a static Javadoc link in the doc:
-  // <JavadocLink packageName="scalardl-common" path="com/scalar/dl/ledger/config" className="LedgerConfig" />
+  // <JavadocLink packageName="<PACKAGE_NAME>" path="<PATH>" className="<CLASS_NAME>" />
+  // In addition, be sure to add the following below the title to import the component:
+  // import JavadocLink from "/src/theme/JavadocLink.js";
   return (
     <a
       href={`https://javadoc.io/static/com.scalar-labs/${packageName}/${docsClassName}/${path}/${className}.html`}


### PR DESCRIPTION
## Description

This PR adds a feature that dynamically generates links to versioned Javadocs based on the version of the docs that the visitor is viewing. By implementing this feature, we can:

- Move away from providing a generic link to our Javadocs, saving visitors time in finding our Java API class names.
- Avoid adding links that include a specific version of a Javadoc link that must be updated when a new patch version is released.

> [!NOTE]
>
> After implementing this feature, we'll need to use the following syntax to add links to Javadocs:
>
> ```markdown
> <JavadocLink packageName="<PACKAGE_NAME>" path="<PATH>" className="<CLASS_NAME>" />
> ``` 
>
> The syntax for the Javadoc link above is as follows:
>
> `https://javadoc.io/static/com.scalar-labs/<PACKAGE_NAME>/3.10.0/<PATH>/<CLASS_NAME>.html`

## Related issues and/or PRs

N/A

## Changes made

- Created the JavadocLink component for generating the link based on the package name and class name.
- Added `className` (a native field in Docusaurus) to the versions section of **docusaurus.config.js**. The `className` should be the latest version (`major.minor.patch`) version for that `major.minor` version. 

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A