### PR TITLE
Refine glossary tooltip feature (support capitalized terms and plural forms, remove tooltip from terms in backticks)

### DIFF
--- a/src/components/GlossaryInjector.tsx
+++ b/src/components/GlossaryInjector.tsx
@@ -58,6 +58,9 @@ const GlossaryInjector: React.FC<GlossaryInjectorProps> = ({ children }) => {
         // Check if the parent element is a Mermaid diagram.
         const isMermaidDiagram = parentElement && parentElement.closest('.docusaurus-mermaid-container'); // Adjust the selector as necessary.
 
+        // Check if the parent element is an inline code block (text in backticks).
+        const isInlineCode = parentElement && (parentElement.tagName === 'CODE' || parentElement.classList.contains('inlineCode'));
+
         // Only wrap terms in tooltips if the parent is within the target div and not in headings or tab titles.
         if (
           parentElement &&
@@ -66,7 +69,8 @@ const GlossaryInjector: React.FC<GlossaryInjectorProps> = ({ children }) => {
           !isTabTitle && // Skip tab titles.
           !isCodeBlock && // Skip code blocks.
           !isCard && // Skip Cards.
-          !isMermaidDiagram // Skip Mermaid diagrams.
+          !isMermaidDiagram && // Skip Mermaid diagrams.
+          !isInlineCode // Skip inline code (text in backticks).
         ) {
           let currentText = currentNode.textContent!;
           const newNodes: Node[] = [];


### PR DESCRIPTION
## Description

This PR enhances the glossary tooltip component by improving its handling of glossary terms and their plural forms, while also refining the conditions under which tooltips are applied. The changes also include not showing tooltips for terms in backticks, which might be distracting and unnecessary in many cases.

## Related issues and/or PRs

N/A

## Changes made

### Improvements to glossary term matching

* Updated the regex pattern to match both exact terms and their plural forms (`s` or `es`), while also making the matching case-insensitive. This ensures broader and more accurate term detection.  (`src/components/GlossaryInjector.tsx`, [src/components/GlossaryInjector.tsxL69-R148](diffhunk://#diff-a29d46fa93159f09bd4e170daa2a60dbb43ca196b88675a769c72468151b0ec2L69-R148))
* Adjusted the tooltip rendering logic to ensure that terms are underlined when a plural form is detected. (`src/components/GlossaryInjector.tsx`, [src/components/GlossaryInjector.tsxL69-R148](diffhunk://#diff-a29d46fa93159f09bd4e170daa2a60dbb43ca196b88675a769c72468151b0ec2L69-R148))

### Refinements to tooltip exclusions

* Added a check to skip inline code blocks (text wrapped in backticks) when wrapping terms in tooltips, preventing unnecessary interference with code formatting.  (`src/components/GlossaryInjector.tsx`, [[1]](diffhunk://#diff-a29d46fa93159f09bd4e170daa2a60dbb43ca196b88675a769c72468151b0ec2R61-R63) [[2]](diffhunk://#diff-a29d46fa93159f09bd4e170daa2a60dbb43ca196b88675a769c72468151b0ec2L69-R148)

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A