### PR TITLE
Update `className` to latest patch versions in Docusaurus config file

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,25 +78,25 @@ const config = {
                 label: '3.15',
                 path: 'latest', // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 banner: 'none',
-                className: '3.15.2',
+                className: '3.15.3',
               },
               "3.14": { // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 label: '3.14',
                 path: '3.14', // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 banner: 'none',
-                className: '3.14.2',
+                className: '3.14.3',
               },
               "3.13": {
                 label: '3.13',
                 path: '3.13',
                 banner: 'none',
-                className: '3.13.3',
+                className: '3.13.4',
               },
               "3.12": {
                 label: '3.12',
                 path: '3.12',
                 banner: 'none',
-                className: '3.12.6',
+                className: '3.12.7',
               },
               "3.11": {
                 label: '3.11',


### PR DESCRIPTION
## Description

This PR updates the patch versions listed in the Docusaurus configuration file. These patch versions determine which versions of Javadocs visitors are automatically routed to when they click the Javadoc links.

## Related issues and/or PRs

- Patch versions added in https://github.com/scalar-labs/docs-scalardb/pull/1202.

## Changes made

- Updated the latest patch versions in **docusaurus.config.js** for the `JavadocLink` component.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A