### PR TITLE
Add syntax highlight for additional coding languages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -492,6 +492,7 @@ const config = {
       prism: {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,
+        additionalLanguages: ['csharp', 'docker', 'java', 'json', 'log', 'properties', 'python', 'scala', 'sql', 'toml'],
       },
       announcementBar: {
         id: 'new_version',


### PR DESCRIPTION
## Description

This PR adds syntax highlighting for additional coding languages. 

> [!NOTE]
>
> By default, Docusaurus includes a limited number of languages that have syntax highlighting, [as described in their documentation](https://docusaurus.io/docs/3.5.2/markdown-features/code-blocks#supported-languages).

## Related issues and/or PRs

N/A

## Changes made

- Added the following languages to the Docusaurus configuration file, which enables syntax highlighting:
  - `csharp`
  - `docker`
  - `java`
  - `json`
  - `log`
  - `properties`
  - `python`
  - `scala`
  - `sql`
  - `toml`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A