### PR TITLE
Add patch version release notes for `3.15.2`, `3.14.3`, `3.13.3`, `3.12.6`, and `3.11.6`

### DIFF
--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -10,6 +10,41 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.15.
 
+## v3.15.2
+
+**Release date:** March 24, 2025
+
+### Summary
+
+This release has several improvements and bug fixes.
+
+### Community edition
+
+#### Improvements
+
+- ScalarDB BIGINT datatype will now be mapped to Oracle's NUMBER(16). ([#2566](https://github.com/scalar-labs/scalardb/pull/2566))
+
+#### Bug fixes
+
+- Upgraded the Netty library to fix a security issue. [CVE-2025-24970](https://github.com/advisories/GHSA-4g8c-wm8x-jfhw "CVE-2025-24970") ([#2552](https://github.com/scalar-labs/scalardb/pull/2552))
+
+### Enterprise edition
+
+#### Enhancements
+
+##### ScalarDB Cluster
+
+- Added a configuration option (`scalar.db.transaction.enabled`) to enable or disable the transaction feature in ScalarDB Cluster. The default value is `true`.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Fixed a bug related to the metadata cache behavior when using auth in the SQL interface.
+- Fixed configurations for the embedding feature.
+- Fixed a bug that allowed superusers to execute ABAC administrative operations for non-existing users.
+- Fixed a bug a table-not-found error occurs when dropping empty ABAC system tables.
+
 ## v3.15.1
 
 **Release date:** February 20, 2025

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -179,14 +179,6 @@ const config = {
             from: '/docs/releases/release-support-policy',
           },
           {
-            to: '/docs/latest/scalardb-analytics/run-analytical-queries',
-            from: '/docs/latest/scalardb-analytics/development',
-          },
-          {
-            to: '/docs/3.14/scalardb-analytics/run-analytical-queries',
-            from: '/docs/3.14/scalardb-analytics/development',
-          },
-          {
             to: '/docs/latest/scalardb-analytics/run-analytical-queries#version-compatibility',
             from: '/docs/latest/scalardb-analytics-spark/version-compatibility',
           },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -179,6 +179,14 @@ const config = {
             from: '/docs/releases/release-support-policy',
           },
           {
+            to: '/docs/latest/scalardb-analytics/run-analytical-queries',
+            from: '/docs/latest/scalardb-analytics/development',
+          },
+          {
+            to: '/docs/3.14/scalardb-analytics/run-analytical-queries',
+            from: '/docs/3.14/scalardb-analytics/development',
+          },
+          {
             to: '/docs/latest/scalardb-analytics/run-analytical-queries#version-compatibility',
             from: '/docs/latest/scalardb-analytics-spark/version-compatibility',
           },

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -14,6 +14,41 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.15 のリリースノートのリストが含まれています。
 
+## v3.15.2
+
+**発売日:** 2025年03月24日
+
+### まとめ
+
+このリリースには、いくつかの改善とバグ修正が含まれています。
+
+### Community edition
+
+#### 改善点
+
+- ScalarDB BIGINT データ型が Oracle の NUMBER(16) にマッピングされるようになりました。([#2566](https://github.com/scalar-labs/scalardb/pull/2566))
+
+#### バグの修正
+
+- セキュリティ問題を修正するために Netty ライブラリをアップグレードしました。 [CVE-2025-24970](https://github.com/advisories/GHSA-4g8c-wm8x-jfhw "CVE-2025-24970") ([#2552](https://github.com/scalar-labs/scalardb/pull/2552))
+
+### Enterprise edition
+
+#### 機能強化
+
+##### ScalarDB Cluster
+
+- ScalarDB Cluster のトランザクション機能を有効または無効にする設定オプション (`scalar.db.transaction.enabled`) を追加しました。デフォルト値は `true` です。
+
+#### バグ修正
+
+##### ScalarDB Cluster
+
+- SQL インターフェースで認証を使用する場合のメタデータキャッシュの動作に関連するバグを修正しました。
+- 埋め込み機能の設定を修正しました。
+- スーパーユーザーが存在しないユーザーに対して ABAC 管理操作を実行できるバグを修正しました。
+- 空の ABAC システムテーブルを削除するときにテーブルが見つからないというエラーが発生するバグを修正しました。
+
 ## v3.15.1
 
 **発売日:** 2025年02月20日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/releases/release-notes.mdx
@@ -14,6 +14,37 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.13 のリリースノートのリストが含まれています。
 
+## v3.13.3
+
+**発売日:** 2025年03月24日
+
+### まとめ
+
+このリリースには、いくつかの改善とバグ修正が含まれています。
+
+### Community edition
+
+#### 改善点
+
+- ScalarDB BIGINT データ型が Oracle の NUMBER(16) にマッピングされるようになりました。([#2566](https://github.com/scalar-labs/scalardb/pull/2566))
+
+#### バグの修正
+
+- セキュリティ問題を修正するために Netty ライブラリをアップグレードしました。 [CVE-2025-24970](https://github.com/advisories/GHSA-4g8c-wm8x-jfhw "CVE-2025-24970") ([#2552](https://github.com/scalar-labs/scalardb/pull/2552))
+
+### Enterprise edition
+
+#### バグの修正
+
+##### ScalarDB Cluster
+
+- セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました。 [CVE-2024-45337](https://github.com/advisories/GHSA-v778-237x-gjrc "CVE-2024-45337") [CVE-2024-45338](https://github.com/advisories/GHSA-w32m-9786-jp63 "CVE-2024-45338")
+- SQL インターフェースで auth を使用する場合のメタデータキャッシュの動作に関連するバグを修正しました。
+
+##### ScalarDB SQL
+
+- SQL ステートメントパーサーが INT 型および BIGINT 型の列の負の数値リテラルを拒否する問題を修正しました。
+
 ## v3.13.2
 
 **発売日:** 2025年01月23日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.14/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.14/releases/release-notes.mdx
@@ -14,6 +14,37 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.14 のリリースノートのリストが含まれています。
 
+## v3.14.2
+
+**発売日:** 2025年03月24日
+
+### まとめ
+
+このリリースには、いくつかの改善とバグ修正が含まれています。
+
+### Community edition
+
+#### 改善点
+
+- ScalarDB BIGINT データ型が Oracle の NUMBER(16) にマッピングされるようになりました。([#2566](https://github.com/scalar-labs/scalardb/pull/2566))
+
+#### バグの修正
+
+- セキュリティ問題を修正するために Netty ライブラリをアップグレードしました。 [CVE-2025-24970](https://github.com/advisories/GHSA-4g8c-wm8x-jfhw "CVE-2025-24970") ([#2552](https://github.com/scalar-labs/scalardb/pull/2552))
+
+### Enterprise edition
+
+#### バグの修正
+
+##### ScalarDB Cluster
+
+- セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました。 [CVE-2024-45337](https://github.com/advisories/GHSA-v778-237x-gjrc "CVE-2024-45337") [CVE-2024-45338](https://github.com/advisories/GHSA-w32m-9786-jp63 "CVE-2024-45338")
+- SQL インターフェースで auth を使用する場合のメタデータキャッシュの動作に関連するバグを修正しました。
+
+##### ScalarDB SQL
+
+- SQL ステートメントパーサーが INT 型および BIGINT 型の列の負の数値リテラルを拒否する問題を修正しました。
+
 ## v3.14.1
 
 **発売日:** 2025年01月23日

--- a/versioned_docs/version-3.11/releases/release-notes.mdx
+++ b/versioned_docs/version-3.11/releases/release-notes.mdx
@@ -9,6 +9,37 @@ tags:
 
 This page includes a list of release notes for ScalarDB 3.11.
 
+## v3.11.6
+
+**Release date:** March 24, 2025
+
+### Summary
+
+This release has several improvements and bug fixes.
+
+### Community edition
+
+#### Improvements
+
+- ScalarDB BIGINT datatype will now be mapped to Oracle's NUMBER(16). ([#2566](https://github.com/scalar-labs/scalardb/pull/2566))
+
+#### Bug fixes
+
+- Upgraded the Netty library to fix a security issue. [CVE-2025-24970](https://github.com/advisories/GHSA-4g8c-wm8x-jfhw "CVE-2025-24970") ([#2552](https://github.com/scalar-labs/scalardb/pull/2552))
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-45337](https://github.com/advisories/GHSA-v778-237x-gjrc "CVE-2024-45337") [CVE-2024-45338](https://github.com/advisories/GHSA-w32m-9786-jp63 "CVE-2024-45338")
+- Fixed a bug related to the metadata cache behavior when using auth in the SQL interface.
+
+##### ScalarDB SQL
+
+- Fix an issue causing the SQL statement parser to reject negative numeric literal for columns of type INT and BIGINT.
+
 ## v3.11.5
 
 **Release date:** January 23, 2025

--- a/versioned_docs/version-3.12/releases/release-notes.mdx
+++ b/versioned_docs/version-3.12/releases/release-notes.mdx
@@ -9,6 +9,37 @@ tags:
 
 This page includes a list of release notes for ScalarDB 3.12.
 
+## v3.12.6
+
+**Release date:** March 24, 2025
+
+### Summary
+
+This release has several improvements and bug fixes.
+
+### Community edition
+
+#### Improvements
+
+- ScalarDB BIGINT datatype will now be mapped to Oracle's NUMBER(16). ([#2566](https://github.com/scalar-labs/scalardb/pull/2566))
+
+#### Bug fixes
+
+- Upgraded the Netty library to fix a security issue. [CVE-2025-24970](https://github.com/advisories/GHSA-4g8c-wm8x-jfhw "CVE-2025-24970") ([#2552](https://github.com/scalar-labs/scalardb/pull/2552))
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-45337](https://github.com/advisories/GHSA-v778-237x-gjrc "CVE-2024-45337") [CVE-2024-45338](https://github.com/advisories/GHSA-w32m-9786-jp63 "CVE-2024-45338")
+- Fixed a bug related to the metadata cache behavior when using auth in the SQL interface.
+
+##### ScalarDB SQL
+
+- Fix an issue causing the SQL statement parser to reject negative numeric literal for columns of type INT and BIGINT.
+
 ## v3.12.5
 
 **Release date:** January 23, 2025

--- a/versioned_docs/version-3.13/releases/release-notes.mdx
+++ b/versioned_docs/version-3.13/releases/release-notes.mdx
@@ -10,6 +10,37 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.13.
 
+## v3.13.3
+
+**Release date:** March 24, 2025
+
+### Summary
+
+This release has several improvements and bug fixes.
+
+### Community edition
+
+#### Improvements
+
+- ScalarDB BIGINT datatype will now be mapped to Oracle's NUMBER(16). ([#2566](https://github.com/scalar-labs/scalardb/pull/2566))
+
+#### Bug fixes
+
+- Upgraded the Netty library to fix a security issue. [CVE-2025-24970](https://github.com/advisories/GHSA-4g8c-wm8x-jfhw "CVE-2025-24970") ([#2552](https://github.com/scalar-labs/scalardb/pull/2552))
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-45337](https://github.com/advisories/GHSA-v778-237x-gjrc "CVE-2024-45337") [CVE-2024-45338](https://github.com/advisories/GHSA-w32m-9786-jp63 "CVE-2024-45338")
+- Fixed a bug related to the metadata cache behavior when using auth in the SQL interface.
+
+##### ScalarDB SQL
+
+- Fix an issue causing the SQL statement parser to reject negative numeric literal for columns of type INT and BIGINT.
+
 ## v3.13.2
 
 **Release date:** January 23, 2025

--- a/versioned_docs/version-3.14/releases/release-notes.mdx
+++ b/versioned_docs/version-3.14/releases/release-notes.mdx
@@ -10,6 +10,37 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.14.
 
+## v3.14.2
+
+**Release date:** March 24, 2025
+
+### Summary
+
+This release has several improvements and bug fixes.
+
+### Community edition
+
+#### Improvements
+
+- ScalarDB BIGINT datatype will now be mapped to Oracle's NUMBER(16). ([#2566](https://github.com/scalar-labs/scalardb/pull/2566))
+
+#### Bug fixes
+
+- Upgraded the Netty library to fix a security issue. [CVE-2025-24970](https://github.com/advisories/GHSA-4g8c-wm8x-jfhw "CVE-2025-24970") ([#2552](https://github.com/scalar-labs/scalardb/pull/2552))
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix security issues. [CVE-2024-45337](https://github.com/advisories/GHSA-v778-237x-gjrc "CVE-2024-45337") [CVE-2024-45338](https://github.com/advisories/GHSA-w32m-9786-jp63 "CVE-2024-45338")
+- Fixed a bug related to the metadata cache behavior when using auth in the SQL interface.
+
+##### ScalarDB SQL
+
+- Fix an issue causing the SQL statement parser to reject negative numeric literal for columns of type INT and BIGINT.
+
 ## v3.14.1
 
 **Release date:** January 23, 2025


### PR DESCRIPTION
## Description

This PR adds patch version release notes for ScalarDB 3.15, 3.14, 3.13, 3.12, and 3.11.

## Related issues and/or PRs

N/A

## Changes made

- Added patch version release notes for the following versions:
  - `3.15.2`
  - `3.14.2`
  - `3.13.3`
  - `3.12.6`
  - `3.11.6`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A