### PR TITLE
Add release notes for ScalarDB Analytics

### DIFF
--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -134,3 +134,27 @@ This release includes a lot of enhancements, improvements, security issue fixes,
 - Fixed missing strict date validation on time-related type formatters, which could allow invalid dates (e.g., February 30) to be silently accepted instead of rejected.
 - `ResultSet.getObject` on BLOB columns now returns a `java.sql.Blob`, and `ResultSet.getBlob`, `ResultSet.getBinaryStream`, and several `PreparedStatement.setBlob` / `setBinaryStream` overloads are now supported. `ResultSetMetaData.getColumnType` for FLOAT columns now returns `Types.REAL` (previously `Types.FLOAT`). `ResultSet.getString` now returns Java `null` for SQL NULL instead of the literal string `"null"`, in line with the JDBC spec. As a side effect, the SQL CLI now renders BLOB values as `X'...'` hex literals instead of `[B@xxxxxxxx`.
 - Fixed an issue where `CachedMetadata#invalidateNamespaceNamesCache()` did not actually invalidate the cached list of namespaces, causing `SHOW NAMESPACES` and related operations to potentially return stale results until the cache TTL expired.
+
+### ScalarDB Analytics
+
+### Enhancements
+
+- Password authentication with access token support.
+- Internal user directory management.
+- gRPC authentication interceptor.
+- SDK and CLI authentication with token caching.
+- Spark data source authentication support.
+- ScalarDB Cluster password authentication backend.
+- gRPC retry with exponential backoff for Client SDK.
+
+### Improvements
+
+- Set scan fetch size to 4096 for JDBC and ScalarDB data sources.
+
+### Breaking changes
+
+- Unify ScalarDB namespace to `scalardb_analytics` and add domain prefixes to table names (`registry_`, `auth_`) to avoid PostgreSQL identifier length limits.
+
+### Bug fixes
+
+- Use TIMESTAMPTZ instead of TIMESTAMP for temporal columns.

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -24,7 +24,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 ### Community edition
 
