### PR TITLE
Add patch version release notes for `3.15.3`, `3.14.3`, `3.13.4`, and `3.12.7`

### DIFF
--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -10,6 +10,34 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.15.
 
+## v3.15.3
+
+**Release date:** May 15, 2025
+
+### Summary
+
+This release includes fixes for vulnerabilities and bugs, and adds support for running ScalarDB Cluster on the Omnistrate service.
+
+### Community edition
+
+#### Bug fixes
+
+- Fixed an issue with `DistributedStorageAdmin.getNamespaceNames()` API when using the DynamoDB storage with the namespace prefix setting `scalar.db.dynamo.namespace.prefix`. The namespace names returned by this method wrongly contained the prefix. ([#2641](https://github.com/scalar-labs/scalardb/pull/2641))
+
+### Enterprise edition
+
+#### Improvements
+
+##### ScalarDB Cluster
+
+- Added support for the Omnistrate service. Now, you can run ScalarDB Cluster in the Omnistrate service.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix a security issue. [CVE-2025-22869](https://github.com/advisories/GHSA-hcg3-q754-cr77)
+
 ## v3.15.2
 
 **Release date:** March 24, 2025

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -14,6 +14,34 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.15 のリリースノートのリストが含まれています。
 
+## v3.15.3
+
+**発売日:** 2025年05月15日
+
+### まとめ
+
+このリリースには、脆弱性とバグの修正が含まれており、Omnistrate サービス上で ScalarDB Cluster を実行するためのサポートが追加されています。
+
+### Community edition
+
+#### バグの修正
+
+- 名前空間プレフィックス設定 `scalar.db.dynamo.namespace.prefix` を使用して DynamoDB ストレージを使用する場合の `DistributedStorageAdmin.getNamespaceNames()` API の問題を修正しました。このメソッドによって返される名前空間名に誤ってプレフィックスが含まれていました。([#2641](https://github.com/scalar-labs/scalardb/pull/2641))
+
+### Enterprise edition
+
+#### 改善点
+
+##### ScalarDB Cluster
+
+- Omnistrate サービスのサポートを追加しました。これにより、Omnistrate サービス上で ScalarDB Cluster を実行できるようになりました。
+
+#### バグの修正
+
+##### ScalarDB Cluster
+
+- セキュリティの問題を修正するために `grpc_health_probe` をアップグレードしました。[CVE-2025-22869](https://github.com/advisories/GHSA-hcg3-q754-cr77)
+
 ## v3.15.2
 
 **発売日:** 2025年03月24日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/releases/release-notes.mdx
@@ -14,6 +14,28 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.13 のリリースノートのリストが含まれています。
 
+## v3.13.4
+
+**発売日:** 2025年05月15日
+
+### まとめ
+
+このリリースには脆弱性とバグの修正が含まれています。
+
+### Community edition
+
+#### バグの修正
+
+- 名前空間プレフィックス設定 `scalar.db.dynamo.namespace.prefix` を使用して DynamoDB ストレージを使用する場合の `DistributedStorageAdmin.getNamespaceNames()` API の問題を修正しました。このメソッドによって返される名前空間名に誤ってプレフィックスが含まれていました。([#2641](https://github.com/scalar-labs/scalardb/pull/2641))
+
+### Enterprise edition
+
+#### バグの修正
+
+##### ScalarDB Cluster
+
+- セキュリティの問題を修正するために `grpc_health_probe` をアップグレードしました。[CVE-2025-22869](https://github.com/advisories/GHSA-hcg3-q754-cr77)
+
 ## v3.13.3
 
 **発売日:** 2025年03月24日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.14/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.14/releases/release-notes.mdx
@@ -14,6 +14,28 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.14 のリリースノートのリストが含まれています。
 
+## v3.14.3
+
+**発売日:** 2025年05月15日
+
+### まとめ
+
+このリリースには脆弱性とバグの修正が含まれています。
+
+### Community edition
+
+#### バグの修正
+
+- 名前空間プレフィックス設定 `scalar.db.dynamo.namespace.prefix` を使用して DynamoDB ストレージを使用する場合の `DistributedStorageAdmin.getNamespaceNames()` API の問題を修正しました。このメソッドによって返される名前空間名に誤ってプレフィックスが含まれていました。([#2641](https://github.com/scalar-labs/scalardb/pull/2641))
+
+### Enterprise edition
+
+#### バグの修正
+
+##### ScalarDB Cluster
+
+- セキュリティの問題を修正するために `grpc_health_probe` をアップグレードしました。[CVE-2025-22869](https://github.com/advisories/GHSA-hcg3-q754-cr77)
+
 ## v3.14.2
 
 **発売日:** 2025年03月24日

--- a/versioned_docs/version-3.12/releases/release-notes.mdx
+++ b/versioned_docs/version-3.12/releases/release-notes.mdx
@@ -9,6 +9,22 @@ tags:
 
 This page includes a list of release notes for ScalarDB 3.12.
 
+## v3.12.7
+
+**Release date:** May 15, 2025
+
+### Summary
+
+This release includes a vulnerability fix.
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix a security issue. [CVE-2025-22869](https://github.com/advisories/GHSA-hcg3-q754-cr77)
+
 ## v3.12.6
 
 **Release date:** March 24, 2025

--- a/versioned_docs/version-3.13/releases/release-notes.mdx
+++ b/versioned_docs/version-3.13/releases/release-notes.mdx
@@ -10,6 +10,28 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.13.
 
+## v3.13.4
+
+**Release date:** May 15, 2025
+
+### Summary
+
+This release includes fixes for vulnerabilities and bugs.
+
+### Community edition
+
+#### Bug fixes
+
+- Fixed an issue with `DistributedStorageAdmin.getNamespaceNames()` API when using the DynamoDB storage with the namespace prefix setting `scalar.db.dynamo.namespace.prefix`. The namespace names returned by this method wrongly contained the prefix. ([#2641](https://github.com/scalar-labs/scalardb/pull/2641))
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix a security issue. [CVE-2025-22869](https://github.com/advisories/GHSA-hcg3-q754-cr77)
+
 ## v3.13.3
 
 **Release date:** March 24, 2025

--- a/versioned_docs/version-3.14/releases/release-notes.mdx
+++ b/versioned_docs/version-3.14/releases/release-notes.mdx
@@ -10,6 +10,28 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.14.
 
+## v3.14.3
+
+**Release date:** May 15, 2025
+
+### Summary
+
+This release includes fixes for vulnerabilities and bugs.
+
+### Community edition
+
+#### Bug fixes
+
+- Fixed an issue with `DistributedStorageAdmin.getNamespaceNames()` API when using the DynamoDB storage with the namespace prefix setting `scalar.db.dynamo.namespace.prefix`. The namespace names returned by this method wrongly contained the prefix. ([#2641](https://github.com/scalar-labs/scalardb/pull/2641))
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix a security issue. [CVE-2025-22869](https://github.com/advisories/GHSA-hcg3-q754-cr77)
+
 ## v3.14.2
 
 **Release date:** March 24, 2025


### PR DESCRIPTION
## Description

This PR adds patch version release notes for ScalarDB 3.15, 3.14, 3.13, and 3.12.

## Related issues and/or PRs

N/A

## Changes made

- Added patch version release notes for the following versions:
  - `3.15.3`
  - `3.14.3`
  - `3.13.4`
  - `3.12.7`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A