### PR TITLE
Mark ScalarDB 3.10 as no longer supported

### DIFF
--- a/docs/releases/release-support-policy.mdx
+++ b/docs/releases/release-support-policy.mdx
@@ -64,11 +64,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a></td>
-      <td>2023-07-20</td>
-      <td>2024-12-26</td>
-      <td>2025-06-24</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a>**</td>
+      <td class="version-out-of-support">2023-07-20</td>
+      <td class="version-out-of-support">2024-12-26</td>
+      <td class="version-out-of-support">2025-06-24</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a>**</td>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -105,9 +105,9 @@ const config = {
                 className: '3.11.6',
               },
               "3.10": {
-                label: '3.10',
+                label: '3.10 (unsupported)',
                 path: '3.10',
-                banner: 'none',
+                banner: 'unmaintained',
               },
               "3.9": {
                 label: '3.9 (unsupported)',

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
@@ -68,11 +68,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.10/releases/release-notes#v3100">3.10</a></td>
-      <td>2023-07-20</td>
-      <td>2024-12-26</td>
-      <td>2025-06-24</td>
-      <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.10/releases/release-notes#v3100">3.10</a>**</td>
+      <td class="version-out-of-support">2023-07-20</td>
+      <td class="version-out-of-support">2024-12-26</td>
+      <td class="version-out-of-support">2025-06-24</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.9/releases/release-notes#v390">3.9</a>**</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.10.json
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.10.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "3.10",
+    "message": "3.10 (サポートされていない)",
     "description": "The label for version 3.10"
   }
 }

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.13/releases/release-support-policy.mdx
@@ -54,11 +54,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.10/releases/release-notes#v3100">3.10</a></td>
-      <td>2023-07-20</td>
-      <td>2024-12-26</td>
-      <td>2025-06-24</td>
-      <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.10/releases/release-notes#v3100">3.10</a>*</td>
+      <td class="version-out-of-support">2023-07-20</td>
+      <td class="version-out-of-support">2024-12-26</td>
+      <td class="version-out-of-support">2025-06-24</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.9/releases/release-notes#v390">3.9</a>*</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.14/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.14/releases/release-support-policy.mdx
@@ -61,11 +61,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.10/releases/release-notes#v3100">3.10</a></td>
-      <td>2023-07-20</td>
-      <td>2024-12-26</td>
-      <td>2025-06-24</td>
-      <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.10/releases/release-notes#v3100">3.10</a>*</td>
+      <td class="version-out-of-support">2023-07-20</td>
+      <td class="version-out-of-support">2024-12-26</td>
+      <td class="version-out-of-support">2025-06-24</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.9/releases/release-notes#v390">3.9</a>*</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-pages/unsupported-versions.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-pages/unsupported-versions.mdx
@@ -9,6 +9,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 ScalarDB の次のバージョンはサポートされなくなりました。
 
+- [ScalarDB 3.10](/docs/3.10/)
 - [ScalarDB 3.9](/docs/3.9/)
 - [ScalarDB 3.8](/docs/3.8/)
 - [ScalarDB 3.7](/docs/3.7/)

--- a/src/data/notifications.js
+++ b/src/data/notifications.js
@@ -36,8 +36,8 @@ const notificationsList = [
   },
   {
     message: {
-      en: 'Support for ScalarDB 3.10 will end soon: Please consider upgrading for enhanced features and continued support',
-      ja: 'ScalarDB 3.10 のサポートがまもなく終了します: 機能強化と継続的なサポートのため、アップグレードをご検討ください'
+      en: 'Support for ScalarDB 3.11 will end soon: Please consider upgrading for enhanced features and continued support',
+      ja: 'ScalarDB 3.11 のサポートがまもなく終了します: 機能強化と継続的なサポートのため、アップグレードをご検討ください'
     },
     url: {
       en: 'scalar-kubernetes/HowToUpgradeScalarDB?utm_source=docs-site&utm_medium=notifications',

--- a/src/pages/unsupported-versions.mdx
+++ b/src/pages/unsupported-versions.mdx
@@ -5,6 +5,7 @@
 
 The following versions of ScalarDB are no longer supported:
 
+- [ScalarDB 3.10](/docs/3.10/)
 - [ScalarDB 3.9](/docs/3.9/)
 - [ScalarDB 3.8](/docs/3.8/)
 - [ScalarDB 3.7](/docs/3.7/)

--- a/versioned_docs/version-3.10/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.10/releases/release-support-policy.mdx
@@ -28,11 +28,11 @@ This page describes Scalar's support policy for major and minor version releases
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a></td>
-      <td>2023-07-20</td>
-      <td>2024-12-26</td>
-      <td>2025-06-24</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a>*</td>
+      <td class="version-out-of-support">2023-07-20</td>
+      <td class="version-out-of-support">2024-12-26</td>
+      <td class="version-out-of-support">2025-06-24</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a>*</td>

--- a/versioned_docs/version-3.11/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.11/releases/release-support-policy.mdx
@@ -35,11 +35,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a></td>
-      <td>2023-07-20</td>
-      <td>2024-12-26</td>
-      <td>2025-06-24</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a>*</td>
+      <td class="version-out-of-support">2023-07-20</td>
+      <td class="version-out-of-support">2024-12-26</td>
+      <td class="version-out-of-support">2025-06-24</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a>*</td>

--- a/versioned_docs/version-3.12/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.12/releases/release-support-policy.mdx
@@ -42,11 +42,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a></td>
-      <td>2023-07-20</td>
-      <td>2024-12-26</td>
-      <td>2025-06-24</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a>*</td>
+      <td class="version-out-of-support">2023-07-20</td>
+      <td class="version-out-of-support">2024-12-26</td>
+      <td class="version-out-of-support">2025-06-24</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a>*</td>

--- a/versioned_docs/version-3.13/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.13/releases/release-support-policy.mdx
@@ -50,11 +50,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a></td>
-      <td>2023-07-20</td>
-      <td>2024-12-26</td>
-      <td>2025-06-24</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a>*</td>
+      <td class="version-out-of-support">2023-07-20</td>
+      <td class="version-out-of-support">2024-12-26</td>
+      <td class="version-out-of-support">2025-06-24</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a>*</td>

--- a/versioned_docs/version-3.14/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.14/releases/release-support-policy.mdx
@@ -57,11 +57,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardb.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a></td>
-      <td>2023-07-20</td>
-      <td>2024-12-26</td>
-      <td>2025-06-24</td>
-      <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a>*</td>
+      <td class="version-out-of-support">2023-07-20</td>
+      <td class="version-out-of-support">2024-12-26</td>
+      <td class="version-out-of-support">2025-06-24</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardb.scalar-labs.com/docs/3.9/releases/release-notes#v390">3.9</a>*</td>


### PR DESCRIPTION
## Description

This PR marks ScalarDB 3.10 as no longer supported since Assistance Support ended on June 24, 2025.

## Related issues and/or PRs

N/A

## Changes made

- In each version of the **Release Support Policy** docs:
  - Added an asterisk to 3.10.
  - Added the `out-of-support` style to the cells in the table.
- In **docusaurus.config.js**:
  - Added the `unmaintained` banner, which automatically adds a banner to each page for version 3.10 that states the version is no longer supported.
- On the **Unsupported Versions** page in English and Japanese, which appears in the version dropdown menu:
  - Added a link to version 3.10 docs.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A