### PR TITLE
Mark ScalarDB 3.9 as no longer supported

### DIFF
--- a/docs/releases/release-support-policy.mdx
+++ b/docs/releases/release-support-policy.mdx
@@ -71,7 +71,7 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8**</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>**</td>
       <td class="version-out-of-support">2023-01-17</td>
       <td class="version-out-of-support">2024-04-26</td>
       <td class="version-out-of-support">2024-10-23</td>

--- a/docs/releases/release-support-policy.mdx
+++ b/docs/releases/release-support-policy.mdx
@@ -64,11 +64,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a></td>
-      <td>2023-04-27</td>
-      <td>2024-07-19</td>
-      <td>2025-01-15</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a>**</td>
+      <td class="version-out-of-support">2023-04-27</td>
+      <td class="version-out-of-support">2024-07-19</td>
+      <td class="version-out-of-support">2025-01-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>**</td>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -102,9 +102,9 @@ const config = {
                 banner: 'none',
               },
               "3.9": {
-                label: '3.9',
+                label: '3.9 (unsupported)',
                 path: '3.9',
-                banner: 'none',
+                banner: 'unmaintained',
               },
               "3.8": {
                 label: '3.8 (unsupported)',

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
@@ -68,11 +68,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.9/releases/release-notes#v390">3.9</a></td>
-      <td>2023-04-27</td>
-      <td>2024-07-19</td>
-      <td>2025-01-15</td>
-      <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.9/releases/release-notes#v390">3.9</a>**</td>
+      <td class="version-out-of-support">2023-04-27</td>
+      <td class="version-out-of-support">2024-07-19</td>
+      <td class="version-out-of-support">2025-01-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8</a>**</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
@@ -75,7 +75,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8**</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8</a>**</td>
       <td class="version-out-of-support">2023-01-17</td>
       <td class="version-out-of-support">2024-04-26</td>
       <td class="version-out-of-support">2024-10-23</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/releases/release-support-policy.mdx
@@ -68,35 +68,35 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8**</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
       <td class="version-out-of-support">2023-01-17</td>
       <td class="version-out-of-support">2024-04-26</td>
       <td class="version-out-of-support">2024-10-23</td>
       <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a>*</td>
       <td class="version-out-of-support">2022-09-03</td>
       <td class="version-out-of-support">2024-01-17</td>
       <td class="version-out-of-support">2024-07-15</td>
       <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.6/releases/release-notes#v360">3.6</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.6/releases/release-notes#v360">3.6</a>*</td>
       <td class="version-out-of-support">2022-07-08</td>
       <td class="version-out-of-support">2023-09-03</td>
       <td class="version-out-of-support">2024-03-01</td>
       <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
       <td class="version-out-of-support">2022-02-16</td>
       <td class="version-out-of-support">2023-07-08</td>
       <td class="version-out-of-support">2024-01-04</td>
       <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
       <td class="version-out-of-support">2021-12-02</td>
       <td class="version-out-of-support">2023-02-16</td>
       <td class="version-out-of-support">2023-08-15</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/releases/release-support-policy.mdx
@@ -61,11 +61,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.9/releases/release-notes#v390">3.9</a></td>
-      <td>2023-04-27</td>
-      <td>2024-07-19</td>
-      <td>2025-01-15</td>
-      <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.9/releases/release-notes#v390">3.9</a>*</td>
+      <td class="version-out-of-support">2023-04-27</td>
+      <td class="version-out-of-support">2024-07-19</td>
+      <td class="version-out-of-support">2025-01-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8</a>*</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.9.json
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.9.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "3.9",
+    "message": "3.9 (サポートされていない)",
     "description": "The label for version 3.9"
   }
 }

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-pages/unsupported-versions.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-pages/unsupported-versions.mdx
@@ -9,6 +9,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 ScalarDB の次のバージョンはサポートされなくなりました。
 
+- [ScalarDB 3.9](/docs/3.9/)
 - [ScalarDB 3.8](/docs/3.8/)
 - [ScalarDB 3.7](/docs/3.7/)
 - [ScalarDB 3.6](/docs/3.6/)

--- a/src/pages/unsupported-versions.mdx
+++ b/src/pages/unsupported-versions.mdx
@@ -5,6 +5,7 @@
 
 The following versions of ScalarDB are no longer supported:
 
+- [ScalarDB 3.9](/docs/3.9/)
 - [ScalarDB 3.8](/docs/3.8/)
 - [ScalarDB 3.7](/docs/3.7/)
 - [ScalarDB 3.6](/docs/3.6/)

--- a/versioned_docs/version-3.10/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.10/releases/release-support-policy.mdx
@@ -35,11 +35,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a></td>
-      <td>2023-04-27</td>
-      <td>2024-07-19</td>
-      <td>2025-01-15</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a>*</td>
+      <td class="version-out-of-support">2023-04-27</td>
+      <td class="version-out-of-support">2024-07-19</td>
+      <td class="version-out-of-support">2025-01-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>