-#### 改善点
+#### 機能強化
 
 - `AuthAdmin.getRole(roleName)` を追加しました。 ([#3238](https://github.com/scalar-labs/scalardb/pull/3238))
 - 操作レベルの属性を追加し、グローバル機構を必要とせずに、操作ごとにクロスパーティションスキャン、フィルタリング、および並べ替えを許可しました。 ([#3425](https://github.com/scalar-labs/scalardb/pull/3425))

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -138,3 +138,27 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - 時間関連の型フォーマッターで厳密な日付検証が欠落していた問題を修正しました。これにより、無効な日付 (例: 2月30日) が拒否されずに静かに受け入れられる可能性がありました。
 - `ResultSet.getObject` は BLOB 列で `java.sql.Blob` を返すようになり、`ResultSet.getBlob`、`ResultSet.getBinaryStream`、および複数の `PreparedStatement.setBlob` / `setBinaryStream` オーバーロードがサポートされるようになりました。`ResultSetMetaData.getColumnType` は FLOAT 列で `Types.REAL` (以前は `Types.FLOAT`) を返すようになりました。`ResultSet.getString` は JDBC 仕様に準拠して、SQL NULL に対してリテラル文字列 `"null"` ではなく Java `null` を返すようになりました。付随的な効果として、SQL CLI は BLOB 値を `[B@xxxxxxxx` ではなく `X'...'` 16進リテラルとしてレンダリングします。
 - `CachedMetadata#invalidateNamespaceNamesCache()` が実際に名前空間のキャッシュリストを無効にしなかった問題を修正しました。これにより `SHOW NAMESPACES` および関連操作がキャッシュ TTL が期限切れになるまで古い結果を返す可能性がありました。
+
+### ScalarDB Analytics
+
+### 機能強化
+
+- パスワード認証とアクセストークンのサポート。
+- 内部ユーザーディレクトリの管理。
+- gRPC 認証インターセプター。
+- SDK および CLI のトークンキャッシュを使用した認証。
+- Spark データソースの認証サポート。
+- ScalarDB クラスターのパスワード認証バックエンド。
+- Client SDK の gRPC リトライと指数バックオフ。
+
+### 改善点
+
+- JDBC および ScalarDB データソースのスキャンフェッチサイズを 4096 に設定。
+
+### 破壊的変更
+
+- ScalarDB の名前空間を `scalardb_analytics` に統一し、テーブル名にドメインプレフィックス (`registry_`、`auth_`) を追加して、PostgreSQL の識別子長制限を回避。
+
+### バグの修正
+
+- 時間関連の列に対して TIMESTAMPTZ を使用するように変更。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.14/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.14/releases/release-notes.mdx
@@ -234,3 +234,13 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - セキュリティ問題を修正するため、`grpc_health_probe` をアップグレードしました。[CVE-2024-34156](https://github.com/advisories/GHSA-crqm-pwhx-j97f "CVE-2024-34156")
 - セキュリティ問題を修正するため、`scalar-admin` をアップグレードしました。[CVE-2024-25638](https://github.com/advisories/GHSA-cfxw-4h78-h7fw "CVE-2024-25638")
 - セキュリティ問題を修正するため、Protobuf Java ライブラリをアップグレードしました。[CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8 "CVE-2024-7254")
+
+### ScalarDB Analytics
+
+ScalarDB Analytics の初回リリース。
+
+### 機能強化
+
+- Spark カタログの統合による外部データソースのクエリサポート。
+- ScalarDB データソースのサポート。
+- ビューのサポート。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.15/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.15/releases/release-notes.mdx
@@ -285,3 +285,20 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 - [Spring Data JDBC For ScalarDB] `existsById()` API が動作しないバグを修正しました
 - SQL ステートメントパーサーが INT 型および BIGINT 型の列の負の数値リテラルを拒否する問題を修正しました。
+
+## v3.15.0
+
+### ScalarDB Analytics
+
+#### 機能強化
+
+- ScalarDB の時間関連の型のサポート。
+- DynamoDB データソース。
+
+#### 改善点
+
+- クエリごとにログファイルにクエリイベントを蓄積するようになりました。
+
+#### バグの修正
+
+- 重複したカタログの初期化によるエラーを回避しました。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.16/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.16/releases/release-notes.mdx
@@ -156,6 +156,18 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - セキュリティ問題を修正するために gRPC ライブラリをアップグレードしました。[CVE-2025-55163](https://github.com/advisories/GHSA-prj3-ccx8-p6x4 "CVE-2025-55163")
 - セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました: [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3 "CVE-2025-47907")、[CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27 "CVE-2025-58183")、[CVE-2025-58186](https://github.com/advisories/GHSA-rjcg-56ph-3qvg "CVE-2025-58186")、[CVE-2025-58187](https://github.com/advisories/GHSA-frhw-mqj2-wxw2 "CVE-2025-58187")、および [CVE-2025-58188](https://github.com/advisories/GHSA-7wwx-xj66-r44x "CVE-2025-58188")。
 
+### ScalarDB Analytics
+
+#### 機能強化
+
+- AWS Marketplace との統合を備えたメータリングサービス。
+
+#### バグの修正
+
+- Databricks および Snowflake プロバイダーのデシリアライズを修正しました。
+- Databricks JDBC ダイアレクトの登録が不足していた問題を修正しました。
+- メータリングコレクターの TLS サポートを追加しました。
+
 ## v3.16.1
 
 **発売日:** 2025年07月16日
@@ -184,6 +196,13 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - ABAC が有効な場合に、ABAC ポリシーが設定されていないテーブルで put 操作を実行すると `UnsupportedOperationException` がスローされるバグを修正しました。
 - セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました。[CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874")
 - ワンフェーズコミット最適化が有効な場合にレプリケーション機能が開始されないようにバリデーションを追加しました。
+
+### ScalarDB Analytics
+
+#### 機能強化
+
+- PAYG サポート用の Spark リソース使用量収集モジュール。
+- クライアント Fat Jar サポート。
 
 ## v3.16.0
 
@@ -263,3 +282,18 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - スーパーユーザーが存在しないユーザーに対して ABAC 管理操作を実行できるバグを修正しました。
 - 空の ABAC システムテーブルを削除する際にテーブルが見つからないエラーが発生するバグを修正しました。
 - コーディネーターグループコミット機能が有効なときのメモリリークの問題を修正しました。
+
+### ScalarDB Analytics
+
+#### 機能強化
+
+- gRPC カタログサーバー（クライアント-サーバーアーキテクチャ）。
+- カタログサーバー用のコマンドラインクライアント。
+- Snowflake データソース。
+- Databricks データソース。
+
+#### バグの修正
+
+- MySQL データソース: 設定されたデータベースのテーブルのみを解決するように修正しました。
+- SQL Server データソース: 設定されたデータベースのスキーマのみを解決するように修正しました。
+- Databricks データソース: サポートされていない "interval" 型のマッピングを修正しました。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.17/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.17/releases/release-notes.mdx
@@ -146,6 +146,12 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - トランザクションが期限切れになった際にポーズ機能が正しく動作しないバグを修正しました。
 - scalar-metering をアップグレードすることで、ScalarDB Cluster が Omnistrate 環境にデプロイできないバグを修正しました。
 
+### ScalarDB Analytics
+
+#### バグの修正
+
+- Azure Synapse Analytics との互換性のためのリロケーションルールを追加しました。
+
 ## v3.17.0
 
 **発売日:** 2025年11月26日
@@ -250,3 +256,27 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - ワンフェーズコミット最適化が有効な場合にレプリケーション機能が開始されないようにバリデーションを追加しました。
 - 重複する列名が存在する場合に SQL API の `ResultSet` が不正な結果を返すバグを修正しました。
 - セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました: [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3 "CVE-2025-47907")、[CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27 "CVE-2025-58183")、[CVE-2025-58186](https://github.com/advisories/GHSA-rjcg-56ph-3qvg "CVE-2025-58186")、[CVE-2025-58187](https://github.com/advisories/GHSA-frhw-mqj2-wxw2 "CVE-2025-58187")、および [CVE-2025-58188](https://github.com/advisories/GHSA-7wwx-xj66-r44x "CVE-2025-58188")。
+
+### ScalarDB Analytics
+
+#### 機能強化
+
+- プログラムによるサーバーアクセスのための Java クライアント SDK。
+- `${file:...}` 構文を使用したプロバイダー JSON 内のファイル参照の置換。
+- CLI およびサーバー用のマルチプラットフォーム Docker イメージ (ARM64/AMD64)。
+- 統合テストのためのデータベースバージョンのカバレッジを拡大。
+
+#### 改善点
+
+- Spark モジュールを Scala に移行し、Client SDK 統合および Maven Central への公開を行いました。
+- サーバーのデータベースアクセスを ScalarDB SQL に移行しました。
+- クライアント側モジュール (SDK、gRPC) の Java 8 互換性を向上させました。
+- 将来のプラグインサポートのためにデータソースプロバイダーのアーキテクチャをリファクタリングしました。
+- CLI のデータソース登録コマンドの一貫性を他のサブコマンドと改善しました。
+- ScalarDB プロバイダーがファイルパスではなく埋め込みマップとして構成を受け取るように変更しました。
+- ビュー機能を削除しました。
+
+#### バグの修正
+
+- 名前空間が空の場合にデータソースの削除が失敗する問題を修正しました。
+- システムユーザーの Oracle スキーマ解決ルールを修正しました。

--- a/versioned_docs/version-3.14/releases/release-notes.mdx
+++ b/versioned_docs/version-3.14/releases/release-notes.mdx
@@ -230,3 +230,13 @@ This release includes a lot of enhancements, improvements, bug fixes, and vulner
 - Upgraded `grpc_health_probe` to fix a security issue. [CVE-2024-34156](https://github.com/advisories/GHSA-crqm-pwhx-j97f "CVE-2024-34156")
 - Upgraded `scalar-admin` to fix a security issue. [CVE-2024-25638](https://github.com/advisories/GHSA-cfxw-4h78-h7fw "CVE-2024-25638")
 - Upgraded the Protobuf Java library to fix a security issue. [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8 "CVE-2024-7254")
+
+### ScalarDB Analytics
+
+Initial release of ScalarDB Analytics.
+
+### Enhancements
+
+- Spark catalog integration for querying external data sources.
+- ScalarDB data source support.
+- View support.

--- a/versioned_docs/version-3.15/releases/release-notes.mdx
+++ b/versioned_docs/version-3.15/releases/release-notes.mdx
@@ -281,3 +281,20 @@ This release includes numerous enhancements, improvements, and bug fixes. The [3
 
 - [Spring Data JDBC For ScalarDB] Fixed a bug `existsById()` API not working
 - Fix an issue causing the SQL statement parser to reject negative numeric literal for columns of type INT and BIGINT.
+
+## v3.15.0
+
+### ScalarDB Analytics
+
+#### Enhancements
+
+- ScalarDB time-related types support.
+- DynamoDB data source.
+
+#### Improvements
+
+- Accumulate query events into log file per query.
+
+#### Bug fixes
+
+- Avoid error due to duplicate catalog initialization.

--- a/versioned_docs/version-3.16/releases/release-notes.mdx
+++ b/versioned_docs/version-3.16/releases/release-notes.mdx
@@ -153,6 +153,18 @@ This release includes several bug fixes and vulnerability fixes.
 - Upgraded the gRPC library to fix a security issue. [CVE-2025-55163](https://github.com/advisories/GHSA-prj3-ccx8-p6x4 "CVE-2025-55163")
 - Upgraded `grpc_health_probe` to fix security issues: [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3 "CVE-2025-47907"), [CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27 "CVE-2025-58183"), [CVE-2025-58186](https://github.com/advisories/GHSA-rjcg-56ph-3qvg "CVE-2025-58186"), [CVE-2025-58187](https://github.com/advisories/GHSA-frhw-mqj2-wxw2 "CVE-2025-58187"), and [CVE-2025-58188](https://github.com/advisories/GHSA-7wwx-xj66-r44x "CVE-2025-58188").
 
+### ScalarDB Analytics
+
+#### Enhancements
+
+- Metering service with AWS Marketplace integration.
+
+#### Bug fixes
+
+- Fix deserialization for Databricks and Snowflake providers.
+- Add missing Databricks JDBC dialect registration.
+- Add TLS support for metering collector.
+
 ## v3.16.1
 
 **Release date:** July 16, 2025
@@ -181,6 +193,13 @@ This release includes several bug fixes and vulnerability fixes.
 - Fixed a bug where an `UnsupportedOperationException` was thrown when executing put operations on tables without ABAC policies, when ABAC was enabled.
 - Upgraded `grpc_health_probe` to fix a security issue. [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874")
 - Added validation to prevent the replication feature from starting if the one-phase commit optimization is enabled.
+
+### ScalarDB Analytics
+
+#### Enhancements
+
+- Spark resource usage collection module for PAYG support.
+- Client fat jar support.
 
 ## v3.16.0
 
@@ -260,3 +279,18 @@ This release includes many enhancements, improvements, bug fixes, and performanc
 - Fixed a bug that allowed superusers to execute ABAC administrative operations for non-existing users.
 - Fixed a bug a table-not-found error occurs when dropping empty ABAC system tables.
 - Fixed a memory leak issue when the coordinator group commit feature is enabled.
+
+### ScalarDB Analytics
+
+#### Enhancements
+
+- gRPC catalog server with client-server architecture.
+- Command line client for catalog server.
+- Snowflake data source.
+- Databricks data source.
+
+#### Bug fixes
+
+- MySQL data source: only resolve tables of configured database.
+- SQL Server data source: only resolve schemas of configured database.
+- Databricks data source: fix type mapping for unsupported "interval" types.

--- a/versioned_docs/version-3.17/releases/release-notes.mdx
+++ b/versioned_docs/version-3.17/releases/release-notes.mdx
@@ -142,6 +142,12 @@ This release mainly consists of several minor bug fixes and small improvements.
 - Fixed a bug where the pause functionality did not work correctly when transactions expired.
 - Fixed a bug where ScalarDB Cluster cannot be deployed in the Omnistrate environment by upgrading scalar-metering.
 
+### ScalarDB Analytics
+
+#### Bug fixes
+
+- Added relocation rules for Azure Synapse Analytics compatibility.
+
 ## v3.17.0
 
 **Release date:** November 26, 2025
@@ -241,9 +247,33 @@ This release includes many enhancements, improvements, security issue fixes, and
 
 - Fixed a bug where the data tag was updated even when it was not specified in update or upsert operations.
 - Added missing metrics for the remote replication features.
-- Released missing Jar file of `replication-cli`
+- Released missing Jar file of `replication-cli`.
 - Fixed a bug where an `UnsupportedOperationException` was thrown when executing put operations on tables without ABAC policies, when ABAC was enabled.
 - Upgraded `grpc_health_probe` to fix a security issue. [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874")
 - Added validation to prevent the replication feature from starting if the one-phase commit optimization is enabled
 - Fixed a bug where `ResultSet` in SQL API returned incorrect results when duplicate column names were present.
 - Upgraded `grpc_health_probe` to fix security issues: [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3 "CVE-2025-47907"), [CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27 "CVE-2025-58183"), [CVE-2025-58186](https://github.com/advisories/GHSA-rjcg-56ph-3qvg "CVE-2025-58186"), [CVE-2025-58187](https://github.com/advisories/GHSA-frhw-mqj2-wxw2 "CVE-2025-58187"), and [CVE-2025-58188](https://github.com/advisories/GHSA-7wwx-xj66-r44x "CVE-2025-58188").
+
+### ScalarDB Analytics
+
+#### Enhancements
+
+- Java Client SDK for programmatic server access.
+- File reference substitution in provider JSON using `${file:...}` syntax.
+- Multi-platform Docker images (ARM64/AMD64) for CLI and server.
+- Expanded database version coverage for integration tests.
+
+#### Improvements
+
+- Migrated Spark modules to Scala with Client SDK integration and Maven Central publishing.
+- Migrated server database access to ScalarDB SQL.
+- Improved Java 8 compatibility for client-side modules (SDK, gRPC).
+- Refactored data source provider architecture for future plugin support.
+- Improved CLI data source register command consistency with other subcommands.
+- Changed ScalarDB provider to take configuration as an embedded map instead of a file path.
+- Removed view feature.
+
+#### Bug fixes
+
+- Fixed data source deletion failing when namespaces are empty.
+- Fixed Oracle schema resolution rule for system users.


### PR DESCRIPTION
## Description

This PR adds release notes for ScalarDB Analytics, covering versions 3.14 through 3.18.

## Related issues and/or PRs

N/A

## Changes made

- Added release notes for ScalarDB Analytics in both English and Japanese for the following versions:
  - 3.14.0
  - 3.15.0
  - 3.16.0
  - 3.16.1
  - 3.16.2
  - 3.17.0
  - 3.17.1
  - 3.18.0

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A