### PR TITLE
Remove note about Community docs site from repository README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-# ScalarDB Enterprise Documentation
+# ScalarDB Documentation
 
-> **Note**
-> 
-> If you're looking for the documentation repository for the open-source version of ScalarDB, please see [scalar-labs/docs-scalardb-community](https://github.com/scalar-labs/docs-scalardb-community), which stores the documentation for [ScalarDB Community Docs](https://scalardb-community.scalar-labs.com/docs).
-
-This repository contains documentation source files for the commercial version of ScalarDB. Please view this documentation at [ScalarDB Enterprise Docs](https://scalardb.scalar-labs.com/docs).
+This repository contains documentation source files for ScalarDB. Please view this documentation at [ScalarDB Docs](https://scalardb.scalar-labs.com/docs).
 
 ## Interested in using ScalarDB Enterprise?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ScalarDB Documentation
 
-This repository contains documentation source files for ScalarDB. Please view this documentation at [ScalarDB Docs](https://scalardb.scalar-labs.com/docs).
+This repository contains the source files for the [ScalarDB documentation](https://scalardb.scalar-labs.com/docs).
 
 ## Interested in using ScalarDB Enterprise?
 


### PR DESCRIPTION
## Description

This PR updates the README.md file to generalize the documentation for ScalarDB, removing references to the Community edition docs site, which had been previously been a separate docs site. In #469, we added tags, which specify whether a doc is applicable to Community or Enterprise editions and then we created a redirect from the old Community docs site to the now all-encompassing ScalarDB docs site.

## Related issues and/or PRs

N/A

## Changes made

* Removed references to the Community edition docs site and revised wording to be more generic about ScalarDB docs.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A