### PR TITLE
Add ScalarDB features doc to sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -40,6 +40,11 @@ const sidebars = {
           label: 'Design',
         },
         {
+          type: 'doc',
+          id: 'features',
+          label: 'Features',
+        },
+        {
           "type": "doc",
           "id": "glossary",
           "label": "Glossary",
@@ -937,6 +942,11 @@ const sidebars = {
           type: 'doc',
           id: 'design',
           label: 'デザイン',
+        },
+        {
+          "type": "doc",
+          "id": "features",
+          "label": "機能",
         },
         {
           "type": "doc",

--- a/versioned_sidebars/version-3.12-sidebars.json
+++ b/versioned_sidebars/version-3.12-sidebars.json
@@ -21,6 +21,11 @@
         },
         {
           "type": "doc",
+          "id": "features",
+          "label": "Features"
+        },
+        {
+          "type": "doc",
           "id": "glossary",
           "label": "Glossary"
         },

--- a/versioned_sidebars/version-3.13-sidebars.json
+++ b/versioned_sidebars/version-3.13-sidebars.json
@@ -21,6 +21,11 @@
         },
         {
           "type": "doc",
+          "id": "features",
+          "label": "Features"
+        },
+        {
+          "type": "doc",
           "id": "glossary",
           "label": "Glossary"
         },
@@ -871,6 +876,11 @@
           "type": "doc",
           "id": "design",
           "label": "デザイン"
+        },
+        {
+          "type": "doc",
+          "id": "features",
+          "label": "機能"
         },
         {
           "type": "doc",

--- a/versioned_sidebars/version-3.14-sidebars.json
+++ b/versioned_sidebars/version-3.14-sidebars.json
@@ -21,6 +21,11 @@
         },
         {
           "type": "doc",
+          "id": "features",
+          "label": "Features"
+        },
+        {
+          "type": "doc",
           "id": "glossary",
           "label": "Glossary"
         },
@@ -885,6 +890,11 @@
           "type": "doc",
           "id": "design",
           "label": "デザイン"
+        },
+        {
+          "type": "doc",
+          "id": "features",
+          "label": "機能"
         },
         {
           "type": "doc",


### PR DESCRIPTION
## Description

This PR adds the ScalarDB features doc to the sidebar navigation.

## Related issues and/or PRs

ScalarDB features doc added in the following PRs:

- https://github.com/scalar-labs/docs-scalardb/pull/1164
- https://github.com/scalar-labs/docs-scalardb/pull/1182
- https://github.com/scalar-labs/docs-scalardb/pull/1195
- https://github.com/scalar-labs/docs-scalardb/pull/1196
- https://github.com/scalar-labs/docs-scalardb/pull/1197
- https://github.com/scalar-labs/docs-scalardb/pull/1198
- https://github.com/scalar-labs/docs-scalardb/pull/1199

## Changes made

- Added the ScalarDB features doc to the sidebar navigation for 3.15 (latest), 3.14, 3.13, and 3.12.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A