### PR TITLE
Fix vector search and ABAC titles in sidebar navigation and re-order them

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -244,6 +244,16 @@ const sidebars = {
                 },
                 {
                   type: 'doc',
+                  id: 'scalardb-cluster/encrypt-data-at-rest',
+                  label: 'Encrypt Data at Rest',
+                },
+                {
+                  type: 'doc',
+                  id: 'scalardb-cluster/encrypt-wire-communications',
+                  label: 'Encrypt Wire Communications',
+                },
+                {
+                  type: 'doc',
                   id: 'scalardb-benchmarks/README',
                   label: 'Run Benchmarks',
                 },
@@ -400,16 +410,6 @@ const sidebars = {
               type: 'doc',
               id: 'scalardb-cluster/scalardb-cluster-grpc-api-guide',
               label: 'ScalarDB Cluster gRPC API Guide',
-            },
-            {
-              type: 'doc',
-              id: 'scalardb-cluster/encrypt-data-at-rest',
-              label: 'Encrypt Data at Rest',
-            },
-            {
-              type: 'doc',
-              id: 'scalardb-cluster/encrypt-wire-communications',
-              label: 'Encrypt Wire Communications',
             },
             {
               type: 'category',
@@ -1119,6 +1119,16 @@ const sidebars = {
                 },
                 {
                   type: 'doc',
+                  id: 'scalardb-cluster/encrypt-data-at-rest',
+                  label: '保存データを暗号化',
+                },
+                {
+                  type: 'doc',
+                  id: 'scalardb-cluster/encrypt-wire-communications',
+                  label: 'ワイヤ通信を暗号化',
+                },
+                {
+                  type: 'doc',
                   id: 'scalardb-benchmarks/README',
                   label: 'ベンチマークを実行',
                 },
@@ -1271,16 +1281,6 @@ const sidebars = {
               type: 'doc',
               id: 'scalardb-cluster/scalardb-cluster-grpc-api-guide',
               label: 'ScalarDB Cluster gRPC API ガイド',
-            },
-            {
-              type: 'doc',
-              id: 'scalardb-cluster/encrypt-data-at-rest',
-              label: '保存データを暗号化',
-            },
-            {
-              type: 'doc',
-              id: 'scalardb-cluster/encrypt-wire-communications',
-              label: 'ワイヤ通信を暗号化',
             },
             {
               type: 'category',

--- a/sidebars.js
+++ b/sidebars.js
@@ -154,6 +154,11 @@ const sidebars = {
           ],
         },
         {
+          type: 'doc',
+          id: 'scalardb-cluster/getting-started-with-vector-search',
+          label: 'Try Running Vector Search Through ScalarDB Cluster',
+        },
+        {
           type: 'category',
           label: 'Reference',
           collapsible: true,
@@ -167,11 +172,6 @@ const sidebars = {
               type: 'doc',
               id: 'scalardb-cluster/getting-started-with-using-python-for-scalardb-cluster',
               label: 'Use Python for ScalarDB Cluster',
-            },
-            {
-              type: 'doc',
-              id: 'scalardb-cluster/getting-started-with-vector-search',
-              label: 'Use Vector Search in ScalarDB Cluster',
             },
             {
               type: 'doc',
@@ -1029,6 +1029,11 @@ const sidebars = {
           ],
         },
         {
+          type: 'doc',
+          id: 'scalardb-cluster/getting-started-with-vector-search',
+          label: 'ScalarDB Cluster を使用してベクトル検索を実行',
+        },
+        {
           type: 'category',
           label: '関連情報',
           collapsible: true,
@@ -1042,11 +1047,6 @@ const sidebars = {
               type: 'doc',
               id: 'scalardb-cluster/getting-started-with-using-python-for-scalardb-cluster',
               label: 'Python から ScalarDB Cluster を使用',
-            },
-            {
-              type: 'doc',
-              id: 'scalardb-cluster/getting-started-with-vector-search',
-              label: 'ScalarDB Cluster でベクトル検索を使用',
             },
             {
               type: 'doc',

--- a/sidebars.js
+++ b/sidebars.js
@@ -239,6 +239,11 @@ const sidebars = {
                 },
                 {
                   type: 'doc',
+                  id: 'scalardb-cluster/authorize-with-abac',
+                  label: 'Control User Access in a Fine-Grained Manner',
+                },
+                {
+                  type: 'doc',
                   id: 'scalardb-benchmarks/README',
                   label: 'Run Benchmarks',
                 },
@@ -405,11 +410,6 @@ const sidebars = {
               type: 'doc',
               id: 'scalardb-cluster/encrypt-wire-communications',
               label: 'Encrypt Wire Communications',
-            },
-            {
-              type: 'doc',
-              id: 'scalardb-cluster/authorize-with-abac',
-              label: 'Control User Access',
             },
             {
               type: 'category',
@@ -1114,6 +1114,11 @@ const sidebars = {
                 },
                 {
                   type: 'doc',
+                  id: 'scalardb-cluster/authorize-with-abac',
+                  label: 'ユーザアクセスを細かく制御',
+                },
+                {
+                  type: 'doc',
                   id: 'scalardb-benchmarks/README',
                   label: 'ベンチマークを実行',
                 },
@@ -1276,11 +1281,6 @@ const sidebars = {
               type: 'doc',
               id: 'scalardb-cluster/encrypt-wire-communications',
               label: 'ワイヤ通信を暗号化',
-            },
-            {
-              type: 'doc',
-              id: 'scalardb-cluster/authorize-with-abac',
-              label: 'ユーザーアクセスを制御',
             },
             {
               type: 'category',


### PR DESCRIPTION
## Description

This PR revises the titles of the new vector search and attribute-based access control (ABAC) docs in the sidebar navigation and moves them to the **Advanced Configurations** subcategory.

In addition, this PR moves encryption-related docs to the **Advanced Configurations** subcategory.

## Related issues and/or PRs

- Docs originally added in https://github.com/scalar-labs/docs-scalardb/pull/980.

## Changes made

- Changed the title of the vector search and ABAC docs in the sidebar navigation.
- Moved the following docs:
  - The vector search doc from **Develop > References** to **Develop > Run Transactions > Advanced Configurations and Operations**.
  - The ABAC doc from **Develop > References** to **Develop > Run Transactions > Advanced Configurations and Operations**.
  - The two encryption-related docs from **Develop > References** to **Develop > Run Transactions > Advanced Configurations and Operations**.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A