### PR TITLE
Hide "Try now" CTA button on mobile to prevent overlapping the search area

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -820,6 +820,13 @@ html[data-theme="dark"] .notification-dropdown {
   opacity: 88%;
 }
 
+/* Hide CTA button on mobile to prevent overlapping the search button */
+@media (max-width: 996px) {
+  .navbar__link--cta {
+    display: none;
+  }
+}
+
 /* Ask AI button styles */
 .ask-ai-button {
   display: inline-flex;


### PR DESCRIPTION
## Description

This PR introduces a responsive CSS change to improve the user interface on mobile devices. Specifically, it hides the "Try now" call-to-action (CTA) button in the navbar on smaller screens to prevent it from overlapping with the search button.

## Related issues and/or PRs

N/A

## Changes made

* Added a media query to hide the `.navbar__link--cta` button on screens smaller than 996px wide to prevent UI overlap issues on mobile devices in `src/css/custom.css`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Confirmed this fix works across the following browsers: Chrome, Firefox, Edge, and Safari.