### PR TITLE
Add redirect for ScalarDB Analytics index page to design page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -186,6 +186,10 @@ const config = {
             to: '/docs/latest/releases/release-support-policy',
             from: '/docs/releases/release-support-policy',
           },
+          { // The redirect for this doc in Japanese is at i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/scalardb-analytics/index.html.
+            to: '/docs/latest/scalardb-analytics/design',
+            from: '/docs/latest/scalardb-analytics',
+          },
           {
             to: '/docs/latest/scalardb-analytics/quickstart',
             from: '/docs/latest/scalardb-samples/scalardb-analytics-spark-sample',

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/scalardb-analytics/index.html
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/scalardb-analytics/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0;url=./design">
+</head>
+<body>
+  <!-- Optional content to display before redirection -->
+</body>
+</html>


### PR DESCRIPTION
## Description

This PR adds a redirect from the ScalarDB Analytics index page (previously `README.mdx`, which is currently not being used) to the ScalarDB Analytics design page (`design.mdx`).

## Related issues and/or PRs

N/A

## Changes made

- Added a redirect from `scalardb-analytics` to `scalardb-analytics/design`.
  - English redirect is in `docusaurus.config.js`.
  - Japanese redirect is in `i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/scalardb-analytics/index.html`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A