### PR TITLE
Remove glossary tooltips version from home pages

### DIFF
--- a/src/components/GlossaryInjector.tsx
+++ b/src/components/GlossaryInjector.tsx
@@ -36,19 +36,11 @@ const GlossaryInjector: React.FC<GlossaryInjectorProps> = ({ children }) => {
       const path = window.location.pathname;
 
       // Check for various version index patterns
-      // English versions
-      if (path.match(/\/docs\/latest\/?$/) ||
-          path.match(/\/docs\/latest\/index(\.html)?/) ||
-          path.match(/\/docs\/[0-9]+\.[0-9]+\/?$/) ||
-          path.match(/\/docs\/[0-9]+\.[0-9]+\/index(\.html)?/)) {
-        return true;
-      }
-
-      // Japanese versions
-      if (path.match(/\/ja-jp\/docs\/latest\/?$/) ||
-          path.match(/\/ja-jp\/docs\/latest\/index(\.html)?/) ||
-          path.match(/\/ja-jp\/docs\/[0-9]+\.[0-9]+\/?$/) ||
-          path.match(/\/ja-jp\/docs\/[0-9]+\.[0-9]+\/index(\.html)?/)) {
+      const localePrefix = '(?:/ja-jp)?'; // Matches either '/ja-jp' or nothing
+      if (path.match(new RegExp(`${localePrefix}/docs/latest/?$`)) ||
+          path.match(new RegExp(`${localePrefix}/docs/latest/index(\\.html)?`)) ||
+          path.match(new RegExp(`${localePrefix}/docs/[0-9]+\\.[0-9]+/?$`)) ||
+          path.match(new RegExp(`${localePrefix}/docs/[0-9]+\\.[0-9]+/index(\\.html)?`))) {
         return true;
       }
     }

--- a/src/components/GlossaryInjector.tsx
+++ b/src/components/GlossaryInjector.tsx
@@ -89,14 +89,14 @@ const GlossaryInjector: React.FC<GlossaryInjectorProps> = ({ children }) => {
 
           while ((match = regex.exec(currentText))) {
             const matchedText = match[0]; // The full matched text (may include plural suffix).
-            
+
             // Find the base term from the glossary that matches (without plural).
             const baseTerm = terms.find(term => 
               matchedText.toLowerCase() === term.toLowerCase() || 
               matchedText.toLowerCase() === `${term.toLowerCase()}s` || 
               matchedText.toLowerCase() === `${term.toLowerCase()}es`
             );
-            
+
             if (!baseTerm) {
               // Skip if no matching base term found.
               continue;
@@ -116,11 +116,11 @@ const GlossaryInjector: React.FC<GlossaryInjectorProps> = ({ children }) => {
               tooltipWrapper.className = 'glossary-term';
 
               const definition = glossary[baseTerm];
-              
+
               // Extract the part to underline (the base term) and the suffix (if plural).
               let textToUnderline = matchedText;
               let suffix = '';
-              
+
               if (matchedText.toLowerCase() !== baseTerm.toLowerCase()) {
                 // This is a plural form - only underline the base part.
                 const baseTermLength = baseTerm.length;

--- a/src/components/GlossaryInjector.tsx
+++ b/src/components/GlossaryInjector.tsx
@@ -30,8 +30,33 @@ const GlossaryInjector: React.FC<GlossaryInjectorProps> = ({ children }) => {
       .catch((err) => console.error('Failed to load glossary:', err));
   }, []);
 
+  // Function to check if the current page is a version index page
+  const isVersionIndexPage = () => {
+    if (typeof window !== 'undefined') {
+      const path = window.location.pathname;
+
+      // Check for various version index patterns
+      // English versions
+      if (path.match(/\/docs\/latest\/?$/) ||
+          path.match(/\/docs\/latest\/index(\.html)?/) ||
+          path.match(/\/docs\/[0-9]+\.[0-9]+\/?$/) ||
+          path.match(/\/docs\/[0-9]+\.[0-9]+\/index(\.html)?/)) {
+        return true;
+      }
+
+      // Japanese versions
+      if (path.match(/\/ja-jp\/docs\/latest\/?$/) ||
+          path.match(/\/ja-jp\/docs\/latest\/index(\.html)?/) ||
+          path.match(/\/ja-jp\/docs\/[0-9]+\.[0-9]+\/?$/) ||
+          path.match(/\/ja-jp\/docs\/[0-9]+\.[0-9]+\/index(\.html)?/)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   useEffect(() => {
-    if (Object.keys(glossary).length === 0) return;
+    if (Object.keys(glossary).length === 0 || isVersionIndexPage()) return;
 
     // Sort terms in descending order by length to prioritize multi-word terms.
     const terms = Object.keys(glossary).sort((a, b) => b.length - a.length);


### PR DESCRIPTION
## Description

This PR hides glossary tooltips on version home pages by adjusting the glossary injection logic in the **GlossaryInjector** component accordingly.

## Related issues and/or PRs

N/A

## Changes made

* [`src/components/GlossaryInjector.tsx`](diffhunk://#diff-a29d46fa93159f09bd4e170daa2a60dbb43ca196b88675a769c72468151b0ec2R33-R59): Added the `isVersionIndexPage` function to identify version index pages based on URL patterns for both English and Japanese documentation. Updated the `useEffect` hook to skip glossary injection on these pages.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A