### PR TITLE
Add patch version release notes for `3.14.1`, `3.13.2`, `3.12.5`, `3.11.5`, and `3.10.7`

### DIFF
--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -10,6 +10,35 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.14.
 
+## v3.14.1
+
+**Release date:** January 23, 2025
+
+### Summary
+
+This release has several improvements and bug fixes.
+
+### Community edition
+
+#### Improvements
+
+- ScalarDB now supports MySQL 8.4 and 8.0; PostgreSQL 17, 16, 15, 14, and 13; Amazon Aurora PostgreSQL 16, 15, 14, and 13; and Amazon Aurora MySQL 3 and 2. (#2302)
+
+#### Bug fixes
+
+- Added validation for primary key columns in the Cosmos DB adapter. The validation ensures that the text values of the primary key columns do not contain illegal characters (`:`, `/`, `\`, `#`, and `?`). (#2292)
+- Fixed the behavior of multiple mutations for the same record in a transaction in Consensus Commit. (#2340)
+- Fixed the behavior when deleting a non-existing record in the Cosmos adapter. (#2341)
+- Fixed bugs in GetBuilder and ScanBuilder. (#2352)
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB SQL
+
+- [Spring Data JDBC For ScalarDB] Fixed a bug regarding the `existsById()` API not working.
+
 ## v3.14.0
 
 **Release date:** November 22, 2024

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -76,25 +76,25 @@ const config = {
                 label: '3.14',
                 path: 'latest', // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 banner: 'none',
-                className: '3.14.0',
+                className: '3.14.1',
               },
               "3.13": {
                 label: '3.13',
                 path: '3.13',
                 banner: 'none',
-                className: '3.13.1',
+                className: '3.13.2',
               },
               "3.12": {
                 label: '3.12',
                 path: '3.12',
                 banner: 'none',
-                className: '3.12.4',
+                className: '3.12.5',
               },
               "3.11": {
                 label: '3.11',
                 path: '3.11',
                 banner: 'none',
-                className: '3.11.4',
+                className: '3.11.5',
               },
               "3.10": {
                 label: '3.10',

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -16,7 +16,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 ## v3.14.0
 
-**発売日:** 2024 年 11 月 22 日
+**発売日:** 2024年11月22日
 
 ### まとめ
 
@@ -31,7 +31,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 #### 改善点
 
-- MySQL および Oracle のキー列サイズを変更するオプションを追加し、デフォルトとして 128 バイトを使用しました。([#2245](https://github.com/scalar-labs/scalardb/pull/2245))
+- MySQL および Oracle の鍵列サイズを変更するオプションを追加し、デフォルトとして 128 バイトを使用しました。([#2245](https://github.com/scalar-labs/scalardb/pull/2245))
 - メタデータキャッシュの有効期限 (`scalar.db.metadata.cache_expiration_time_secs`) のデフォルト値を 60 秒に変更しました。([#2274](https://github.com/scalar-labs/scalardb/pull/2274))
 
 #### バグの修正

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -14,6 +14,35 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.14 のリリースノートのリストが含まれています。
 
+## v3.14.1
+
+**発売日:** 2025年01月23日
+
+### まとめ
+
+このリリースには、いくつかの改善とバグ修正が含まれています。
+
+### Community edition
+
+#### 改善点
+
+- ScalarDB は、MySQL 8.4 および 8.0、PostgreSQL 17、16、15、14、13、Amazon Aurora PostgreSQL 16、15、14、13、Amazon Aurora MySQL 3 および 2 をサポートするようになりました。(#2302)
+
+#### バグの修正
+
+- Cosmos DB アダプターの主鍵列の検証を追加しました。検証により、主鍵列のテキスト値に不正な文字 (`:`、`/`、`\`、`#`、`?`) が含まれていないことが保証されます。(#2292)
+- Consensus Commit のトランザクションで同じレコードに対して複数のミューテーションが発生する動作を修正しました。 (#2340)
+- Cosmos アダプターで存在しないレコードを削除するときの動作を修正しました。(#2341)
+- GetBuilder と ScanBuilder のバグを修正しました。(#2352)
+
+### Enterprise edition
+
+#### バグの修正
+
+##### ScalarDB SQL
+
+- [Spring Data JDBC For ScalarDB] `existsById()` API が動作しないというバグを修正しました。
+
 ## v3.14.0
 
 **発売日:** 2024年11月22日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/releases/release-notes.mdx
@@ -14,6 +14,35 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.13 のリリースノートのリストが含まれています。
 
+## v3.13.2
+
+**発売日:** 2025年01月23日
+
+### まとめ
+
+このリリースには、いくつかの改善とバグ修正が含まれています。
+
+### Community edition
+
+#### 改善点
+
+- ScalarDB は、MySQL 8.4 および 8.0、PostgreSQL 17、16、15、14、13、Amazon Aurora PostgreSQL 16、15、14、13、Amazon Aurora MySQL 3 および 2 をサポートするようになりました。(#2302)
+
+#### バグの修正
+
+- Cosmos DB アダプターの主鍵列の検証を追加しました。検証により、主鍵列のテキスト値に不正な文字 (`:`、`/`、`\`、`#`、`?`) が含まれていないことが保証されます。(#2292)
+- Consensus Commit のトランザクションで同じレコードに対して複数のミューテーションが発生する動作を修正しました。 (#2340)
+- Cosmos アダプターで存在しないレコードを削除するときの動作を修正しました。(#2341)
+- GetBuilder と ScanBuilder のバグを修正しました。(#2352)
+
+### Enterprise edition
+
+#### バグの修正
+
+##### ScalarDB SQL
+
+- [Spring Data JDBC For ScalarDB] `existsById()` API が動作しないというバグを修正しました。
+
 ## v3.13.1
 
 **発売日:** 2024年10月13日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/releases/release-notes.mdx
@@ -16,7 +16,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 ## v3.13.1
 
-**発売日:** 2024 年 10 月 13 日
+**発売日:** 2024年10月13日
 
 ### まとめ
 
@@ -60,7 +60,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 ## v3.13.0
 
-**発売日:** 2024 年 7 月 8 日
+**発売日:** 2024年7月8日
 
 ### まとめ
 
@@ -72,7 +72,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 - 非 JDBC データベースの動的な任意フィルタリングを追加しました。([#1682](https://github.com/scalar-labs/scalardb/pull/1682))
 - トランザクション API に挿入、アップサート、更新の各操作を追加しました。([#1697](https://github.com/scalar-labs/scalardb/pull/1697))
-- JDBC ストレージの 1 つとして YugabyteDB アダプターを追加しました。([#1710](https://github.com/scalar-labs/scalardb/pull/1710))
+- JDBC ストレージの1つとして YugabyteDB アダプターを追加しました。([#1710](https://github.com/scalar-labs/scalardb/pull/1710))
 - Coordinator テーブルにグループコミット機能を追加しました。([#1728](https://github.com/scalar-labs/scalardb/pull/1728))
 - トランザクションマネージャーを使用して CRUD 操作を直接実行できるようになりました。([#1755](https://github.com/scalar-labs/scalardb/pull/1755))
 - パーティションスキャンとインデックススキャンの任意のフィルタリングのサポートを追加しました。([#1763](https://github.com/scalar-labs/scalardb/pull/1763))
@@ -83,7 +83,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 #### 改善点
 
-- JDBC アダプターで MySQL および SQL Server のハードコードされた照合順序を削除しました。その結果、テーブルの作成時に、基礎となるデータベースで構成された照合順序が使用されます。([#1518](https://github.com/scalar-labs/scalardb/pull/1518))
+- JDBC アダプターで MySQL および SQL Server のハードコードされた照合順序を削除しました。その結果、テーブルの作成時に、基礎となるデータベースで設定された照合順序が使用されます。([#1518](https://github.com/scalar-labs/scalardb/pull/1518))
 - Schema Loader のエラーメッセージにエラーコードを追加しました。([#1564](https://github.com/scalar-labs/scalardb/pull/1564))
 - バックグラウンドワーカーで優先キューを使用することで、グループコミットのパフォーマンスが向上しました。([#1641](https://github.com/scalar-labs/scalardb/pull/1641))
 - フィルタリングによるスキャンをリファクタリングしました。([#1715](https://github.com/scalar-labs/scalardb/pull/1715))
@@ -98,7 +98,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - セキュリティ問題を修正するために PostgresSQL ライブラリをアップグレードしました。[CVE-2024-1597](https://github.com/advisories/GHSA-24rp-q3w6-vc56 "CVE-2024-1597") ([#1547](https://github.com/scalar-labs/scalardb/pull/1547))
 - トランザクション内のレコードをスキャンしているときに `EXTRA_READ` 検証中に `NullPointerException` が発生するが、その一部が他のトランザクションによって削除されるというバグを修正しました。([#1624](https://github.com/scalar-labs/scalardb/pull/1624))
 - put および delete 操作の暗黙的な事前読み取りに対して遅延リカバリが実行されないというバグを修正しました。([#1681](https://github.com/scalar-labs/scalardb/pull/1681))
-- 関連するレコードをコンセンサスコミットトランザクションに入れた後、インデックスキーでレコードをスキャンすると、一貫性のない結果が表示されるバグを修正しました。([#1727](https://github.com/scalar-labs/scalardb/pull/1727))
+- 関連するレコードをコンセンサスコミットトランザクションに入れた後、インデックス鍵でレコードをスキャンすると、一貫性のない結果が表示されるバグを修正しました。([#1727](https://github.com/scalar-labs/scalardb/pull/1727))
 - セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました。[CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g "CVE-2024-24790")、[CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph "CVE-2023-45283")、[CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m "CVE-2023-45288") ([#1980](https://github.com/scalar-labs/scalardb/pull/1980))
 - スナップショット管理の問題を修正しました。([#1976](https://github.com/scalar-labs/scalardb/pull/1976))
 - MySQL ストレージを使用しているときに、同じテーブル名を持つ別の名前空間のテーブルにアクセスできる可能性があるという、import-table 機能のバグを修正しました。([#2001](https://github.com/scalar-labs/scalardb/pull/2001))

--- a/versioned_docs/version-3.10/releases/release-notes.mdx
+++ b/versioned_docs/version-3.10/releases/release-notes.mdx
@@ -9,6 +9,34 @@ tags:
 
 This page includes a list of release notes for ScalarDB 3.10.
 
+## v3.10.7
+
+**Release date:** January 23, 2025
+
+### Summary
+
+This release has several improvements and bug fixes.
+
+### Community edition
+
+#### Improvements
+
+- ScalarDB now supports MySQL 8.4 and 8.0; PostgreSQL 17, 16, 15, 14, and 13; Amazon Aurora PostgreSQL 16, 15, 14, and 13; and Amazon Aurora MySQL 3 and 2. (#2302)
+
+#### Bug fixes
+
+- Added validation for primary key columns in the Cosmos DB adapter. The validation ensures that the text values of the primary key columns do not contain illegal characters (`:`, `/`, `\`, `#`, and `?`). (#2292)
+- Fixed the behavior when deleting a non-existing record in the Cosmos adapter. (#2341)
+- Fixed bugs in GetBuilder and ScanBuilder. (#2352)
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB SQL
+
+- [Spring Data JDBC For ScalarDB] Fixed a bug regarding the `existsById()` API not working.
+
 ## v3.10.6
 
 **Release date:** October 13, 2024

--- a/versioned_docs/version-3.11/releases/release-notes.mdx
+++ b/versioned_docs/version-3.11/releases/release-notes.mdx
@@ -9,6 +9,34 @@ tags:
 
 This page includes a list of release notes for ScalarDB 3.11.
 
+## v3.11.5
+
+**Release date:** January 23, 2025
+
+### Summary
+
+This release has several improvements and bug fixes.
+
+### Community edition
+
+#### Improvements
+
+- ScalarDB now supports MySQL 8.4 and 8.0; PostgreSQL 17, 16, 15, 14, and 13; Amazon Aurora PostgreSQL 16, 15, 14, and 13; and Amazon Aurora MySQL 3 and 2. (#2302)
+
+#### Bug fixes
+
+- Added validation for primary key columns in the Cosmos DB adapter. The validation ensures that the text values of the primary key columns do not contain illegal characters (`:`, `/`, `\`, `#`, and `?`). (#2292)
+- Fixed the behavior when deleting a non-existing record in the Cosmos adapter. (#2341)
+- Fixed bugs in GetBuilder and ScanBuilder. (#2352)
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB SQL
+
+- [Spring Data JDBC For ScalarDB] Fixed a bug regarding the `existsById()` API not working.
+
 ## v3.11.4
 
 **Release date:** October 13, 2024

--- a/versioned_docs/version-3.12/releases/release-notes.mdx
+++ b/versioned_docs/version-3.12/releases/release-notes.mdx
@@ -9,6 +9,34 @@ tags:
 
 This page includes a list of release notes for ScalarDB 3.12.
 
+## v3.12.5
+
+**Release date:** January 23, 2025
+
+### Summary
+
+This release has several improvements and bug fixes.
+
+### Community edition
+
+#### Improvements
+
+- ScalarDB now supports MySQL 8.4 and 8.0; PostgreSQL 17, 16, 15, 14, and 13; Amazon Aurora PostgreSQL 16, 15, 14, and 13; and Amazon Aurora MySQL 3 and 2. (#2302)
+
+#### Bug fixes
+
+- Added validation for primary key columns in the Cosmos DB adapter. The validation ensures that the text values of the primary key columns do not contain illegal characters (`:`, `/`, `\`, `#`, and `?`). (#2292)
+- Fixed the behavior when deleting a non-existing record in the Cosmos adapter. (#2341)
+- Fixed bugs in GetBuilder and ScanBuilder. (#2352)
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB SQL
+
+- [Spring Data JDBC For ScalarDB] Fixed a bug regarding the `existsById()` API not working.
+
 ## v3.12.4
 
 **Release date:** October 13, 2024

--- a/versioned_docs/version-3.13/releases/release-notes.mdx
+++ b/versioned_docs/version-3.13/releases/release-notes.mdx
@@ -10,6 +10,35 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.13.
 
+## v3.13.2
+
+**Release date:** January 23, 2025
+
+### Summary
+
+This release has several improvements and bug fixes.
+
+### Community edition
+
+#### Improvements
+
+- ScalarDB now supports MySQL 8.4 and 8.0; PostgreSQL 17, 16, 15, 14, and 13; Amazon Aurora PostgreSQL 16, 15, 14, and 13; and Amazon Aurora MySQL 3 and 2. (#2302)
+
+#### Bug fixes
+
+- Added validation for primary key columns in the Cosmos DB adapter. The validation ensures that the text values of the primary key columns do not contain illegal characters (`:`, `/`, `\`, `#`, and `?`). (#2292)
+- Fixed the behavior of multiple mutations for the same record in a transaction in Consensus Commit. (#2340)
+- Fixed the behavior when deleting a non-existing record in the Cosmos adapter. (#2341)
+- Fixed bugs in GetBuilder and ScanBuilder. (#2352)
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB SQL
+
+- [Spring Data JDBC For ScalarDB] Fixed a bug regarding the `existsById()` API not working.
+
 ## v3.13.1
 
 **Release date:** October 13, 2024


### PR DESCRIPTION
## Description

This PR adds patch version release notes for ScalarDB 3.14, 3.13, 3.12, 3.11, and 3.10.

## Related issues and/or PRs

N/A

## Changes made

- Added patch version release notes for the following versions:
  - `3.14.1`
  - `3.13.2`
  - `3.12.5`
  - `3.11.5`
  - `3.10.7`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A