### PR TITLE
Add patch version release notes for 3.17.3, 3.16.5, and 3.15.8

### DIFF
--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -10,6 +10,55 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.17.
 
+## v3.17.3
+
+**Release date:** April 15, 2026
+
+### Summary
+
+This release includes several improvements and bug fixes.
+
+### Community edition
+
+#### Improvements
+
+- Replaced MySQL Connector/J with MariaDB Connector/J due to licensing concerns. ([#3428](https://github.com/scalar-labs/scalardb/pull/3428))
+- Added support for setting null values on secondary index columns in DynamoDB. When a null value is set, the attribute is removed from the item and the record will not appear in secondary index scans. ([#3326](https://github.com/scalar-labs/scalardb/pull/3326))
+- Inserting or updating records with TIME (microsecond precision), TIMESTAMP (millisecond precision), and TIMESTAMPTZ (millisecond precision) column values will truncate out-of-range precision rather than throwing an exception. ([#3393](https://github.com/scalar-labs/scalardb/pull/3393))
+- Fixed an issue where index-based Get and Scan operations in Consensus Commit could miss records in PREPARED or DELETED state, by adding before-image secondary index check. ([#3419](https://github.com/scalar-labs/scalardb/pull/3419))
+- Added support for the SERIALIZABLE isolation level for index-based Get, Scan, and ScanAll operations in Consensus Commit when before-image indexes are present. Run `repairTable()` to create before-image indexes for existing tables. ([#3463](https://github.com/scalar-labs/scalardb/pull/3463))
+- Shortened JDBC index names using a hash when they exceed the maximum identifier length supported by the underlying database. ([#3481](https://github.com/scalar-labs/scalardb/pull/3481))
+
+#### Bug fixes
+
+- Fixed `dropColumnFromTable()` from dropping the secondary index even when column drop is unsupported. ([#3450](https://github.com/scalar-labs/scalardb/pull/3450))
+- Upgraded the Netty library to fix security issues: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") and [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871") ([#3452](https://github.com/scalar-labs/scalardb/pull/3452))
+- Fixed a bug where index-based Get and Scan operations could return incorrect results after lazy recovery rolled back a PREPARED record whose after-image index value matched the query but whose before-image (restored) value did not. ([#3488](https://github.com/scalar-labs/scalardb/pull/3488))
+
+### Enterprise edition
+
+#### Improvements
+
+##### ScalarDB SQL
+
+- Updated the TIMESTAMPTZ literal to make optional the space character before the UTC timezone `Z` character. For example, `2021-03-04 12:30:45.123Z` is now accepted, in addition to the current format `2021-03-04 12:30:45.123 Z`. Also, when selecting a TIMESTAMPTZ column, the value is printed without a space before the `Z`.
+- Fixed an issue where the shadow jar was unnecessarily published to GitHub Packages for the CLI module.
+- Inserting or updating records with TIME (microsecond precision), TIMESTAMP (millisecond precision), and TIMESTAMPTZ (millisecond precision) column values will truncate out-of-range precision rather than throwing an exception.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix security issues: [CVE-2025-59250](https://github.com/advisories/GHSA-m494-w24q-6f7w "CVE-2025-59250") and [CVE-2026-25679](https://github.com/advisories/GHSA-j3gx-2473-5fp8 "CVE-2026-25679")
+- Upgraded the Netty library to fix security issues: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") and [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871")
+- Fixed a bug where one-shot batch operations bypassed pause control in the GateKept transaction managers.
+- Upgraded `grpc_health_probe` to fix a security issue: [CVE-2026-34986](https://github.com/advisories/GHSA-78h2-9frx-2jm8 "CVE-2026-34986").
+
+##### ScalarDB SQL
+
+- Fixed a bug where duplicate column names were allowed in CREATE TABLE statements.
+- Fixed missing strict date validation on time-related type formatters, which could allow invalid dates (e.g., February 30) to be silently accepted instead of rejected.
+
 ## v3.17.2
 
 **Release date:** March 6, 2026

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,19 +78,19 @@ const config = {
                 label: '3.17',
                 path: 'latest', // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 banner: 'none',
-                className: '3.17.2',
+                className: '3.17.3',
               },
               "3.16": { // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 label: '3.16',
                 path: '3.16', // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 banner: 'none',
-                className: '3.16.4',
+                className: '3.16.5',
               },
               "3.15": { // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 label: '3.15',
                 path: '3.15', // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 banner: 'none',
-                className: '3.15.7',
+                className: '3.15.8',
               },
               "3.14": { // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 label: '3.14',

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -117,7 +117,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 #### 改善点
 
-- アクティブトランザクション管理を有効/無効にするための `scalar.db.active_transaction_management.enabled` 設定オプションを追加しました（デフォルト: `true`）。([#3233](https://github.com/scalar-labs/scalardb/pull/3233))
+- アクティブトランザクション管理を有効/無効にするための `scalar.db.active_transaction_management.enabled` 設定オプションを追加しました (デフォルト: `true`)。([#3233](https://github.com/scalar-labs/scalardb/pull/3233))
 
 #### バグの修正
 
@@ -177,8 +177,8 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 #### 改善点
 
-- Db2 を使用する場合、Db2 から ScalarDB BLOB 列に使用されるデフォルトのデータ型が `VARBINARY(32672)` から `BLOB(2G)` に変更され、最大 2GB のデータを格納できるようになりました。これにより、BLOB 列はパーティションキー、クラスタリングキー、セカンダリインデックス、またはクロスパーティション スキャン（つまり ScanAll）操作での順序列として使用できないという新しい制限が生じます。([#3000](https://github.com/scalar-labs/scalardb/pull/3000))
-- Oracle を使用する場合、Oracle から ScalarDB BLOB 列に使用されるデフォルトのデータ型が `RAW(2000)` から `BLOB` に変更され、最大 2GB のデータを格納できるようになりました。これにより新しい制限が導入されます：BLOB 列は、パーティションキー、クラスタリングキー、セカンダリインデックス、または Get や Scan 操作の条件として使用できなくなります。([#3070](https://github.com/scalar-labs/scalardb/pull/3070))
+- Db2 を使用する場合、Db2 から ScalarDB BLOB 列に使用されるデフォルトのデータ型が `VARBINARY(32672)` から `BLOB(2G)` に変更され、最大 2GB のデータを格納できるようになりました。これにより、BLOB 列はパーティションキー、クラスタリングキー、セカンダリインデックス、またはクロスパーティション スキャン (つまり ScanAll) 操作での順序列として使用できないという新しい制限が生じます。([#3000](https://github.com/scalar-labs/scalardb/pull/3000))
+- Oracle を使用する場合、Oracle から ScalarDB BLOB 列に使用されるデフォルトのデータ型が `RAW(2000)` から `BLOB` に変更され、最大 2GB のデータを格納できるようになりました。これにより新しい制限が導入されます: BLOB 列は、パーティションキー、クラスタリングキー、セカンダリインデックス、または Get や Scan 操作の条件として使用できなくなります。([#3070](https://github.com/scalar-labs/scalardb/pull/3070))
 - JDBC トランザクションマネージャーを使用する場合、設定 `scalar.db.jdbc.isolation_level` が設定されていない場合に JDBC トランザクション分離レベルを SERIALIZABLE に設定しないようになりました。デフォルトは、ストレージによって設定されたデフォルト値になります。([#3076](https://github.com/scalar-labs/scalardb/pull/3076))
 - ScalarDB Data Loader CLI の Maven パブリッシュサポートを追加し、Maven アーティファクトとしての配布を可能にしました。([#3120](https://github.com/scalar-labs/scalardb/pull/3120))
 
@@ -249,4 +249,4 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました。[CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874")
 - ワンフェーズコミット最適化が有効な場合にレプリケーション機能が開始されないようにバリデーションを追加しました。
 - 重複する列名が存在する場合に SQL API の `ResultSet` が不正な結果を返すバグを修正しました。
-- セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました：[CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3 "CVE-2025-47907")、[CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27 "CVE-2025-58183")、[CVE-2025-58186](https://github.com/advisories/GHSA-rjcg-56ph-3qvg "CVE-2025-58186")、[CVE-2025-58187](https://github.com/advisories/GHSA-frhw-mqj2-wxw2 "CVE-2025-58187")、および [CVE-2025-58188](https://github.com/advisories/GHSA-7wwx-xj66-r44x "CVE-2025-58188")。
+- セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました: [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3 "CVE-2025-47907")、[CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27 "CVE-2025-58183")、[CVE-2025-58186](https://github.com/advisories/GHSA-rjcg-56ph-3qvg "CVE-2025-58186")、[CVE-2025-58187](https://github.com/advisories/GHSA-frhw-mqj2-wxw2 "CVE-2025-58187")、および [CVE-2025-58188](https://github.com/advisories/GHSA-7wwx-xj66-r44x "CVE-2025-58188")。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -14,6 +14,55 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.17 のリリースノートのリストが含まれています。
 
+## v3.17.3
+
+**発売日:** 2026年4月15日
+
+### まとめ
+
+このリリースには、いくつかの改善点とバグ修正が含まれています。
+
+### Community edition
+
+#### 改善点
+
+- MySQL Connector/J を MariaDB Connector/J に置き換えました。ライセンス上の懸念によるものです。 ([#3428](https://github.com/scalar-labs/scalardb/pull/3428))
+- DynamoDB のセカンダリインデックス列に null 値を設定するサポートを追加しました。null 値が設定されると、属性はアイテムから削除され、レコードはセカンダリインデックスのスキャンに表示されなくなります。 ([#3326](https://github.com/scalar-labs/scalardb/pull/3326))
+- TIME (マイクロ秒精度)、TIMESTAMP (ミリ秒精度)、TIMESTAMPTZ (ミリ秒精度)列の値を挿入または更新する際、範囲外の精度は例外をスローするのではなく切り捨てられるようになりました。 ([#3393](https://github.com/scalar-labs/scalardb/pull/3393))
+- Consensus Commit のインデックスベースの Get および Scan 操作で、PREPARED または DELETED 状態のレコードを見逃す可能性がある問題を修正しました。before-image セカンダリインデックスのチェックを追加しました。 ([#3419](https://github.com/scalar-labs/scalardb/pull/3419))
+- before-image インデックスが存在する場合、Consensus Commit のインデックスベースの Get、Scan、および ScanAll 操作で SERIALIZABLE 分離レベルをサポートするようになりました。既存のテーブルに before-image インデックスを作成するには、`repairTable()` を実行してください。 ([#3463](https://github.com/scalar-labs/scalardb/pull/3463))
+- JDBC インデックス名が基盤となるデータベースでサポートされている最大識別子長を超える場合、ハッシュを使用して短縮されるようになりました。 ([#3481](https://github.com/scalar-labs/scalardb/pull/3481))
+
+#### バグの修正
+
+- `dropColumnFromTable()` が列の削除をサポートしていない場合でもセカンダリインデックスを削除してしまう問題を修正しました。 ([#3450](https://github.com/scalar-labs/scalardb/pull/3450))
+- Netty ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") および [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871") ([#3452](https://github.com/scalar-labs/scalardb/pull/3452))
+- インデックスベースの Get および Scan 操作が、lazy recovery によって PREPARED レコードがロールバックされた後に不正確な結果を返す可能性があるバグを修正しました。after-image インデックス値がクエリに一致しても、before-image (復元された) 値が一致しない場合があります。 ([#3488](https://github.com/scalar-labs/scalardb/pull/3488))
+
+### Enterprise edition
+
+#### 改善点
+
+##### ScalarDB SQL
+
+- TIMESTAMPTZ リテラルを更新し、UTC タイムゾーン `Z` 文字の前のスペース文字をオプションにしました。例えば、`2021-03-04 12:30:45.123Z` が現在の形式 `2021-03-04 12:30:45.123 Z` に加えて受け入れられるようになりました。また、TIMESTAMPTZ 列を選択する際、値は `Z` の前にスペースを入れずに表示されます。
+- CLI モジュールのシャドウ jar が不必要に GitHub Packages に公開される問題を修正しました。
+- TIME (マイクロ秒精度)、TIMESTAMP (ミリ秒精度)、TIMESTAMPTZ (ミリ秒精度) 列の値を挿入または更新する際、範囲外の精度は例外をスローするのではなく切り捨てられるようになりました。
+
+#### バグの修正
+
+##### ScalarDB Cluster
+
+- `grpc_health_probe` をアップグレードしてセキュリティ問題を修正しました: [CVE-2025-59250](https://github.com/advisories/GHSA-m494-w24q-6f7w "CVE-2025-59250") および [CVE-2026-25679](https://github.com/advisories/GHSA-j3gx-2473-5fp8 "CVE-2026-25679")
+- Netty ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") および [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871")
+- ワンショットバッチ操作が GateKept トランザクションマネージャーでポーズ制御をバイパスするバグを修正しました。
+- `grpc_health_probe` をアップグレードしてセキュリティ問題を修正しました: [CVE-2026-34986](https://github.com/advisories/GHSA-78h2-9frx-2jm8 "CVE-2026-34986").
+
+##### ScalarDB SQL
+
+- CREATE TABLE ステートメントで重複する列名が許可されるバグを修正しました。
+- 時間関連の型フォーマッターで厳密な日付検証が欠落していた問題を修正しました。これにより、無効な日付 (例: 2月30日) が拒否されずに静かに受け入れられる可能性がありました。
+
 ## v3.17.2
 
 **発売日:** 2026年3月6日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.15/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.15/releases/release-notes.mdx
@@ -78,10 +78,10 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 ##### ScalarDB Cluster
 
-- セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました：[CVE-2025-68121](https://github.com/advisories/GHSA-h355-32pf-p2xm "CVE-2025-68121")、[CVE-2025-61726](https://github.com/advisories/GHSA-gm9r-q53w-2gh4 "CVE-2025-61726")、[CVE-2025-61728](https://github.com/advisories/GHSA-g9q4-qjx4-2v7q "CVE-2025-61728")、[CVE-2025-61729](https://github.com/advisories/GHSA-7c64-f9jr-v9h2 "CVE-2025-61729")、および [CVE-2025-61730](https://github.com/advisories/GHSA-gr56-3gp6-6gmj "CVE-2025-61730")
-- セキュリティ問題を修正するために Kubernetes Java Client をアップグレードしました：[CVE-2024-29371](https://github.com/advisories/GHSA-3677-xxcr-wjqv "CVE-2024-29371")
-- セキュリティ問題を修正するために Kubernetes Java Client から `com.microsoft.azure:adal4j` を除外しました：[CVE-2023-52428](https://github.com/advisories/GHSA-gvpg-vgmx-xg6w "CVE-2023-52428"), [CVE-2021-31684](https://github.com/advisories/GHSA-fg2v-w576-w4v3 "CVE-2021-31684"), および [CVE-2023-1370](https://github.com/advisories/GHSA-493p-pfq6-5258 "CVE-2023-1370")
-- セキュリティ問題を修正するために Jackson ライブラリをアップグレードしました：[GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq "GHSA-72hv-8253-57qq")
+- セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました: [CVE-2025-68121](https://github.com/advisories/GHSA-h355-32pf-p2xm "CVE-2025-68121")、[CVE-2025-61726](https://github.com/advisories/GHSA-gm9r-q53w-2gh4 "CVE-2025-61726")、[CVE-2025-61728](https://github.com/advisories/GHSA-g9q4-qjx4-2v7q "CVE-2025-61728")、[CVE-2025-61729](https://github.com/advisories/GHSA-7c64-f9jr-v9h2 "CVE-2025-61729")、および [CVE-2025-61730](https://github.com/advisories/GHSA-gr56-3gp6-6gmj "CVE-2025-61730")
+- セキュリティ問題を修正するために Kubernetes Java Client をアップグレードしました: [CVE-2024-29371](https://github.com/advisories/GHSA-3677-xxcr-wjqv "CVE-2024-29371")
+- セキュリティ問題を修正するために Kubernetes Java Client から `com.microsoft.azure:adal4j` を除外しました: [CVE-2023-52428](https://github.com/advisories/GHSA-gvpg-vgmx-xg6w "CVE-2023-52428"), [CVE-2021-31684](https://github.com/advisories/GHSA-fg2v-w576-w4v3 "CVE-2021-31684"), および [CVE-2023-1370](https://github.com/advisories/GHSA-493p-pfq6-5258 "CVE-2023-1370")
+- セキュリティ問題を修正するために Jackson ライブラリをアップグレードしました: [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq "GHSA-72hv-8253-57qq")
 
 ##### ScalarDB SQL
 
@@ -114,7 +114,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 - 重複する列名が存在する場合に SQL API の `ResultSet` が不正な結果を返すバグを修正しました。
 - セキュリティ問題を修正するために gRPC ライブラリをアップグレードしました。[CVE-2025-55163](https://github.com/advisories/GHSA-prj3-ccx8-p6x4 "CVE-2025-55163")
-- セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました：[CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3 "CVE-2025-47907")、[CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27 "CVE-2025-58183")、[CVE-2025-58186](https://github.com/advisories/GHSA-rjcg-56ph-3qvg "CVE-2025-58186")、[CVE-2025-58187](https://github.com/advisories/GHSA-frhw-mqj2-wxw2 "CVE-2025-58187")、および [CVE-2025-58188](https://github.com/advisories/GHSA-7wwx-xj66-r44x "CVE-2025-58188")。
+- セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました: [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3 "CVE-2025-47907")、[CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27 "CVE-2025-58183")、[CVE-2025-58186](https://github.com/advisories/GHSA-rjcg-56ph-3qvg "CVE-2025-58186")、[CVE-2025-58187](https://github.com/advisories/GHSA-frhw-mqj2-wxw2 "CVE-2025-58187")、および [CVE-2025-58188](https://github.com/advisories/GHSA-7wwx-xj66-r44x "CVE-2025-58188")。
 
 ## v3.15.5
 

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.15/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.15/releases/release-notes.mdx
@@ -14,6 +14,49 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.15 のリリースノートのリストが含まれています。
 
+## v3.15.8
+
+**発売日:** 2026年4月15日
+
+### まとめ
+
+このリリースには、いくつかの改善点とバグ修正が含まれています。
+
+### Community edition
+
+#### 改善点
+
+- ライセンスの問題により、MySQL Connector/J を MariaDB Connector/J に置き換えました。 ([#3428](https://github.com/scalar-labs/scalardb/pull/3428))
+- TIME (マイクロ秒精度)、TIMESTAMP (ミリ秒精度)、および TIMESTAMPTZ (ミリ秒精度) 列の値を挿入または更新する際、範囲外の精度は例外をスローするのではなく切り捨てられるようになりました。 ([#3393](https://github.com/scalar-labs/scalardb/pull/3393))
+- JDBC インデックス名が基盤となるデータベースでサポートされている最大識別子長を超える場合、ハッシュを使用して短縮されるようになりました。 ([#3481](https://github.com/scalar-labs/scalardb/pull/3481))
+
+#### バグの修正
+
+- Netty ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") および [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871") ([#3452](https://github.com/scalar-labs/scalardb/pull/3452))
+
+### Enterprise edition
+
+#### 改善点
+
+##### ScalarDB SQL
+
+- TIMESTAMPTZ リテラルを更新し、UTC タイムゾーン `Z` 文字の前のスペース文字をオプションにしました。例えば、`2021-03-04 12:30:45.123Z` が現在の形式 `2021-03-04 12:30:45.123 Z` に加えて受け入れられるようになりました。また、TIMESTAMPTZ 列を選択する際、値は `Z` の前にスペースを入れずに表示されます。
+- CLI モジュールのシャドウ JAR が不要に GitHub Packages に公開される問題を修正しました。
+- TIME (マイクロ秒精度)、TIMESTAMP (ミリ秒精度)、および TIMESTAMPTZ (ミリ秒精度) 列の値を挿入または更新する際、範囲外の精度は例外をスローするのではなく切り捨てられるようになりました。
+
+#### バグの修正
+
+##### ScalarDB Cluster
+
+- `grpc_health_probe` をアップグレードしてセキュリティ問題を修正しました: [CVE-2025-59250](https://github.com/advisories/GHSA-m494-w24q-6f7w "CVE-2025-59250") および [CVE-2026-25679](https://github.com/advisories/GHSA-j3gx-2473-5fp8 "CVE-2026-25679")
+- Netty ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") および [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871")
+- `grpc_health_probe` をアップグレードしてセキュリティ問題を修正しました: [CVE-2026-34986](https://github.com/advisories/GHSA-78h2-9frx-2jm8 "CVE-2026-34986").
+
+##### ScalarDB SQL
+
+- CREATE TABLE ステートメントで重複する列名が許可されていたバグを修正しました。
+- 時間関連の型フォーマッタで厳密な日付検証が欠落していたバグを修正しました。これにより、無効な日付 (例: 2月30日) が静かに受け入れられるのではなく、拒否されるようになりました。
+
 ## v3.15.7
 
 **発売日:** 2026年3月6日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.16/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.16/releases/release-notes.mdx
@@ -103,7 +103,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 #### 改善点
 
-- アクティブトランザクション管理を有効/無効にするための設定オプション `scalar.db.active_transaction_management.enabled` を追加しました（デフォルト: `true`）。([#3233](https://github.com/scalar-labs/scalardb/pull/3233))
+- アクティブトランザクション管理を有効/無効にするための設定オプション `scalar.db.active_transaction_management.enabled` を追加しました  (デフォルト: `true`)。([#3233](https://github.com/scalar-labs/scalardb/pull/3233))
 
 #### バグの修正
 
@@ -154,7 +154,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 - 重複する列名が存在する場合に SQL API の `ResultSet` が不正な結果を返すバグを修正しました。
 - セキュリティ問題を修正するために gRPC ライブラリをアップグレードしました。[CVE-2025-55163](https://github.com/advisories/GHSA-prj3-ccx8-p6x4 "CVE-2025-55163")
-- セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました：[CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3 "CVE-2025-47907")、[CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27 "CVE-2025-58183")、[CVE-2025-58186](https://github.com/advisories/GHSA-rjcg-56ph-3qvg "CVE-2025-58186")、[CVE-2025-58187](https://github.com/advisories/GHSA-frhw-mqj2-wxw2 "CVE-2025-58187")、および [CVE-2025-58188](https://github.com/advisories/GHSA-7wwx-xj66-r44x "CVE-2025-58188")。
+- セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました: [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3 "CVE-2025-47907")、[CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27 "CVE-2025-58183")、[CVE-2025-58186](https://github.com/advisories/GHSA-rjcg-56ph-3qvg "CVE-2025-58186")、[CVE-2025-58187](https://github.com/advisories/GHSA-frhw-mqj2-wxw2 "CVE-2025-58187")、および [CVE-2025-58188](https://github.com/advisories/GHSA-7wwx-xj66-r44x "CVE-2025-58188")。
 
 ## v3.16.1
 
@@ -237,7 +237,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 ##### ScalarDB Cluster
 
-- ScalarDB Cluster におけるトランザクション機能の有効または無効を設定するための構成オプション（`scalar.db.transaction.enabled`）を追加しました。デフォルト値は `true` です。
+- ScalarDB Cluster におけるトランザクション機能の有効または無効を設定するための構成オプション  (`scalar.db.transaction.enabled`) を追加しました。デフォルト値は `true` です。
 - ScalarDB Cluster におけるトランザクション抽象にスキャナー API のサポートを追加し、結果を反復的に取得できるようにしました。
 - ScalarDB Cluster において、読み取り専用モードでトランザクションを開始するサポートを追加しました。
 - ScalarDB Cluster において、SQL を使用して読み取り専用モードでトランザクションを開始するサポートを追加しました。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.16/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.16/releases/release-notes.mdx
@@ -14,6 +14,54 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.16 のリリースノートのリストが含まれています。
 
+## v3.16.5
+
+**リリース日:** 2026年4月15日
+
+### 概要
+
+このリリースには、いくつかの改善点とバグ修正が含まれています。
+
+### Community edition
+
+#### 改善点
+
+- ライセンスの問題により、MySQL Connector/J を MariaDB Connector/J に置き換えました。 ([#3428](https://github.com/scalar-labs/scalardb/pull/3428))
+- Consensus Commit プロトコルにおけるワンフェーズコミット最適化の適用範囲を拡張しました。これにより、トランザクションが後で更新するレコードのみを読み取る場合でも、SERIALIZABLE 分離レベルでワンフェーズコミットを使用できるようになり、読み取り-修正-書き込みワークロードのパフォーマンスが向上します。 ([#3295](https://github.com/scalar-labs/scalardb/pull/3295))
+- DynamoDB のセカンダリインデックス列に null 値を設定するサポートを追加しました。null 値が設定されると、属性はアイテムから削除され、レコードはセカンダリインデックスのスキャンに表示されなくなります。 ([#3326](https://github.com/scalar-labs/scalardb/pull/3326))
+- TIME (マイクロ秒精度)、TIMESTAMP (ミリ秒精度)、および TIMESTAMPTZ (ミリ秒精度) 列値を持つレコードの挿入または更新時に、範囲外の精度を切り捨てるようになり、例外がスローされなくなりました。 ([#3393](https://github.com/scalar-labs/scalardb/pull/3393))
+- Consensus Commit におけるインデックスベースの Get および Scan 操作で、PREPARED または DELETED 状態のレコードを見逃す可能性がある問題を修正しました。これにより、before-image セカンダリインデックスのチェックが追加されました。 ([#3419](https://github.com/scalar-labs/scalardb/pull/3419))
+- Consensus Commit におけるインデックスベースの Get、Scan、および ScanAll 操作で、before-image インデックスが存在する場合に SERIALIZABLE 分離レベルをサポートするようになりました。既存のテーブルに対して before-image インデックスを作成するには、`repairTable()` を実行してください。 ([#3463](https://github.com/scalar-labs/scalardb/pull/3463))
+- JDBC インデックス名が基盤となるデータベースでサポートされる最大識別子長を超える場合、ハッシュを使用して短縮されるようになりました。 ([#3481](https://github.com/scalar-labs/scalardb/pull/3481))
+
+#### バグの修正
+
+- Netty ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") および [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871") ([#3452](https://github.com/scalar-labs/scalardb/pull/3452))
+- Lazy リカバリが PREPARED レコードをロールバックした後、after-image インデックス値がクエリに一致しても before-image  (復元された) 値が一致しない場合に、インデックスベースの Get および Scan 操作が不正確な結果を返す可能性があるバグを修正しました。 ([#3488](https://github.com/scalar-labs/scalardb/pull/3488))
+
+### Enterprise edition
+
+#### 改善点
+
+##### ScalarDB SQL
+
+- TIMESTAMPTZ リテラルを更新し、UTC タイムゾーン `Z` 文字の前のスペース文字をオプションにしました。例えば、`2021-03-04 12:30:45.123Z` が現在の形式 `2021-03-04 12:30:45.123 Z` に加えて受け入れられるようになりました。また、TIMESTAMPTZ 列を選択する際、値は `Z` の前にスペースを入れずに表示されます。
+- CLI モジュールのシャドウ JAR が不必要に GitHub Packages に公開される問題を修正しました。
+- TIME  (マイクロ秒精度)、TIMESTAMP  (ミリ秒精度)、および TIMESTAMPTZ  (ミリ秒精度) 列値を持つレコードの挿入または更新時に、範囲外の精度を切り捨てるようになり、例外がスローされなくなりました。
+
+#### バグの修正
+
+##### ScalarDB Cluster
+
+- `grpc_health_probe` をアップグレードしてセキュリティ問題を修正しました: [CVE-2025-59250](https://github.com/advisories/GHSA-m494-w24q-6f7w "CVE-2025-59250") および [CVE-2026-25679](https://github.com/advisories/GHSA-j3gx-2473-5fp8 "CVE-2026-25679")
+- Netty ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") および [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871")
+- `grpc_health_probe` をアップグレードしてセキュリティ問題を修正しました: [CVE-2026-34986](https://github.com/advisories/GHSA-78h2-9frx-2jm8 "CVE-2026-34986")
+
+##### ScalarDB SQL
+
+- CREATE TABLE ステートメントで重複する列名が許可されるバグを修正しました。
+- 時間関連の型フォーマッタで厳密な日付検証が欠落していた問題を修正しました。これにより、無効な日付  (例: 2月30日) が静かに受け入れられるのではなく、正しく拒否されるようになりました。
+
 ## v3.16.4
 
 **発売日:** 2026年3月6日

--- a/versioned_docs/version-3.15/releases/release-notes.mdx
+++ b/versioned_docs/version-3.15/releases/release-notes.mdx
@@ -10,6 +10,49 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.15.
 
+## v3.15.8
+
+**Release date:** April 15, 2026
+
+### Summary
+
+This release includes improvements and bug fixes.
+
+### Community edition
+
+#### Improvements
+
+- Replaced MySQL Connector/J with MariaDB Connector/J due to licensing concerns. ([#3428](https://github.com/scalar-labs/scalardb/pull/3428))
+- Inserting or updating records with TIME (microsecond precision), TIMESTAMP (millisecond precision), and TIMESTAMPTZ (millisecond precision) column values will truncate out-of-range precision rather than throwing an exception. ([#3393](https://github.com/scalar-labs/scalardb/pull/3393))
+- Shortened JDBC index names using a hash when they exceed the maximum identifier length supported by the underlying database. ([#3481](https://github.com/scalar-labs/scalardb/pull/3481))
+
+#### Bug fixes
+
+- Upgraded the Netty library to fix security issues: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") and [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871") ([#3452](https://github.com/scalar-labs/scalardb/pull/3452))
+
+### Enterprise edition
+
+#### Improvements
+
+##### ScalarDB SQL
+
+- Updated the TIMESTAMPTZ literal to make optional the space character before the UTC timezone `Z` character. For example, `2021-03-04 12:30:45.123Z` is now accepted, in addition to the current format `2021-03-04 12:30:45.123 Z`. Also, when selecting a TIMESTAMPTZ column, the value is printed without a space before the `Z`.
+- Fixed an issue where the shadow jar was unnecessarily published to GitHub Packages for the CLI module.
+- Inserting or updating records with TIME (microsecond precision), TIMESTAMP (millisecond precision), and TIMESTAMPTZ (millisecond precision) column values will truncate out-of-range precision rather than throwing an exception.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix security issues: [CVE-2025-59250](https://github.com/advisories/GHSA-m494-w24q-6f7w "CVE-2025-59250") and [CVE-2026-25679](https://github.com/advisories/GHSA-j3gx-2473-5fp8 "CVE-2026-25679")
+- Upgraded the Netty library to fix security issues: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") and [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871")
+- Upgraded `grpc_health_probe` to fix a security issue: [CVE-2026-34986](https://github.com/advisories/GHSA-78h2-9frx-2jm8 "CVE-2026-34986").
+
+##### ScalarDB SQL
+
+- Fixed a bug where duplicate column names were allowed in CREATE TABLE statements.
+- Fixed missing strict date validation on time-related type formatters, which could allow invalid dates (e.g., February 30) to be silently accepted instead of rejected.
+
 ## v3.15.7
 
 **Release date:** March 6, 2026

--- a/versioned_docs/version-3.16/releases/release-notes.mdx
+++ b/versioned_docs/version-3.16/releases/release-notes.mdx
@@ -10,6 +10,55 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.16.
 
+## v3.16.5
+
+**Release date:** April 15, 2026
+
+### Summary
+
+This release includes improvements and bug fixes.
+
+### Community edition
+
+#### Improvements
+
+- Replaced MySQL Connector/J with MariaDB Connector/J due to licensing concerns. ([#3428](https://github.com/scalar-labs/scalardb/pull/3428))
+- Extended the applicability of one-phase commit optimization in the Consensus Commit protocol. This allows one-phase commit to be used even in SERIALIZABLE isolation level when the transaction only reads records that it subsequently updates, improving performance for read-modify-write workloads. ([#3295](https://github.com/scalar-labs/scalardb/pull/3295))
+- Added support for setting null values on secondary index columns in DynamoDB. When a null value is set, the attribute is removed from the item and the record will not appear in secondary index scans. ([#3326](https://github.com/scalar-labs/scalardb/pull/3326))
+- Inserting or updating records with TIME (microsecond precision), TIMESTAMP (millisecond precision), and TIMESTAMPTZ (millisecond precision) column values will truncate out-of-range precision rather than throwing an exception. ([#3393](https://github.com/scalar-labs/scalardb/pull/3393))
+- Fixed an issue where index-based Get and Scan operations in Consensus Commit could miss records in PREPARED or DELETED state, by adding before-image secondary index check. ([#3419](https://github.com/scalar-labs/scalardb/pull/3419))
+- Added support for the SERIALIZABLE isolation level for index-based Get, Scan, and ScanAll operations in Consensus Commit when before-image indexes are present. Run `repairTable()` to create before-image indexes for existing tables. ([#3463](https://github.com/scalar-labs/scalardb/pull/3463))
+- Shortened JDBC index names using a hash when they exceed the maximum identifier length supported by the underlying database. ([#3481](https://github.com/scalar-labs/scalardb/pull/3481))
+
+#### Bug fixes
+
+- Upgraded the Netty library to fix security issues: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") and [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871") ([#3452](https://github.com/scalar-labs/scalardb/pull/3452))
+- Fixed a bug where index-based Get and Scan operations could return incorrect results after lazy recovery rolled back a PREPARED record whose after-image index value matched the query but whose before-image (restored) value did not. ([#3488](https://github.com/scalar-labs/scalardb/pull/3488))
+
+### Enterprise edition
+
+#### Improvements
+
+##### ScalarDB SQL
+
+- Updated the TIMESTAMPTZ literal to make optional the space character before the UTC timezone `Z` character. For example, `2021-03-04 12:30:45.123Z` is now accepted, in addition to the current format `2021-03-04 12:30:45.123 Z`. Also, when selecting a TIMESTAMPTZ column, the value is printed without a space before the `Z`.
+- Fixed an issue where the shadow jar was unnecessarily published to GitHub Packages for the CLI module.
+- Inserting or updating records with TIME (microsecond precision), TIMESTAMP (millisecond precision), and TIMESTAMPTZ (millisecond precision) column values will truncate out-of-range precision rather than throwing an exception.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Upgraded `grpc_health_probe` to fix security issues: [CVE-2025-59250](https://github.com/advisories/GHSA-m494-w24q-6f7w "CVE-2025-59250") and [CVE-2026-25679](https://github.com/advisories/GHSA-j3gx-2473-5fp8 "CVE-2026-25679")
+- Upgraded the Netty library to fix security issues: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") and [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871")
+- Upgraded `grpc_health_probe` to fix a security issue: [CVE-2026-34986](https://github.com/advisories/GHSA-78h2-9frx-2jm8 "CVE-2026-34986").
+
+##### ScalarDB SQL
+
+- Fixed a bug where duplicate column names were allowed in CREATE TABLE statements.
+- Fixed missing strict date validation on time-related type formatters, which could allow invalid dates (e.g., February 30) to be silently accepted instead of rejected.
+
+
 ## v3.16.4
 
 **Release date:** March 6, 2026


### PR DESCRIPTION
## Description

This PR adds patch version release notes for ScalarDB 3.17, 3.16, and 3.15.

## Related issues and/or PRs

N/A

## Changes made

- Added patch version release notes for the following versions:
  - 3.17.3
  - 3.16.5
  - 3.15.8
- Updated patch versions for the `className` configurations in the Docusaurus configuration file.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A