### PR TITLE
Add redirects for old ScalarDB supported databases and storage abstraction pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -196,12 +196,20 @@ const config = {
             from: '/docs/3.14/scalardb-analytics-spark/version-compatibility',
           },
           {
+            to: '/docs/latest/run-non-transactional-storage-operations-through-primitive-crud-interface',
+            from: '/docs/latest/storage-abstraction',
+          },
+          {
             to: '/docs/3.13/run-non-transactional-storage-operations-through-primitive-crud-interface',
             from: '/docs/3.13/storage-abstraction',
           },
           {
             to: '/docs/3.12/run-non-transactional-storage-operations-through-primitive-crud-interface',
             from: '/docs/3.12/storage-abstraction',
+          },
+          {
+            to: '/docs/latest/requirements#databases',
+            from: '/docs/latest/scalardb-supported-databases',
           },
           {
             to: '/docs/3.13/requirements#databases',


### PR DESCRIPTION
## Description

This PR adds redirects for the following pages:

- Supported databases
- Storage abstraction

Versioned redirects already exist for these pages (added in #568). However, since the links to the latest versions of these pages are used elsewhere online, we should redirect visitors instead of showing them a "Page not found" message.

## Related issues and/or PRs

- Versioned redirects added in #568.

## Changes made

- Added redirects for the latest versions of the **scalardb-supported-databases.mdx** and **storage-abstraction.mdx** pages.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A