### PR TITLE
Fix glossary term matching for Japanese docs

### DIFF
--- a/src/components/GlossaryInjector.tsx
+++ b/src/components/GlossaryInjector.tsx
@@ -12,11 +12,12 @@ const GlossaryInjector: React.FC<GlossaryInjectorProps> = ({ children }) => {
   useEffect(() => {
     const url = window.location.pathname;
     let glossaryPath = '/docs/glossary.json'; // Use the English version as the default glossary.
+    const isJapaneseSite = url.startsWith('/ja-jp/docs');
 
     if (process.env.NODE_ENV === 'production') { // The glossary tooltip works only in production environments.
-      glossaryPath = url.startsWith('/ja-jp/docs') ? '/ja-jp/glossary.json' : '/docs/glossary.json';
+      glossaryPath = isJapaneseSite ? '/ja-jp/glossary.json' : '/docs/glossary.json';
     } else {
-      glossaryPath = url.startsWith('/ja-jp/docs') ? '/ja-jp/glossary.json' : '/docs/glossary.json';
+      glossaryPath = isJapaneseSite ? '/ja-jp/glossary.json' : '/docs/glossary.json';
     }
 
     fetch(glossaryPath)
@@ -50,7 +51,7 @@ const GlossaryInjector: React.FC<GlossaryInjectorProps> = ({ children }) => {
   useEffect(() => {
     if (Object.keys(glossary).length === 0 || isVersionIndexPage()) return;
 
-    // Sort terms in descending order by length to prioritize multi-word terms.
+    // Sort terms in descending order to prioritize multi-word terms.
     const terms = Object.keys(glossary).sort((a, b) => b.length - a.length);
     const processedTerms = new Set<string>(); // Set to track processed terms.
 
@@ -93,12 +94,22 @@ const GlossaryInjector: React.FC<GlossaryInjectorProps> = ({ children }) => {
           const newNodes: Node[] = [];
           let hasReplacements = false;
 
-          // Create a regex pattern to match both exact terms and their plural forms.
+          // Check if the visitor is on the Japanese version of the site.
+          const isJapaneseSite = window.location.pathname.startsWith('/ja-jp/');
+
+          // Create a regex pattern based on the language.
           const regexPattern = terms.map(term => {
             const escapedTerm = term.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-            // Match exact term or term followed by 's' or 'es' at word boundary.
+
+            // For the Japanese version of the site, don't use word boundaries that don't work well with Japanese characters.
+            if (isJapaneseSite) {
+              return `(${escapedTerm})`;
+            }
+
+            // For English site, match exact term or term followed by 's' or 'es' at word boundary.
             return `(\\b${escapedTerm}(s|es)?\\b)`;
           }).join('|');
+
           const regex = new RegExp(regexPattern, 'gi'); // The 'i' flag is for case-insensitive matching.
 
           let lastIndex = 0;
@@ -107,12 +118,22 @@ const GlossaryInjector: React.FC<GlossaryInjectorProps> = ({ children }) => {
           while ((match = regex.exec(currentText))) {
             const matchedText = match[0]; // The full matched text (may include plural suffix).
 
-            // Find the base term from the glossary that matches (without plural).
-            const baseTerm = terms.find(term => 
-              matchedText.toLowerCase() === term.toLowerCase() || 
-              matchedText.toLowerCase() === `${term.toLowerCase()}s` || 
-              matchedText.toLowerCase() === `${term.toLowerCase()}es`
-            );
+            // Find the base term from the glossary that matches.
+            let baseTerm: string | undefined;
+
+            if (isJapaneseSite) {
+              // For Japanese, look for an exact match only.
+              baseTerm = terms.find(term => 
+                matchedText.toLowerCase() === term.toLowerCase()
+              );
+            } else {
+              // For English, check both singular and plural forms too.
+              baseTerm = terms.find(term => 
+                matchedText.toLowerCase() === term.toLowerCase() || 
+                matchedText.toLowerCase() === `${term.toLowerCase()}s` || 
+                matchedText.toLowerCase() === `${term.toLowerCase()}es`
+              );
+            }
 
             if (!baseTerm) {
               // Skip if no matching base term found.
@@ -138,7 +159,8 @@ const GlossaryInjector: React.FC<GlossaryInjectorProps> = ({ children }) => {
               let textToUnderline = matchedText;
               let suffix = '';
 
-              if (matchedText.toLowerCase() !== baseTerm.toLowerCase()) {
+              // Only apply pluralization logic for the English version of the site.
+              if (!isJapaneseSite && matchedText.toLowerCase() !== baseTerm.toLowerCase()) {
                 // This is a plural form - only underline the base part.
                 const baseTermLength = baseTerm.length;
                 textToUnderline = matchedText.substring(0, baseTermLength);


### PR DESCRIPTION
## Description

This PR fixes the component `GlossaryInjector`, which is used for showing terms in the glossary across pages. The problem was that many glossary terms were not showing on Japanese pages because those terms weren't detected with/without plurals, which was specific to only English terms. The problem occurred after introducing support for glossary terms in plural form in #834.

To fix this issue, I've refactored glossary term detection to better handle Japanese language pages by avoiding word boundaries and pluralization logic that are not applicable. This ensures accurate glossary injection for both English and Japanese documentation.

## Related issues and/or PRs

- Problem introduced in https://github.com/scalar-labs/docs-scalardl/pull/834.

## Changes made

* **Introduced `isJapaneseSite` flag:** Added a flag to detect if the current site is Japanese (`/ja-jp/`) and reused this flag across multiple sections for cleaner and consistent logic. ([[1]](diffhunk://#diff-a29d46fa93159f09bd4e170daa2a60dbb43ca196b88675a769c72468151b0ec2R15-R20), [[2]](diffhunk://#diff-a29d46fa93159f09bd4e170daa2a60dbb43ca196b88675a769c72468151b0ec2L96-R112))
* **Regex pattern adjustments:** Modified the regex pattern generation to avoid word boundaries for Japanese terms, ensuring compatibility with Japanese characters. (`src/components/GlossaryInjector.tsx`, [src/components/GlossaryInjector.tsxL96-R112](diffhunk://#diff-a29d46fa93159f09bd4e170daa2a60dbb43ca196b88675a769c72468151b0ec2L96-R112))
* **Base term matching logic:** Adjusted the logic for finding base terms in the glossary. Japanese terms now require an exact match, while English terms still support singular and plural forms. (`src/components/GlossaryInjector.tsx`, [src/components/GlossaryInjector.tsxL110-R136](diffhunk://#diff-a29d46fa93159f09bd4e170daa2a60dbb43ca196b88675a769c72468151b0ec2L110-R136))
* **Pluralization logic:** Restricted pluralization handling to English terms, ensuring that Japanese terms are processed correctly without unnecessary modifications. (`src/components/GlossaryInjector.tsx`, [src/components/GlossaryInjector.tsxL141-R163](diffhunk://#diff-a29d46fa93159f09bd4e170daa2a60dbb43ca196b88675a769c72468151b0ec2L141-R163))

---

* Updated regex patterns to avoid using word boundaries for Japanese terms, as they don't work well with Japanese characters, while retaining pluralization logic for English terms. 
* Added language-specific logic for matching glossary terms, ensuring exact matches for Japanese and pluralization checks for English. 



---



## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

This pull request enhances the `GlossaryInjector` component by introducing language-specific handling for glossary terms, with a focus on improving support for Japanese. Key changes include the addition of a language check, adjustments to regex patterns, and tailored logic for matching and processing terms based on the site's language.

### Language-specific handling improvements:



### Code clarity and comments:

* Clarified a comment about sorting terms by length, removing redundant wording. (`src/components/GlossaryInjector.tsx`, [src/components/GlossaryInjector.tsxL53-R54](diffhunk://#diff-a29d46fa93159f09bd4e170daa2a60dbb43ca196b88675a769c72468151b0ec2L53-R54))
* Restricted pluralization logic to the English version of the site, improving clarity and correctness. (`src/components/GlossaryInjector.tsx`, [src/components/GlossaryInjector.tsxL141-R163](diffhunk://#diff-a29d46fa93159f09bd4e170daa2a60dbb43ca196b88675a769c72468151b0ec2L141-R163))