--- a/versioned_docs/version-3.10/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.10/releases/release-support-policy.mdx
@@ -42,7 +42,7 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8*</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
       <td class="version-out-of-support">2023-01-17</td>
       <td class="version-out-of-support">2024-04-26</td>
       <td class="version-out-of-support">2024-10-23</td>

--- a/versioned_docs/version-3.11/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.11/releases/release-support-policy.mdx
@@ -49,7 +49,7 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8*</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
       <td class="version-out-of-support">2023-01-17</td>
       <td class="version-out-of-support">2024-04-26</td>
       <td class="version-out-of-support">2024-10-23</td>

--- a/versioned_docs/version-3.11/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.11/releases/release-support-policy.mdx
@@ -42,11 +42,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a></td>
-      <td>2023-04-27</td>
-      <td>2024-07-19</td>
-      <td>2025-01-15</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a>*</td>
+      <td class="version-out-of-support">2023-04-27</td>
+      <td class="version-out-of-support">2024-07-19</td>
+      <td class="version-out-of-support">2025-01-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>

--- a/versioned_docs/version-3.12/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.12/releases/release-support-policy.mdx
@@ -49,11 +49,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a></td>
-      <td>2023-04-27</td>
-      <td>2024-07-19</td>
-      <td>2025-01-15</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a>*</td>
+      <td class="version-out-of-support">2023-04-27</td>
+      <td class="version-out-of-support">2024-07-19</td>
+      <td class="version-out-of-support">2025-01-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>

--- a/versioned_docs/version-3.12/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.12/releases/release-support-policy.mdx
@@ -56,7 +56,7 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8*</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
       <td class="version-out-of-support">2023-01-17</td>
       <td class="version-out-of-support">2024-04-26</td>
       <td class="version-out-of-support">2024-10-23</td>

--- a/versioned_docs/version-3.13/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.13/releases/release-support-policy.mdx
@@ -64,35 +64,35 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8**</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
       <td class="version-out-of-support">2023-01-17</td>
       <td class="version-out-of-support">2024-04-26</td>
       <td class="version-out-of-support">2024-10-23</td>
       <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>*</td>
       <td class="version-out-of-support">2022-09-03</td>
       <td class="version-out-of-support">2024-01-17</td>
       <td class="version-out-of-support">2024-07-15</td>
       <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>*</td>
       <td class="version-out-of-support">2022-07-08</td>
       <td class="version-out-of-support">2023-09-03</td>
       <td class="version-out-of-support">2024-03-01</td>
       <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
       <td class="version-out-of-support">2022-02-16</td>
       <td class="version-out-of-support">2023-07-08</td>
       <td class="version-out-of-support">2024-01-04</td>
       <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
       <td class="version-out-of-support">2021-12-02</td>
       <td class="version-out-of-support">2023-02-16</td>
       <td class="version-out-of-support">2023-08-15</td>

--- a/versioned_docs/version-3.13/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.13/releases/release-support-policy.mdx
@@ -57,11 +57,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a></td>
-      <td>2023-04-27</td>
-      <td>2024-07-19</td>
-      <td>2025-01-15</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a>*</td>
+      <td class="version-out-of-support">2023-04-27</td>
+      <td class="version-out-of-support">2024-07-19</td>
+      <td class="version-out-of-support">2025-01-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>

--- a/versioned_docs/version-3.8/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.8/releases/release-support-policy.mdx
@@ -28,7 +28,7 @@ This page describes Scalar's support policy for major and minor version releases
   </thead>
   <tbody>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8*</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
       <td class="version-out-of-support">2023-01-17</td>
       <td class="version-out-of-support">2024-04-26</td>
       <td class="version-out-of-support">2024-10-23</td>

--- a/versioned_docs/version-3.9/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.9/releases/release-support-policy.mdx
@@ -28,11 +28,11 @@ This page describes Scalar's support policy for major and minor version releases
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a></td>
-      <td>2023-04-27</td>
-      <td>2024-07-19</td>
-      <td>2025-01-15</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a>*</td>
+      <td class="version-out-of-support">2023-04-27</td>
+      <td class="version-out-of-support">2024-07-19</td>
+      <td class="version-out-of-support">2025-01-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>

--- a/versioned_docs/version-3.9/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.9/releases/release-support-policy.mdx
@@ -35,7 +35,7 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8*</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
       <td class="version-out-of-support">2023-01-17</td>
       <td class="version-out-of-support">2024-04-26</td>
       <td class="version-out-of-support">2024-10-23</td>


### PR DESCRIPTION
## Description

This PR marks ScalarDB 3.9 as no longer supported since Assistance Support ended on January 15, 2025.

## Related issues and/or PRs

N/A

## Changes made

- In each version of the **Release Support Policy** docs:
  - Added an asterisk to 3.9.
  - Added the `out-of-support` style to the cells in the table.
- In **docusaurus.config.js**:
  - Added the `unmaintained` banner, which automatically adds a banner to each page for version 3.9 that states the version is no longer supported.
- On the **Unsupported Versions** page in English and Japanese, which appears in the version dropdown menu:
  - Added a link to version 3.9 docs.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A