### PR TITLE
Remove ScalarDB 3.11 end-of-support message from notifications

### DIFF
--- a/src/data/notifications.js
+++ b/src/data/notifications.js
@@ -36,8 +36,8 @@ const notificationsList = [
   },
   {
     message: {
-      en: 'Discover how to implement vector search capabilities with ScalarDB Cluster 3.15',
-      ja: 'ScalarDB Cluster 3.15 でベクトル検索機能を実装する方法を学ぶ'
+      en: 'Discover how to implement vector search capabilities with ScalarDB Cluster',
+      ja: 'ScalarDB Cluster でベクトル検索機能を実装する方法を学ぶ'
     },
     url: {
       en: 'scalardb-cluster/getting-started-with-vector-search?utm_source=docs-site&utm_medium=notifications',


### PR DESCRIPTION
## Description

This PR removes the notification about the end of support for ScalarDB 3.11 since that version is officially no longer supported.

## Related issues and/or PRs

- #1420 

## Changes made

- Removed the notification about the upcoming end of support for ScalarDB 3.11.
- Updated a notification message to refer to "ScalarDB Cluster 3.15" instead of "ScalarDB Cluster" for vector search capabilities.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A