### PR TITLE
Apply white background to .png files when in dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -356,3 +356,7 @@ hr {
   margin: auto;
   max-width: 91%;
 }
+
+html[data-theme="dark"] .container img[src$=".png"] { /* Adds a white background to transparent .png images. */
+  background-color: #ffffff;
+}


### PR DESCRIPTION
## Description

This PR applies a white background to .png files when in dark mode. A background needs to be applied because if the background is transparent, some of the text is difficult to see when in dark mode.

## Related issues and/or PRs

N/A

## Changes made

- Added a style in **custom.css** that applies a background to .png files within the **.container** style.
  - If we don't specify the **.container** style, a white background will be applied to the product logo in the top left-hand corner of the docs site, which is not what we want.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A