### PR TITLE
Fix images overlaying AI assistant modal

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -362,8 +362,13 @@ html[data-theme="dark"] .container img[src$=".png"] { /* Adds a white background
   background-color: #ffffff;
 }
 
+img[class^="img_"] { /* Ensure doc images are always behind overlays and dropdowns. */
+  position: relative;
+  z-index: 1 !important;
+}
+
 .medium-zoom-overlay {
-  z-index: 15;
+  z-index: 1;
   position: fixed;
 }
 


### PR DESCRIPTION
## Description

This PR fixes an issue where, after selecting "Ask AI", images were overlaying the AI assistant modal.

## Related issues and/or PRs

N/A

## Changes made

* Added a new CSS rule for `img[class^="img_"]` to ensure images in documentation are always positioned behind overlays and dropdowns by setting `position: relative` and `z-index: 1`.
* Adjusted the `z-index` of the `.medium-zoom-overlay` class from `15` to `1` to align with the updated image-positioning logic.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A