### PR TITLE
Update `className` for `3.15` to `3.15.4` in Docusaurus config file; add patch version release notes for `3.15.4`

### DIFF
--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -10,6 +10,31 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.15.
 
+## v3.15.4
+
+**Release date:** June 21, 2025
+
+### Summary
+
+This release includes fixes for vulnerabilities and bugs.
+
+### Community edition
+
+#### Bug fixes
+
+- Add exception handling for DateTimeParseException on column value conversion. ([#2662](https://github.com/scalar-labs/scalardb/pull/2662))
+- Upgraded the PostgreSQL driver to fix security issues. [CVE-2025-49146](https://github.com/advisories/GHSA-hq9p-pm7w-8p54 "CVE-2025-49146") ([#2772](https://github.com/scalar-labs/scalardb/pull/2772))
+- Fixed potential connection leak when using `jdbc` storage and Scan operation fails because the target table doesn't exist. ([#2766](https://github.com/scalar-labs/scalardb/pull/2766))
+
+### Enterprise edition
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Fixed a memory leak issue when the coordinator group commit feature is enabled.
+- Upgraded the OpenSearch Java client to fix a security issue. [CVE-2025-27820](https://github.com/advisories/GHSA-73m2-qfq3-56cx "CVE-2025-27820")
+
 ## v3.15.3
 
 **Release date:** May 15, 2025

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,7 +78,7 @@ const config = {
                 label: '3.15',
                 path: 'latest', // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 banner: 'none',
-                className: '3.15.3',
+                className: '3.15.4',
               },
               "3.14": { // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 label: '3.14',

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -14,6 +14,31 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.15 のリリースノートのリストが含まれています。
 
+## v3.15.4
+
+**発売日:** 2025年06月21日
+
+### まとめ
+
+このリリースには脆弱性とバグの修正が含まれています。
+
+### Community edition
+
+#### バグの修正
+
+- カラム値変換におけるDateTimeParseExceptionの例外処理を追加しました。([#2662](https://github.com/scalar-labs/scalardb/pull/2662))
+- セキュリティ問題を修正するためにPostgreSQLドライバーをアップグレードしました。[CVE-2025-49146](https://github.com/advisories/GHSA-hq9p-pm7w-8p54 "CVE-2025-49146") ([#2772](https://github.com/scalar-labs/scalardb/pull/2772))
+- `jdbc`ストレージを使用し、対象テーブルが存在しないためにスキャン操作が失敗した場合の潜在的な接続リークを修正しました。([#2766](https://github.com/scalar-labs/scalardb/pull/2766))
+
+### Enterprise edition
+
+#### バグの修正
+
+##### ScalarDB Cluster
+
+- コーディネーターのグループコミット機能が有効になっている場合のメモリリーク問題を修正しました。
+- セキュリティ問題を修正するためにOpenSearch Javaクライアントをアップグレードしました。[CVE-2025-27820](https://github.com/advisories/GHSA-73m2-qfq3-56cx "CVE-2025-27820")
+
 ## v3.15.3
 
 **発売日:** 2025年05月15日


### PR DESCRIPTION
## Description

This PR updates the `className` from `3.15.3` to `3.15.4` in the Docusaurus configuration file and adds patch version release notes for ScalarDB 3.15.4.

## Related issues and/or PRs

N/A

## Changes made

- Updated the latest patch versions in **docusaurus.config.js** for the `JavadocLink` component.
- Added patch version release notes for 3.15.4.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A