### PR TITLE
Fix issue with preview image not showing correctly when sharing home page on social media

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -4,6 +4,7 @@ tags:
   - Enterprise Standard
   - Enterprise Premium
 displayed_sidebar: docsEnglish
+image: img/scalardb-social-card-preview.png
 ---
 
 # ScalarDB

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/index.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/index.mdx
@@ -4,6 +4,7 @@ tags:
   - Enterprise Standard
   - Enterprise Premium
 displayed_sidebar: docsJapanese
+image: img/scalardb-social-card-preview.png
 ---
 
 # ScalarDB

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/index.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/index.mdx
@@ -4,6 +4,7 @@ tags:
   - Enterprise Standard
   - Enterprise Premium
 displayed_sidebar: docsJapanese
+image: img/scalardb-social-card-preview.png
 ---
 
 # ScalarDB

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.14/index.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.14/index.mdx
@@ -4,6 +4,7 @@ tags:
   - Enterprise Standard
   - Enterprise Premium
 displayed_sidebar: docsJapanese
+image: img/scalardb-social-card-preview.png
 ---
 
 # ScalarDB

--- a/versioned_docs/version-3.12/index.mdx
+++ b/versioned_docs/version-3.12/index.mdx
@@ -3,6 +3,7 @@ tags:
   - Community
   - Enterprise Standard
   - Enterprise Premium
+image: img/scalardb-social-card-preview.png
 ---
 
 # ScalarDB

--- a/versioned_docs/version-3.13/index.mdx
+++ b/versioned_docs/version-3.13/index.mdx
@@ -4,6 +4,7 @@ tags:
   - Enterprise Standard
   - Enterprise Premium
 displayed_sidebar: docsEnglish
+image: img/scalardb-social-card-preview.png
 ---
 
 # ScalarDB

--- a/versioned_docs/version-3.14/index.mdx
+++ b/versioned_docs/version-3.14/index.mdx
@@ -4,6 +4,7 @@ tags:
   - Enterprise Standard
   - Enterprise Premium
 displayed_sidebar: docsEnglish
+image: img/scalardb-social-card-preview.png
 ---
 
 # ScalarDB


### PR DESCRIPTION
## Description

This PR fixes an issue with the social card preview not showing when sharing the home page on social media platforms that show site preview images.

For some reason, the social card image that we added to **docusaurus.config.js** in #1038 isn't being applied when sharing the home page. To work around this, we can manually set the image this way, according to the [Markdown front-matter section in the Docusaurus docs](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#markdown-front-matter).

## Related issues and/or PRs

- #1038 

## Changes made

- Added the social card preview to the front-matter metadata of the home page.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A