### PR TITLE
Mark ScalarDB 3.14 as out of Maintenance Support

### DIFF
--- a/docs/releases/release-support-policy.mdx
+++ b/docs/releases/release-support-policy.mdx
@@ -52,7 +52,7 @@ This page describes Scalar's support policy for major and minor version releases
     <tr>
       <td><a href="https://scalardb.scalar-labs.com/docs/3.14/releases/release-notes#v3140">3.14</a></td>
       <td>2024-11-22</td>
-      <td>2026-02-20</td>
+      <td class="version-out-of-maintenance-support">2026-02-20</td>
       <td>2026-08-18</td>
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
@@ -56,7 +56,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
     <tr>
       <td><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.14/releases/release-notes#v3140">3.14</a></td>
       <td>2024-11-22</td>
-      <td>2026-02-20</td>
+      <td class="version-out-of-maintenance-support">2026-02-20</td>
       <td>2026-08-18</td>
       <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.14/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.14/releases/release-support-policy.mdx
@@ -35,7 +35,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
     <tr>
       <td><a href="https://scalardb.scalar-labs.com/ja-jp/docs/latest/releases/release-notes#v3140">3.14</a></td>
       <td>2024-11-22</td>
-      <td>2026-02-20</td>
+      <td class="version-out-of-maintenance-support">2026-02-20</td>
       <td>2026-08-18</td>
       <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.15/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.15/releases/release-support-policy.mdx
@@ -42,7 +42,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
     <tr>
       <td><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.14/releases/release-notes#v3140">3.14</a></td>
       <td>2024-11-22</td>
-      <td>2026-02-20</td>
+      <td class="version-out-of-maintenance-support">2026-02-20</td>
       <td>2026-08-18</td>
       <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.16/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.16/releases/release-support-policy.mdx
@@ -49,7 +49,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
     <tr>
       <td><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.14/releases/release-notes#v3140">3.14</a></td>
       <td>2024-11-22</td>
-      <td>2026-02-20</td>
+      <td class="version-out-of-maintenance-support">2026-02-20</td>
       <td>2026-08-18</td>
       <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>

--- a/versioned_docs/version-3.14/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.14/releases/release-support-policy.mdx
@@ -31,7 +31,7 @@ This page describes Scalar's support policy for major and minor version releases
     <tr>
       <td><a href="https://scalardb.scalar-labs.com/docs/latest/releases/release-notes#v3140">3.14</a></td>
       <td>2024-11-22</td>
-      <td>2026-02-20</td>
+      <td class="version-out-of-maintenance-support">2026-02-20</td>
       <td>2026-08-18</td>
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>

--- a/versioned_docs/version-3.15/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.15/releases/release-support-policy.mdx
@@ -38,7 +38,7 @@ This page describes Scalar's support policy for major and minor version releases
     <tr>
       <td><a href="https://scalardb.scalar-labs.com/docs/3.14/releases/release-notes#v3140">3.14</a></td>
       <td>2024-11-22</td>
-      <td>2026-02-20</td>
+      <td class="version-out-of-maintenance-support">2026-02-20</td>
       <td>2026-08-18</td>
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>

--- a/versioned_docs/version-3.16/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.16/releases/release-support-policy.mdx
@@ -45,7 +45,7 @@ This page describes Scalar's support policy for major and minor version releases
     <tr>
       <td><a href="https://scalardb.scalar-labs.com/docs/3.14/releases/release-notes#v3140">3.14</a></td>
       <td>2024-11-22</td>
-      <td>2026-02-20</td>
+      <td class="version-out-of-maintenance-support">2026-02-20</td>
       <td>2026-08-18</td>
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>


### PR DESCRIPTION
## Description

This PR marks ScalarDB 3.14 as out of Maintenance Support (ended on February 20, 2026).

## Related issues and/or PRs

N/A

## Changes made

- In each version of the Release Support Policy docs, added the `version-out-of-maintenance-support` style to the `Maintenance Support Ends` cell for 3.14.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A