### PR TITLE
Add 3.18 release notes for ScalarDB Community and Enterprise

### DIFF
--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -12,4 +12,4 @@ This page includes a list of release notes for ScalarDB 3.18.
 
 ## v3.18.0
 
-**Release date:** April 30, 2026
+**Release date:** May 1, 2026

--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -13,3 +13,124 @@ This page includes a list of release notes for ScalarDB 3.18.
 ## v3.18.0
 
 **Release date:** May 1, 2026
+
+### Summary
+
+This release includes a lot of enhancements, improvements, security issue fixes, and bug fixes.
+
+### Community edition
+
+#### Enhancements
+
+- Added `AuthAdmin.getRole(roleName)`. ([#3238](https://github.com/scalar-labs/scalardb/pull/3238))
+- Added operation-level attributes to allow cross-partition scan, filtering, and ordering on a per-operation basis without requiring global configuration. ([#3425](https://github.com/scalar-labs/scalardb/pull/3425))
+- Added `DistributedTransactionAdmin.hasPrivilege()`. ([#3432](https://github.com/scalar-labs/scalardb/pull/3432))
+- Added `AuthenticationMethod` enum and authentication-method-aware user management APIs to `AuthAdmin` to support OIDC authentication. ([#3433](https://github.com/scalar-labs/scalardb/pull/3433))
+- Added `attributes` parameter to `DistributedTransactionManager` `begin` and `start` methods, enabling transaction-scoped attribute configuration. CRUD methods on `DistributedTransactionManager` also pass the operation's attributes to the internally begun transaction. Also added support for specifying the isolation level per transaction in Consensus Commit via the `cc-transaction-isolation` attribute. ([#3466](https://github.com/scalar-labs/scalardb/pull/3466) [#3517](https://github.com/scalar-labs/scalardb/pull/3517) [#3540](https://github.com/scalar-labs/scalardb/pull/3540))
+- Added support for Google Cloud Spanner as a JDBC storage, via its PostgreSQL-compatible dialect. ([#3510](https://github.com/scalar-labs/scalardb/pull/3510))
+
+#### Improvements
+
+- Extended the applicability of one-phase commit optimization in the Consensus Commit protocol. This allows one-phase commit to be used even in SERIALIZABLE isolation level when the transaction only reads records that it subsequently updates, improving performance for read-modify-write workloads. ([#3295](https://github.com/scalar-labs/scalardb/pull/3295))
+- Added batch execution support for mutate operations in the JDBC adapter to improve performance when executing multiple mutations. Mutations with the same SQL statement are now grouped and executed as a batch. ([#3304](https://github.com/scalar-labs/scalardb/pull/3304))
+- Migrated the JDBC adapter's connection pooling library from Apache Commons DBCP2 to HikariCP for improved performance and reliability. ([#3305](https://github.com/scalar-labs/scalardb/pull/3305))
+- Changed the behavior of Consensus Commit transactions to allow Insert/Upsert/Update operations after Delete on the same record within the same transaction. Previously, this operation threw an `IllegalArgumentException`, but now it properly handles the case by treating it as a new record insertion with null values for unspecified columns. ([#3319](https://github.com/scalar-labs/scalardb/pull/3319))
+- Added @CheckReturnValue annotation to Get/Scan builders. ([#3320](https://github.com/scalar-labs/scalardb/pull/3320))
+- Added support for setting null values on secondary index columns in DynamoDB. When a null value is set, the attribute is removed from the item and the record will not appear in secondary index scans. ([#3326](https://github.com/scalar-labs/scalardb/pull/3326))
+- Inserting or updating records with TIME (microsecond precision), TIMESTAMP (millisecond precision), and TIMESTAMPTZ (millisecond precision) column values will truncate out-of-range precision rather than throwing an exception. ([#3393](https://github.com/scalar-labs/scalardb/pull/3393))
+- Fixed a correctness issue in index-based Get, Scan, and ScanAll operations in Consensus Commit where records whose indexed column was being concurrently updated by another transaction could be missed. ScalarDB now maintains a companion before-image secondary index for each user-defined secondary index on a non-primary-key column and uses it to recover PREPARED/DELETED records during index reads. ([#3419](https://github.com/scalar-labs/scalardb/pull/3419) [#3463](https://github.com/scalar-labs/scalardb/pull/3463))
+- Replaced MySQL Connector/J with MariaDB Connector/J to resolve GPLv2 licensing concerns. ([#3428](https://github.com/scalar-labs/scalardb/pull/3428))
+- Shortened JDBC index names using a hash when they exceed the maximum identifier length supported by the underlying database. ([#3481](https://github.com/scalar-labs/scalardb/pull/3481))
+- Relaxed the BigInt value range restriction (`-2^53` to `2^53`) that previously applied to all storage backends. This restriction now only applies to Cosmos DB and Object Storage. Other backends (JDBC, Cassandra, DynamoDB) now support the full Java long range for BigInt columns. ([#3490](https://github.com/scalar-labs/scalardb/pull/3490))
+- Changed the Oracle BIGINT column type mapping from NUMBER(16) to NUMBER(19) to support the full Java long range. ([#3507](https://github.com/scalar-labs/scalardb/pull/3507))
+- Changed the deprecation policy so that APIs and configurations marked as deprecated will now be removed in 4.0.0 instead of 5.0.0. ([#3520](https://github.com/scalar-labs/scalardb/pull/3520))
+
+#### Bug fixes
+
+- Fixed option issues in Object Storage adapter. ([#3237](https://github.com/scalar-labs/scalardb/pull/3237))
+- On Oracle, when importing a table with a column using the `NUMBER(1)` data type, which is usually used for BOOLEAN data, that column can now be mapped to ScalarDB BOOLEAN using ScalarDB Schema Loader `override-columns-type` setting. ([#3239](https://github.com/scalar-labs/scalardb/pull/3239))
+- Fix to increase the maximum allowed string length with Object Storage. ([#3248](https://github.com/scalar-labs/scalardb/pull/3248))
+- Updated the upper limit value displayed in the error message for data size limitation in Object Storage adapter. ([#3264](https://github.com/scalar-labs/scalardb/pull/3264))
+- Added explicit commits for Oracle database when using SERIALIZABLE isolation level to ensure snapshot updates after each operation. ([#3294](https://github.com/scalar-labs/scalardb/pull/3294))
+- Upgraded the Jackson library to fix a security issue: [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq "GHSA-72hv-8253-57qq") ([#3394](https://github.com/scalar-labs/scalardb/pull/3394))
+- Fix `dropColumnFromTable()` dropping the secondary index even when column drop is unsupported. ([#3450](https://github.com/scalar-labs/scalardb/pull/3450))
+- Upgraded the Netty library to fix security issues: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") and [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871") ([#3452](https://github.com/scalar-labs/scalardb/pull/3452))
+- Fixed a bug where index-based Get and Scan operations could return incorrect results after lazy recovery rolled back a PREPARED record whose after-image index value matched the query but whose before-image (restored) value did not. ([#3488](https://github.com/scalar-labs/scalardb/pull/3488))
+
+### Enterprise edition
+
+#### Enhancements
+
+##### ScalarDB Cluster
+
+- Added `getRole()` API and equivalent to retrieve a single role by name.
+- Added support for starting replication with existing backup site tables.
+- Added support for the `executeBatch` API in ScalarDB Cluster SQL transactions, enabling batch execution of multiple SQL statements in a single call.
+- Added client-side optimizations for SQL transactions (piggyback_begin and write_buffering) to reduce RPC overhead between the client and the cluster.
+- Added support for configuring a separate gRPC port for the admin service by using the `scalar.db.cluster.node.admin.port` property.
+- Added `DistributedTransactionAdmin.hasPrivilege()` to check if a specified user has a specific privilege on a table.
+- Added support for the attributes parameter in transaction begin/start methods, enabling transaction-scoped configuration such as isolation level.
+- Added OIDC JWT authentication support.
+- Added ThreadLocal-based user-password authentication support via `CredentialsHolder`, allowing multiple users to share a single `TransactionManager`.
+- Added property-based OIDC JWT authentication support for the client, allowing JWT access tokens to be passed via configuration properties.
+
+##### ScalarDB SQL
+
+- Added `Metadata.getRole(roleName)`
+- Added support for Spring Boot 4 in Spring Data JDBC for ScalarDB.
+- Added support for extending `AbstractJdbcConfiguration` for custom bean configuration in Spring Data JDBC for ScalarDB.
+- Changed the `PreparedStatement` API to use `bind()` methods that return a `BoundStatement` for parameter binding, instead of directly setting values on `PreparedStatement`. Note that this is a breaking change, and users may need to update their source code accordingly.
+- Added `executeBatch` API to execute multiple statements in a single call, with support in the core SQL API, direct-mode, and JDBC driver.
+- Added support for BLOB literals using X'hex' syntax in SQL statements.
+- Added support for AuthenticationMethod in `CREATE/ALTER USER` and `SHOW USERS`
+- Added support for specifying transaction-scoped attributes in `BEGIN` and `START TRANSACTION` SQL statements using the `WITH` clause (e.g., `BEGIN WITH 'cc-transaction-isolation' = 'SNAPSHOT'`). Also added `begin(Map)`, and `beginReadOnly(Map)` methods to `SqlSession` for programmatic attribute specification.
+- Updated `SqlJdbcDatabaseMetaData.getUserName()` to return the authenticated user name via `Metadata.getCurrentUser()`.
+- Added support for specifying ABAC read and write tags in the `WITH` clause of `BEGIN` and `START TRANSACTION` statements.
+
+#### Improvements
+
+##### ScalarDB Cluster
+
+- Refactored internal auth token handling to use a type-safe class hierarchy instead of string prefix parsing.
+- Auth, ABAC, and Encryption modules no longer require `scalar.db.cross_partition_scan.enabled=true` to be enabled globally. These modules now use operation-level cross-partition scan attributes and run internal metadata transactions with Snapshot Isolation.
+- Changed the deprecation policy so that APIs marked as deprecated will now be removed in 4.0.0 instead of 5.0.0.
+
+##### ScalarDB GraphQL
+
+- Relaxed the range of values accepted by the GraphQL `BigInt` scalar to the full Java `long` range, aligning with the corresponding relaxation in ScalarDB. Backend-specific limits (Cosmos DB and Object Storage still restrict BigInt to `-2^53` to `2^53`) are now enforced by ScalarDB at the storage layer rather than by the GraphQL layer.
+
+##### ScalarDB SQL
+
+- Improve thread pool management in two-phase commit interface transaction to avoid potential starvation issues in Spring Data JDBC for ScalarDB.
+- Added one-operation mode support for one-shot query execution to improve performance by skipping explicit transaction begin/commit when the SQL query can be expressed as a single operation.
+- Inserting or updating records with TIME (microsecond precision), TIMESTAMP (millisecond precision), and TIMESTAMPTZ (millisecond precision) column values will truncate out-of-range precision rather than throwing an exception.
+- Fixed an issue where the shadow jar was unnecessarily published to GitHub Packages for the CLI module.
+- Update the TIMESTAMPTZ literal to make optional the space character before the UTC timezone `Z` character. For example, `2021-03-04 12:30:45.123Z` is now accepted, in addition to the current format `2021-03-04 12:30:45.123 Z`. Also, when selecting a TIMESTAMPTZ column, the value is printed without a space before the `Z`.
+- Refactored the SQL statement builder APIs for improved type safety and ergonomics. `SelectStatementBuilder` now enforces SQL clause ordering at the type level so that `having()` is only callable after `groupBy()`, and HAVING supports the same fluent `.and(...)` / `.or(...)` chain as WHERE; `Having.of(...)` factories have been consolidated into `Having.create(...)`; `CreateUserStatementBuilder` / `AlterUserStatementBuilder` expose explicit `withPassword()` / `withSuperuser()` / `withNoSuperuser()` methods in place of the previous overloaded `with(...)`; the `UserOption` enum has been removed in favor of a nullable `superuser` boolean on `CreateUserStatement` / `AlterUserStatement`; and `FunctionRef` now provides convenience factories (`count()`, `sum(...)`, `avg(...)`, `min(...)`, `max(...)`) for common aggregates.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Made `GRANT ROLE` command idempotent, allowing duplicate grants and upgrading to `WITH ADMIN OPTION` when re-granting.
+- Fixed a bug where ScalarDB Cluster cannot be deployed in the Omnistrate environment by upgrading `scalar-metering`.
+- Fixed a bug where the pause functionality did not work correctly when transactions expired.
+- Fixed an issue where the batch operation with piggyback commit threw `CrudException` instead of `CrudConflictException` when a commit conflict occurred. This allows clients to properly detect and handle commit conflicts.
+- Fixed a bug where `batch()` with piggyback commit threw `CrudException` instead of `UnknownTransactionStatusException` on unexpected gRPC errors. This could cause incorrect error handling on the client side, as the transaction status was actually unknown when piggyback commit was enabled.
+- Upgraded `grpc_health_probe` to fix security issues: [CVE-2025-68121](https://github.com/advisories/GHSA-h355-32pf-p2xm "CVE-2025-68121"), [CVE-2025-61726](https://github.com/advisories/GHSA-gm9r-q53w-2gh4 "CVE-2025-61726"), [CVE-2025-61728](https://github.com/advisories/GHSA-g9q4-qjx4-2v7q "CVE-2025-61728"), [CVE-2025-61729](https://github.com/advisories/GHSA-7c64-f9jr-v9h2 "CVE-2025-61729"), and [CVE-2025-61730](https://github.com/advisories/GHSA-gr56-3gp6-6gmj "CVE-2025-61730")
+- Excluded `com.microsoft.azure:adal4j` from the Kubernetes Java Client to fix security issues: [CVE-2023-52428](https://github.com/advisories/GHSA-gvpg-vgmx-xg6w "CVE-2023-52428"), [CVE-2021-31684](https://github.com/advisories/GHSA-fg2v-w576-w4v3 "CVE-2021-31684"), and [CVE-2023-1370](https://github.com/advisories/GHSA-493p-pfq6-5258 "CVE-2023-1370")
+- Upgraded the Jackson library to fix a security issue: [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq "GHSA-72hv-8253-57qq")
+- Upgraded `grpc_health_probe` to fix security issues: [CVE-2025-59250](https://github.com/advisories/GHSA-m494-w24q-6f7w "CVE-2025-59250") and [CVE-2026-25679](https://github.com/advisories/GHSA-j3gx-2473-5fp8 "CVE-2026-25679")
+- Upgraded the Netty library to fix security issues: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") and [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871")
+- Fixed a bug where one-shot batch operations bypassed pause control in the GateKept transaction managers.
+- Upgraded `grpc_health_probe` to fix a security issue: [CVE-2026-34986](https://github.com/advisories/GHSA-78h2-9frx-2jm8 "CVE-2026-34986").
+
+##### ScalarDB SQL
+
+- Ambiguous column names in ORDER BY and HAVING clauses were detected.
+- Fixed a `ClassCastException` that occurred in `StatementUtils.appendTerm()` when handling `DATE`, `TIME`, `TIMESTAMP`, and `TIMESTAMPTZ` values. These values are now correctly formatted as string literals instead of being incorrectly cast to String.
+- Fixed `SelectStatement.toSql()` to correctly generate ORDER BY clauses with aggregate functions such as `SUM()` and `COUNT()`. Previously, only column-based orderings were handled, causing incorrect SQL output when function-based orderings were used.
+- Fixed a bug where duplicate column names were allowed in CREATE TABLE statements.
+- Fixed missing strict date validation on time-related type formatters, which could allow invalid dates (e.g., February 30) to be silently accepted instead of rejected.
+- `ResultSet.getObject` on BLOB columns now returns a `java.sql.Blob`, and `ResultSet.getBlob`, `ResultSet.getBinaryStream`, and several `PreparedStatement.setBlob` / `setBinaryStream` overloads are now supported. `ResultSetMetaData.getColumnType` for FLOAT columns now returns `Types.REAL` (previously `Types.FLOAT`). `ResultSet.getString` now returns Java `null` for SQL NULL instead of the literal string `"null"`, in line with the JDBC spec. As a side effect, the SQL CLI now renders BLOB values as `X'...'` hex literals instead of `[B@xxxxxxxx`.
+- Fixed an issue where `CachedMetadata#invalidateNamespaceNamesCache()` did not actually invalidate the cached list of namespaces, causing `SHOW NAMESPACES` and related operations to potentially return stale results until the cache TTL expired.

--- a/docs/releases/release-support-policy.mdx
+++ b/docs/releases/release-support-policy.mdx
@@ -38,8 +38,8 @@ This page describes Scalar's support policy for major and minor version releases
     <tr>
       <td><a href="https://scalardb.scalar-labs.com/docs/3.17/releases/release-notes#v3170">3.17</a></td>
       <td>2025-11-26</td>
-      <td>2027-04-30</td>
-      <td>2027-10-27</td>
+      <td>2027-05-01</td>
+      <td>2027-10-28</td>
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>
     </tr>
     <tr>

--- a/docs/releases/release-support-policy.mdx
+++ b/docs/releases/release-support-policy.mdx
@@ -30,7 +30,7 @@ This page describes Scalar's support policy for major and minor version releases
   <tbody>
     <tr>
       <td><a href="https://scalardb.scalar-labs.com/docs/latest/releases/release-notes#v3180">3.18</a></td>
-      <td>2026-04-30</td>
+      <td>2026-05-01</td>
       <td>TBD*</td>
       <td>TBD*</td>
       <td><a href="https://www.scalar-labs.com/contact">Contact us</a></td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -17,3 +17,124 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 ## v3.18.0
 
 **発売日:** 2026年05月01日
+
+### まとめ
+
+このリリースには、多くの改善点、セキュリティ問題の修正、およびバグ修正が含まれています。
+
+### Community edition
+
+#### 改善点
+
+- `AuthAdmin.getRole(roleName)` を追加しました。 ([#3238](https://github.com/scalar-labs/scalardb/pull/3238))
+- 操作レベルの属性を追加し、グローバル機構を必要とせずに、操作ごとにクロスパーティションスキャン、フィルタリング、および並べ替えを許可しました。 ([#3425](https://github.com/scalar-labs/scalardb/pull/3425))
+- `DistributedTransactionAdmin.hasPrivilege()` を追加しました。 ([#3432](https://github.com/scalar-labs/scalardb/pull/3432))
+- `AuthenticationMethod` 列挙と認証方法対応のユーザー管理 API を `AuthAdmin` に追加し、OIDC 認証をサポートしました。 ([#3433](https://github.com/scalar-labs/scalardb/pull/3433))
+- `DistributedTransactionManager` の `begin` および `start` メソッドに `attributes` パラメータを追加し、トランザクションスコープの属性設定を有効にしました。また、`DistributedTransactionManager` の CRUD メソッドは、操作の属性を内部で開始されたトランザクションに渡します。また、Consensus Commit で `cc-transaction-isolation` 属性経由で、トランザクションごとに分離レベルを指定できるようになりました。 ([#3466](https://github.com/scalar-labs/scalardb/pull/3466) [#3517](https://github.com/scalar-labs/scalardb/pull/3517) [#3540](https://github.com/scalar-labs/scalardb/pull/3540))
+- Google Cloud Spanner を JDBC ストレージとして、PostgreSQL 互換方言経由でサポートを追加しました。 ([#3510](https://github.com/scalar-labs/scalardb/pull/3510))
+
+#### 改善点
+
+- Consensus Commit プロトコルでのワンフェーズコミット最適化の適用範囲を拡張しました。これにより、トランザクションが後で更新するレコードのみを読む場合、SERIALIZABLE 分離レベルでもワンフェーズコミットを使用できるようになり、読取-修正-書込ワークロードのパフォーマンスが向上します。 ([#3295](https://github.com/scalar-labs/scalardb/pull/3295))
+- JDBC アダプターで描画操作のバッチ実行サポートを追加し、複数の描画実行時のパフォーマンスを向上させました。同じ SQL ステートメントを持つ描画はグループ化され、バッチで実行されます。 ([#3304](https://github.com/scalar-labs/scalardb/pull/3304))
+- JDBC アダプターのコネクションプーリングライブラリを Apache Commons DBCP2 から HikariCP に移行し、パフォーマンスと信頼性を向上させました。 ([#3305](https://github.com/scalar-labs/scalardb/pull/3305))
+- Consensus Commit トランザクションの動作を変更し、同一トランザクション内で Delete 後に Insert/Upsert/Update 操作を許可するようにしました。以前はこれにより `IllegalArgumentException` がスローされていましたが、現在は指定されていない列に null 値を含む新しいレコード挿入として処理されます。 ([#3319](https://github.com/scalar-labs/scalardb/pull/3319))
+- Get/Scan ビルダーに @CheckReturnValue アノテーションを追加しました。 ([#3320](https://github.com/scalar-labs/scalardb/pull/3320))
+- DynamoDB でセカンダリインデックス列に null 値を設定するサポートを追加しました。null 値が設定されると、属性はアイテムから削除され、レコードはセカンダリインデックススキャンに表示されません。 ([#3326](https://github.com/scalar-labs/scalardb/pull/3326))
+- TIME (マイクロ秒精度)、TIMESTAMP (ミリ秒精度)、TIMESTAMPTZ (ミリ秒精度) 列の値を挿入または更新する際、範囲外の精度は例外をスローするのではなく切り捨てられるようになりました。 ([#3393](https://github.com/scalar-labs/scalardb/pull/3393))
+- Consensus Commit のインデックスベース Get、Scan、ScanAll 操作で、インデックス列を別のトランザクションから同時に更新されるレコードが見逃される可能性がある問題を修正しました。ScalarDB は、プライマリキー以外の列のユーザー定義セカンダリインデックスごとに companion before-image セカンダリインデックスを保持し、インデックス読取中に PREPARED/DELETED レコードを復元するために使用します。 ([#3419](https://github.com/scalar-labs/scalardb/pull/3419) [#3463](https://github.com/scalar-labs/scalardb/pull/3463))
+- MySQL Connector/J を MariaDB Connector/J に置き換え、GPLv2 ライセンスの懸念を解決しました。 ([#3428](https://github.com/scalar-labs/scalardb/pull/3428))
+- JDBC インデックス名が基盤となるデータベースでサポートされている最大識別子長を超える場合、ハッシュを使用して短縮されるようになりました。 ([#3481](https://github.com/scalar-labs/scalardb/pull/3481))
+- 以前すべてのストレージバックエンドに適用されていた BigInt 値範囲制限 (`-2^53` から `2^53`) を緩和しました。この制限は現在 Cosmos DB とオブジェクトストレージのみに適用されます。他のバックエンド (JDBC、Cassandra、DynamoDB) は BigInt 列の完全な Java long 範囲をサポートするようになりました。 ([#3490](https://github.com/scalar-labs/scalardb/pull/3490))
+- Oracle BIGINT 列型マッピングを NUMBER(16) から NUMBER(19) に変更し、完全な Java long 範囲をサポートするようにしました。 ([#3507](https://github.com/scalar-labs/scalardb/pull/3507))
+- 非推奨ポリシーを変更し、API と設定に非推奨のマーク付けされたものは 5.0.0 ではなく 4.0.0 で削除されるようになりました。 ([#3520](https://github.com/scalar-labs/scalardb/pull/3520))
+
+#### バグの修正
+
+- オブジェクトストレージアダプターのオプションの問題を修正しました。 ([#3237](https://github.com/scalar-labs/scalardb/pull/3237))
+- Oracle で `NUMBER(1)` データ型を使用する列でテーブルをインポートする場合 (通常は BOOLEAN データに使用)、その列は ScalarDB Schema Loader `override-columns-type` 設定を使用して ScalarDB BOOLEAN にマップできるようになりました。 ([#3239](https://github.com/scalar-labs/scalardb/pull/3239))
+- オブジェクトストレージで許可される最大文字列長を増加させるための修正。 ([#3248](https://github.com/scalar-labs/scalardb/pull/3248))
+- オブジェクトストレージアダプターのデータサイズ制限のエラーメッセージに表示される上限値を更新しました。 ([#3264](https://github.com/scalar-labs/scalardb/pull/3264))
+- SERIALIZABLE 分離レベルを使用する場合、Oracle データベースに対して各操作後のスナップショット更新を確保するための明示的なコミットを追加しました。 ([#3294](https://github.com/scalar-labs/scalardb/pull/3294))
+- セキュリティ問題を修正するため Jackson ライブラリをアップグレードしました: [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq "GHSA-72hv-8253-57qq") ([#3394](https://github.com/scalar-labs/scalardb/pull/3394))
+- 列削除がサポートされていない場合でも `dropColumnFromTable()` がセカンダリインデックスを削除する問題を修正しました。 ([#3450](https://github.com/scalar-labs/scalardb/pull/3450))
+- セキュリティ問題を修正するため Netty ライブラリをアップグレードしました: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") および [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871") ([#3452](https://github.com/scalar-labs/scalardb/pull/3452))
+- lazy recovery が PREPARED レコードをロールバックした後、インデックスベース Get および Scan 操作が不正確な結果を返す可能性があるバグを修正しました。after-image インデックス値がクエリに一致しても、before-image (復元された) 値が一致しない場合があります。 ([#3488](https://github.com/scalar-labs/scalardb/pull/3488))
+
+### Enterprise edition
+
+#### 改善点
+
+##### ScalarDB Cluster
+
+- `getRole()` API とその同等の API を追加し、名前で単一のロールを取得できるようにしました。
+- 既存のバックアップサイトテーブルでレプリケーションを開始するためのサポートを追加しました。
+- ScalarDB Cluster SQL トランザクションで `executeBatch` API をサポートを追加し、単一の呼び出しで複数の SQL ステートメントをバッチ実行できるようにしました。
+- SQL トランザクションのクライアント側最適化 (piggyback_begin および write_buffering) を追加し、クライアントとクラスター間の RPC オーバーヘッドを削減しました。
+- `scalar.db.cluster.node.admin.port` プロパティを使用して、admin サービス用に別の gRPC ポートを設定するサポートを追加しました。
+- `DistributedTransactionAdmin.hasPrivilege()` を追加して、指定されたユーザーがテーブルに対して特定の権限を持っているかどうかを確認できるようにしました。
+- トランザクション begin/start メソッドで attributes パラメーターのサポートを追加し、分離レベルなどのトランザクションスコープ設定を有効にしました。
+- OIDC JWT 認証サポートを追加しました。
+- `CredentialsHolder` 経由の ThreadLocal ベースのユーザーパスワード認証サポートを追加し、複数のユーザーが単一の `TransactionManager` を共有できるようにしました。
+- プロパティベースの OIDC JWT 認証サポートをクライアント用に追加し、JWT アクセストークンを設定プロパティを介して渡すことができるようにしました。
+
+##### ScalarDB SQL
+
+- `Metadata.getRole(roleName)` を追加しました。
+- Spring Data JDBC for ScalarDB で Spring Boot 4 のサポートを追加しました。
+- Spring Data JDBC for ScalarDB でカスタムビーン構成用に `AbstractJdbcConfiguration` を拡張するサポートを追加しました。
+- `PreparedStatement` API を変更し、`PreparedStatement` で直接値を設定する代わりに、`BoundStatement` を返す `bind()` メソッドを使用するように修正しました。これは重大な変更であり、ユーザーはそれに応じてソースコードを更新する必要があります。
+- `executeBatch` API を追加し、単一の呼び出しで複数のステートメントを実行できるようにしました。 core SQL API、direct-mode、JDBC ドライバーでサポートされています。
+- SQL ステートメントで X'hex' 構文を使用した BLOB リテラルのサポートを追加しました。
+- `CREATE/ALTER USER` および `SHOW USERS` での AuthenticationMethod のサポートを追加しました。
+- `BEGIN` および `START TRANSACTION` SQL ステートメントで `WITH` 句 (例: `BEGIN WITH 'cc-transaction-isolation' = 'SNAPSHOT'`) を使用してトランザクションスコープ属性を指定するサポートを追加しました。また、プログラマティック属性指定用に `SqlSession` に `begin(Map)` および `beginReadOnly(Map)` メソッドを追加しました。
+- `SqlJdbcDatabaseMetaData.getUserName()` を更新し、`Metadata.getCurrentUser()` 経由で認証されたユーザー名を返すようにしました。
+- `BEGIN` および `START TRANSACTION` ステートメントの `WITH` 句で ABAC 読取および書込タグを指定するサポートを追加しました。
+
+#### 改善点
+
+##### ScalarDB Cluster
+
+- 内部認証トークン処理をリファクタリングし、文字列プレフィックス解析の代わりに型安全なクラス階層を使用するようにしました。
+- Auth、ABAC、Encryption モジュールは、グローバルに `scalar.db.cross_partition_scan.enabled=true` を有効にする必要がなくなりました。これらのモジュールは操作レベルのクロスパーティションスキャン属性を使用し、Snapshot Isolation で内部メタデータトランザクションを実行するようになりました。
+- 非推奨ポリシーを変更し、非推奨のマーク付けされた API は 5.0.0 ではなく 4.0.0 で削除されるようになりました。
+
+##### ScalarDB GraphQL
+
+- GraphQL `BigInt` スカラーが受け入れる値の範囲を緩和し、完全な Java `long` 範囲にしました。バックエンド固有の制限 (Cosmos DB とオブジェクトストレージは引き続き BigInt を `-2^53` から `2^53` に制限) は、GraphQL レイヤーではなく ScalarDB ストレージレイヤーで適用されるようになりました。
+
+##### ScalarDB SQL
+
+- 二段階コミットインターフェーストランザクション内のスレッドプール管理を改善し、Spring Data JDBC for ScalarDB での潜在的なスターベーション問題を回避しました。
+- ワンショットクエリ実行用のワン操作モードサポートを追加し、SQL クエリを単一操作として表現できる場合は明示的なトランザクション begin/commit をスキップしてパフォーマンスを向上させました。
+- TIME (マイクロ秒精度)、TIMESTAMP (ミリ秒精度)、TIMESTAMPTZ (ミリ秒精度) 列の値を挿入または更新する際、範囲外の精度は例外をスローするのではなく切り捨てられるようになりました。
+- CLI モジュール用の shadow jar が不必要に GitHub Packages に公開される問題を修正しました。
+- TIMESTAMPTZ リテラルを更新し、UTC タイムゾーン `Z` 文字の前のスペース文字をオプションにしました。例えば、`2021-03-04 12:30:45.123Z` が現在の形式 `2021-03-04 12:30:45.123 Z` に加えて受け入れられるようになりました。また、TIMESTAMPTZ 列を選択する際、値は `Z` の前にスペースを入れずに表示されます。
+- SQL ステートメントビルダー API をリファクタリングし、型安全性とエルゴノミクスを改善しました。`SelectStatementBuilder` は SQL 句の順序を型レベルで強制するようになり、`having()` は `groupBy()` の後にのみ呼び出し可能になります。また HAVING は WHERE と同じ流暢な `.and(...)` / `.or(...)` チェーンをサポートします。`Having.of(...)` ファクトリーが `Having.create(...)` に統合されました。`CreateUserStatementBuilder` / `AlterUserStatementBuilder` は、前述のオーバーロードされた `with(...)` に代わって、明示的な `withPassword()` / `withSuperuser()` / `withNoSuperuser()` メソッドが公開されます。`UserOption` 列挙型が削除され、`CreateUserStatement` / `AlterUserStatement` の nullable `superuser` ブール値に置き換わりました。`FunctionRef` は一般的な集計用の便利なファクトリー (`count()`、`sum(...)`、`avg(...)`、`min(...)`、`max(...)`) を提供するようになりました。
+
+#### バグの修正
+
+##### ScalarDB Cluster
+
+- `GRANT ROLE` コマンドをべき等にしました。重複する付与を許可し、再付与時に `WITH ADMIN OPTION` にアップグレードされるようになりました。
+- `scalar-metering` をアップグレードして、ScalarDB Cluster が Omnistrate 環境にデプロイされない問題を修正しました。
+- トランザクションの有効期限が切れた場合に一時停止機能が正しく機能しなかったバグを修正しました。
+- piggyback commit を使用したバッチ操作が、コミット競合が発生した場合に `CrudException` の代わりに `CrudConflictException` をスローする問題を修正しました。これにより、クライアントがコミット競合を適切に検出して処理できるようになります。
+- piggyback commit を使用した `batch()` が予期しない gRPC エラーで `CrudException` の代わりに `UnknownTransactionStatusException` をスローするバグを修正しました。piggyback commit が有効な場合、トランザクションステータスが実際には不明であるにもかかわらず、これがクライアント側で誤ったエラー処理を引き起こす可能性がありました。
+- セキュリティ問題を修正するため `grpc_health_probe` をアップグレードしました: [CVE-2025-68121](https://github.com/advisories/GHSA-h355-32pf-p2xm "CVE-2025-68121")、[CVE-2025-61726](https://github.com/advisories/GHSA-gm9r-q53w-2gh4 "CVE-2025-61726")、[CVE-2025-61728](https://github.com/advisories/GHSA-g9q4-qjx4-2v7q "CVE-2025-61728")、[CVE-2025-61729](https://github.com/advisories/GHSA-7c64-f9jr-v9h2 "CVE-2025-61729")、および [CVE-2025-61730](https://github.com/advisories/GHSA-gr56-3gp6-6gmj "CVE-2025-61730")
+- Kubernetes Java Client から `com.microsoft.azure:adal4j` を除外してセキュリティ問題を修正しました: [CVE-2023-52428](https://github.com/advisories/GHSA-gvpg-vgmx-xg6w "CVE-2023-52428")、[CVE-2021-31684](https://github.com/advisories/GHSA-fg2v-w576-w4v3 "CVE-2021-31684")、および [CVE-2023-1370](https://github.com/advisories/GHSA-493p-pfq6-5258 "CVE-2023-1370")
+- セキュリティ問題を修正するため Jackson ライブラリをアップグレードしました: [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq "GHSA-72hv-8253-57qq")
+- セキュリティ問題を修正するため `grpc_health_probe` をアップグレードしました: [CVE-2025-59250](https://github.com/advisories/GHSA-m494-w24q-6f7w "CVE-2025-59250") および [CVE-2026-25679](https://github.com/advisories/GHSA-j3gx-2473-5fp8 "CVE-2026-25679")
+- セキュリティ問題を修正するため Netty ライブラリをアップグレードしました: [CVE-2026-33870](https://github.com/advisories/GHSA-pwqr-wmgm-9rr8 "CVE-2026-33870") および [CVE-2026-33871](https://github.com/advisories/GHSA-w9fj-cfpg-grvv "CVE-2026-33871")
+- ワンショットバッチ操作が GateKept トランザクションマネージャーで一時停止制御をバイパスするバグを修正しました。
+- セキュリティ問題を修正するため `grpc_health_probe` をアップグレードしました: [CVE-2026-34986](https://github.com/advisories/GHSA-78h2-9frx-2jm8 "CVE-2026-34986")
+
+##### ScalarDB SQL
+
+- ORDER BY および HAVING 句で曖昧な列名が検出されました。
+- `StatementUtils.appendTerm()` で `DATE`、`TIME`、`TIMESTAMP`、および `TIMESTAMPTZ` の値を処理する際に発生していた `ClassCastException` を修正しました。これらの値は、String に誤ってキャストされるのではなく、文字列リテラルとして正しくフォーマットされるようになりました。
+- `SelectStatement.toSql()` を修正し、`SUM()` および `COUNT()` などの集計関数を使用した ORDER BY 句を正しく生成するようにしました。以前は列ベースの順序付けのみが処理され、関数ベースの順序付けが使用される場合に不正な SQL 出力が生成されていました。
+- CREATE TABLE ステートメントで重複する列名が許可されるバグを修正しました。
+- 時間関連の型フォーマッターで厳密な日付検証が欠落していた問題を修正しました。これにより、無効な日付 (例: 2月30日) が拒否されずに静かに受け入れられる可能性がありました。
+- `ResultSet.getObject` は BLOB 列で `java.sql.Blob` を返すようになり、`ResultSet.getBlob`、`ResultSet.getBinaryStream`、および複数の `PreparedStatement.setBlob` / `setBinaryStream` オーバーロードがサポートされるようになりました。`ResultSetMetaData.getColumnType` は FLOAT 列で `Types.REAL` (以前は `Types.FLOAT`) を返すようになりました。`ResultSet.getString` は JDBC 仕様に準拠して、SQL NULL に対してリテラル文字列 `"null"` ではなく Java `null` を返すようになりました。付随的な効果として、SQL CLI は BLOB 値を `[B@xxxxxxxx` ではなく `X'...'` 16進リテラルとしてレンダリングします。
+- `CachedMetadata#invalidateNamespaceNamesCache()` が実際に名前空間のキャッシュリストを無効にしなかった問題を修正しました。これにより `SHOW NAMESPACES` および関連操作がキャッシュ TTL が期限切れになるまで古い結果を返す可能性がありました。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -16,4 +16,4 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 ## v3.18.0
 
-**発売日:** 2026年4月30日
+**発売日:** 2026年05月01日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
@@ -34,7 +34,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
   <tbody>
     <tr>
       <td><a href="https://scalardb.scalar-labs.com/ja-jp/docs/latest/releases/release-notes#v3180">3.18</a></td>
-      <td>2026-04-30</td>
+      <td>2026-05-01</td>
       <td>TBD*</td>
       <td>TBD*</td>
       <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
@@ -42,8 +42,8 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
     <tr>
       <td><a href="https://scalardb.scalar-labs.com/ja-jp/docs/3.17/releases/release-notes#v3170">3.17</a></td>
       <td>2025-11-26</td>
-      <td>2027-04-30</td>
-      <td>2027-10-27</td>
+      <td>2027-05-01</td>
+      <td>2027-10-28</td>
       <td><a href="https://www.scalar-labs.com/contact">お問い合わせ</a></td>
     </tr>
     <tr>


### PR DESCRIPTION
## Description

This PR updates the release notes for ScalarDB 3.18 (Community and Enterprise editions) It also updates the support policy table to reflect the new release and support dates.

## Related issues and/or PRs

N/A

## Changes made

* Added release notes for version 3.18 of ScalarDB Community and Enterprise.
* Updated the release date for ScalarDB 3.18.0 from April 30, 2026, to May 1, 2026, in both the release notes and the release support policy documentation.
* Adjusted support and end-of-life dates for versions 3.17 and 3.18 in the release support policy table.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A