### PR TITLE
Remove ScalarDB Analytics version compatibility doc

### DIFF
--- a/docs/scalardb-analytics/version-compatibility.mdx
+++ b/docs/scalardb-analytics/version-compatibility.mdx
@@ -1,5 +1,0 @@
----
-tags:
-  - Enterprise Option
-displayed_sidebar: docsEnglish
----

--- a/versioned_docs/version-3.14/scalardb-analytics/version-compatibility.mdx
+++ b/versioned_docs/version-3.14/scalardb-analytics/version-compatibility.mdx
@@ -1,6 +1,0 @@
----
-tags:
-  - Enterprise Option
-  - Public Preview
-displayed_sidebar: docsEnglish
----


### PR DESCRIPTION
## Description

This PR removes the version compatibility doc for ScalarDB Analytics. Since the contents of that doc have been moved to a section in the [doc for running analytical queries](https://github.com/scalar-labs/docs-internal-scalardb/blob/cfce5fde40ca7efbdfb0432f1ff49b828b9fce93/docs/en-us/scalardb-analytics/run-analytical-queries.mdx#version-compatibility), and this doc now only has front-matter metadata, we can remove this doc.

## Related issues and/or PRs

N/A

## Changes made

- Removed `version-compatibility.mdx` from versions 3.14 and 3.15 (latest).

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A