### PR TITLE
Clarify AWS and Azure database setup–related labels in sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -589,12 +589,12 @@ const sidebars = {
                 {
                   type: 'doc',
                   id: 'scalar-kubernetes/SetupDatabaseForAWS',
-                  label: 'AWS',
+                  label: 'Databases on AWS',
                 },
                 {
                   type: 'doc',
                   id: 'scalar-kubernetes/SetupDatabaseForAzure',
-                  label: 'Azure',
+                  label: 'Databases on Azure',
                 },
               ],
             },
@@ -1429,12 +1429,12 @@ const sidebars = {
                 {
                   type: 'doc',
                   id: 'scalar-kubernetes/SetupDatabaseForAWS',
-                  label: 'AWS',
+                  label: 'AWS が提供するデータベース',
                 },
                 {
                   type: 'doc',
                   id: 'scalar-kubernetes/SetupDatabaseForAzure',
-                  label: 'Azure',
+                  label: 'Azure が提供するデータベース',
                 },
               ],
             },

--- a/versioned_sidebars/version-3.12-sidebars.json
+++ b/versioned_sidebars/version-3.12-sidebars.json
@@ -553,12 +553,12 @@
                 {
                   "type": "doc",
                   "id": "scalar-kubernetes/SetupDatabaseForAWS",
-                  "label": "AWS"
+                  "label": "Databases on AWS"
                 },
                 {
                   "type": "doc",
                   "id": "scalar-kubernetes/SetupDatabaseForAzure",
-                  "label": "Azure"
+                  "label": "Databases on Azure"
                 }
               ]
             },

--- a/versioned_sidebars/version-3.13-sidebars.json
+++ b/versioned_sidebars/version-3.13-sidebars.json
@@ -563,12 +563,12 @@
                 {
                   "type": "doc",
                   "id": "scalar-kubernetes/SetupDatabaseForAWS",
-                  "label": "AWS"
+                  "label": "Databases on AWS"
                 },
                 {
                   "type": "doc",
                   "id": "scalar-kubernetes/SetupDatabaseForAzure",
-                  "label": "Azure"
+                  "label": "Databases on Azure"
                 }
               ]
             },
@@ -1396,12 +1396,12 @@
                 {
                   "type": "doc",
                   "id": "scalar-kubernetes/SetupDatabaseForAWS",
-                  "label": "AWS"
+                  "label": "AWS が提供するデータベース"
                 },
                 {
                   "type": "doc",
                   "id": "scalar-kubernetes/SetupDatabaseForAzure",
-                  "label": "Azure"
+                  "label": "Azure が提供するデータベース"
                 }
               ]
             },


### PR DESCRIPTION
## Description

This PR clarifies the AWS and Azure database setup–related labels in the sidebar navigation. Since we made a similar change recently on the ScalarDL docs site for the same docs, we should be consistent with using the same labels in the ScalarDB sidebar navigation.

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-scalardl/pull/597

## Changes made

- Changed the generic mention of **AWS** and **Azure** under the **Database Setup Guides** sub-category with **Databases on AWS** and **Databases on AWS**, respectively, in the sidebar navigation for versions 3.14 (latest), 3.13, and 3.12 for both English and Japanese.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A