### PR TITLE
Add "Enterprise Options" as heading in release notes

### DIFF
--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -135,9 +135,11 @@ This release includes a lot of enhancements, improvements, security issue fixes,
 - `ResultSet.getObject` on BLOB columns now returns a `java.sql.Blob`, and `ResultSet.getBlob`, `ResultSet.getBinaryStream`, and several `PreparedStatement.setBlob` / `setBinaryStream` overloads are now supported. `ResultSetMetaData.getColumnType` for FLOAT columns now returns `Types.REAL` (previously `Types.FLOAT`). `ResultSet.getString` now returns Java `null` for SQL NULL instead of the literal string `"null"`, in line with the JDBC spec. As a side effect, the SQL CLI now renders BLOB values as `X'...'` hex literals instead of `[B@xxxxxxxx`.
 - Fixed an issue where `CachedMetadata#invalidateNamespaceNamesCache()` did not actually invalidate the cached list of namespaces, causing `SHOW NAMESPACES` and related operations to potentially return stale results until the cache TTL expired.
 
-### ScalarDB Analytics
+### Enterprise Options
 
-### Enhancements
+#### ScalarDB Analytics
+
+#### Enhancements
 
 - Password authentication with access token support.
 - Internal user directory management.
@@ -147,14 +149,14 @@ This release includes a lot of enhancements, improvements, security issue fixes,
 - ScalarDB Cluster password authentication backend.
 - gRPC retry with exponential backoff for Client SDK.
 
-### Improvements
+#### Improvements
 
 - Set scan fetch size to 4096 for JDBC and ScalarDB data sources.
 
-### Breaking changes
+#### Breaking changes
 
 - Unify ScalarDB namespace to `scalardb_analytics` and add domain prefixes to table names (`registry_`, `auth_`) to avoid PostgreSQL identifier length limits.
 
-### Bug fixes
+#### Bug fixes
 
 - Use TIMESTAMPTZ instead of TIMESTAMP for temporal columns.

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -139,9 +139,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - `ResultSet.getObject` は BLOB 列で `java.sql.Blob` を返すようになり、`ResultSet.getBlob`、`ResultSet.getBinaryStream`、および複数の `PreparedStatement.setBlob` / `setBinaryStream` オーバーロードがサポートされるようになりました。`ResultSetMetaData.getColumnType` は FLOAT 列で `Types.REAL` (以前は `Types.FLOAT`) を返すようになりました。`ResultSet.getString` は JDBC 仕様に準拠して、SQL NULL に対してリテラル文字列 `"null"` ではなく Java `null` を返すようになりました。付随的な効果として、SQL CLI は BLOB 値を `[B@xxxxxxxx` ではなく `X'...'` 16進リテラルとしてレンダリングします。
 - `CachedMetadata#invalidateNamespaceNamesCache()` が実際に名前空間のキャッシュリストを無効にしなかった問題を修正しました。これにより `SHOW NAMESPACES` および関連操作がキャッシュ TTL が期限切れになるまで古い結果を返す可能性がありました。
 
-### ScalarDB Analytics
+### Enterprise Options
 
-### 機能強化
+#### ScalarDB Analytics
+
+#### 機能強化
 
 - パスワード認証とアクセストークンのサポート。
 - 内部ユーザーディレクトリの管理。
@@ -151,14 +153,14 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - ScalarDB クラスターのパスワード認証バックエンド。
 - Client SDK の gRPC リトライと指数バックオフ。
 
-### 改善点
+#### 改善点
 
 - JDBC および ScalarDB データソースのスキャンフェッチサイズを 4096 に設定。
 
-### 破壊的変更
+#### 破壊的変更
 
 - ScalarDB の名前空間を `scalardb_analytics` に統一し、テーブル名にドメインプレフィックス (`registry_`、`auth_`) を追加して、PostgreSQL の識別子長制限を回避。
 
-### バグの修正
+#### バグの修正
 
 - 時間関連の列に対して TIMESTAMPTZ を使用するように変更。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.14/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.14/releases/release-notes.mdx
@@ -235,11 +235,13 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - セキュリティ問題を修正するため、`scalar-admin` をアップグレードしました。[CVE-2024-25638](https://github.com/advisories/GHSA-cfxw-4h78-h7fw "CVE-2024-25638")
 - セキュリティ問題を修正するため、Protobuf Java ライブラリをアップグレードしました。[CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8 "CVE-2024-7254")
 
-### ScalarDB Analytics
+### Enterprise Options
+
+#### ScalarDB Analytics
 
 ScalarDB Analytics の初回リリース。
 
-### 機能強化
+#### 機能強化
 
 - Spark カタログの統合による外部データソースのクエリサポート。
 - ScalarDB データソースのサポート。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.15/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.15/releases/release-notes.mdx
@@ -288,17 +288,19 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 ## v3.15.0
 
-### ScalarDB Analytics
+### Enterprise Options
 
-#### 機能強化
+#### ScalarDB Analytics
+
+##### 機能強化
 
 - ScalarDB の時間関連の型のサポート。
 - DynamoDB データソース。
 
-#### 改善点
+##### 改善点
 
 - クエリごとにログファイルにクエリイベントを蓄積するようになりました。
 
-#### バグの修正
+##### バグの修正
 
 - 重複したカタログの初期化によるエラーを回避しました。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.16/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.16/releases/release-notes.mdx
@@ -156,13 +156,15 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - セキュリティ問題を修正するために gRPC ライブラリをアップグレードしました。[CVE-2025-55163](https://github.com/advisories/GHSA-prj3-ccx8-p6x4 "CVE-2025-55163")
 - セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました: [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3 "CVE-2025-47907")、[CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27 "CVE-2025-58183")、[CVE-2025-58186](https://github.com/advisories/GHSA-rjcg-56ph-3qvg "CVE-2025-58186")、[CVE-2025-58187](https://github.com/advisories/GHSA-frhw-mqj2-wxw2 "CVE-2025-58187")、および [CVE-2025-58188](https://github.com/advisories/GHSA-7wwx-xj66-r44x "CVE-2025-58188")。
 
-### ScalarDB Analytics
+### Enterprise Options
 
-#### 機能強化
+#### ScalarDB Analytics
+
+##### 機能強化
 
 - AWS Marketplace との統合を備えたメータリングサービス。
 
-#### バグの修正
+##### バグの修正
 
 - Databricks および Snowflake プロバイダーのデシリアライズを修正しました。
 - Databricks JDBC ダイアレクトの登録が不足していた問題を修正しました。
@@ -197,9 +199,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました。[CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874")
 - ワンフェーズコミット最適化が有効な場合にレプリケーション機能が開始されないようにバリデーションを追加しました。
 
-### ScalarDB Analytics
+### Enterprise Options
 
-#### 機能強化
+#### ScalarDB Analytics
+
+##### 機能強化
 
 - PAYG サポート用の Spark リソース使用量収集モジュール。
 - クライアント Fat Jar サポート。
@@ -283,16 +287,18 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - 空の ABAC システムテーブルを削除する際にテーブルが見つからないエラーが発生するバグを修正しました。
 - コーディネーターグループコミット機能が有効なときのメモリリークの問題を修正しました。
 
-### ScalarDB Analytics
+### Enterprise Options
 
-#### 機能強化
+#### ScalarDB Analytics
+
+##### 機能強化
 
 - gRPC カタログサーバー（クライアント-サーバーアーキテクチャ）。
 - カタログサーバー用のコマンドラインクライアント。
 - Snowflake データソース。
 - Databricks データソース。
 
-#### バグの修正
+##### バグの修正
 
 - MySQL データソース: 設定されたデータベースのテーブルのみを解決するように修正しました。
 - SQL Server データソース: 設定されたデータベースのスキーマのみを解決するように修正しました。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.17/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.17/releases/release-notes.mdx
@@ -146,9 +146,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - トランザクションが期限切れになった際にポーズ機能が正しく動作しないバグを修正しました。
 - scalar-metering をアップグレードすることで、ScalarDB Cluster が Omnistrate 環境にデプロイできないバグを修正しました。
 
-### ScalarDB Analytics
+### Enterprise Options
 
-#### バグの修正
+#### ScalarDB Analytics
+
+##### バグの修正
 
 - Azure Synapse Analytics との互換性のためのリロケーションルールを追加しました。
 
@@ -257,16 +259,18 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - 重複する列名が存在する場合に SQL API の `ResultSet` が不正な結果を返すバグを修正しました。
 - セキュリティ問題を修正するために `grpc_health_probe` をアップグレードしました: [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3 "CVE-2025-47907")、[CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27 "CVE-2025-58183")、[CVE-2025-58186](https://github.com/advisories/GHSA-rjcg-56ph-3qvg "CVE-2025-58186")、[CVE-2025-58187](https://github.com/advisories/GHSA-frhw-mqj2-wxw2 "CVE-2025-58187")、および [CVE-2025-58188](https://github.com/advisories/GHSA-7wwx-xj66-r44x "CVE-2025-58188")。
 
-### ScalarDB Analytics
+### Enterprise Options
 
-#### 機能強化
+#### ScalarDB Analytics
+
+##### 機能強化
 
 - プログラムによるサーバーアクセスのための Java クライアント SDK。
 - `${file:...}` 構文を使用したプロバイダー JSON 内のファイル参照の置換。
 - CLI およびサーバー用のマルチプラットフォーム Docker イメージ (ARM64/AMD64)。
 - 統合テストのためのデータベースバージョンのカバレッジを拡大。
 
-#### 改善点
+##### 改善点
 
 - Spark モジュールを Scala に移行し、Client SDK 統合および Maven Central への公開を行いました。
 - サーバーのデータベースアクセスを ScalarDB SQL に移行しました。
@@ -276,7 +280,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - ScalarDB プロバイダーがファイルパスではなく埋め込みマップとして構成を受け取るように変更しました。
 - ビュー機能を削除しました。
 
-#### バグの修正
+##### バグの修正
 
 - 名前空間が空の場合にデータソースの削除が失敗する問題を修正しました。
 - システムユーザーの Oracle スキーマ解決ルールを修正しました。

--- a/versioned_docs/version-3.14/releases/release-notes.mdx
+++ b/versioned_docs/version-3.14/releases/release-notes.mdx
@@ -231,11 +231,13 @@ This release includes a lot of enhancements, improvements, bug fixes, and vulner
 - Upgraded `scalar-admin` to fix a security issue. [CVE-2024-25638](https://github.com/advisories/GHSA-cfxw-4h78-h7fw "CVE-2024-25638")
 - Upgraded the Protobuf Java library to fix a security issue. [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8 "CVE-2024-7254")
 
-### ScalarDB Analytics
+### Enterprise Options
+
+#### ScalarDB Analytics
 
 Initial release of ScalarDB Analytics.
 
-### Enhancements
+##### Enhancements
 
 - Spark catalog integration for querying external data sources.
 - ScalarDB data source support.

--- a/versioned_docs/version-3.15/releases/release-notes.mdx
+++ b/versioned_docs/version-3.15/releases/release-notes.mdx
@@ -284,17 +284,19 @@ This release includes numerous enhancements, improvements, and bug fixes. The [3
 
 ## v3.15.0
 
-### ScalarDB Analytics
+### Enterprise Options
 
-#### Enhancements
+#### ScalarDB Analytics
+
+##### Enhancements
 
 - ScalarDB time-related types support.
 - DynamoDB data source.
 
-#### Improvements
+##### Improvements
 
 - Accumulate query events into log file per query.
 
-#### Bug fixes
+##### Bug fixes
 
 - Avoid error due to duplicate catalog initialization.

--- a/versioned_docs/version-3.16/releases/release-notes.mdx
+++ b/versioned_docs/version-3.16/releases/release-notes.mdx
@@ -153,13 +153,15 @@ This release includes several bug fixes and vulnerability fixes.
 - Upgraded the gRPC library to fix a security issue. [CVE-2025-55163](https://github.com/advisories/GHSA-prj3-ccx8-p6x4 "CVE-2025-55163")
 - Upgraded `grpc_health_probe` to fix security issues: [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3 "CVE-2025-47907"), [CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27 "CVE-2025-58183"), [CVE-2025-58186](https://github.com/advisories/GHSA-rjcg-56ph-3qvg "CVE-2025-58186"), [CVE-2025-58187](https://github.com/advisories/GHSA-frhw-mqj2-wxw2 "CVE-2025-58187"), and [CVE-2025-58188](https://github.com/advisories/GHSA-7wwx-xj66-r44x "CVE-2025-58188").
 
-### ScalarDB Analytics
+### Enterprise Options
 
-#### Enhancements
+#### ScalarDB Analytics
+
+##### Enhancements
 
 - Metering service with AWS Marketplace integration.
 
-#### Bug fixes
+##### Bug fixes
 
 - Fix deserialization for Databricks and Snowflake providers.
 - Add missing Databricks JDBC dialect registration.
@@ -194,9 +196,11 @@ This release includes several bug fixes and vulnerability fixes.
 - Upgraded `grpc_health_probe` to fix a security issue. [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874")
 - Added validation to prevent the replication feature from starting if the one-phase commit optimization is enabled.
 
-### ScalarDB Analytics
+### Enterprise Options
 
-#### Enhancements
+#### ScalarDB Analytics
+
+##### Enhancements
 
 - Spark resource usage collection module for PAYG support.
 - Client fat jar support.
@@ -280,16 +284,18 @@ This release includes many enhancements, improvements, bug fixes, and performanc
 - Fixed a bug a table-not-found error occurs when dropping empty ABAC system tables.
 - Fixed a memory leak issue when the coordinator group commit feature is enabled.
 
-### ScalarDB Analytics
+### Enterprise Options
 
-#### Enhancements
+#### ScalarDB Analytics
+
+##### Enhancements
 
 - gRPC catalog server with client-server architecture.
 - Command line client for catalog server.
 - Snowflake data source.
 - Databricks data source.
 
-#### Bug fixes
+##### Bug fixes
 
 - MySQL data source: only resolve tables of configured database.
 - SQL Server data source: only resolve schemas of configured database.

--- a/versioned_docs/version-3.17/releases/release-notes.mdx
+++ b/versioned_docs/version-3.17/releases/release-notes.mdx
@@ -142,9 +142,11 @@ This release mainly consists of several minor bug fixes and small improvements.
 - Fixed a bug where the pause functionality did not work correctly when transactions expired.
 - Fixed a bug where ScalarDB Cluster cannot be deployed in the Omnistrate environment by upgrading scalar-metering.
 
-### ScalarDB Analytics
+### Enterprise Options
 
-#### Bug fixes
+#### ScalarDB Analytics
+
+##### Bug fixes
 
 - Added relocation rules for Azure Synapse Analytics compatibility.
 
@@ -254,16 +256,18 @@ This release includes many enhancements, improvements, security issue fixes, and
 - Fixed a bug where `ResultSet` in SQL API returned incorrect results when duplicate column names were present.
 - Upgraded `grpc_health_probe` to fix security issues: [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3 "CVE-2025-47907"), [CVE-2025-58183](https://github.com/advisories/GHSA-9gcr-gp5f-jw27 "CVE-2025-58183"), [CVE-2025-58186](https://github.com/advisories/GHSA-rjcg-56ph-3qvg "CVE-2025-58186"), [CVE-2025-58187](https://github.com/advisories/GHSA-frhw-mqj2-wxw2 "CVE-2025-58187"), and [CVE-2025-58188](https://github.com/advisories/GHSA-7wwx-xj66-r44x "CVE-2025-58188").
 
-### ScalarDB Analytics
+### Enterprise Options
 
-#### Enhancements
+#### ScalarDB Analytics
+
+##### Enhancements
 
 - Java Client SDK for programmatic server access.
 - File reference substitution in provider JSON using `${file:...}` syntax.
 - Multi-platform Docker images (ARM64/AMD64) for CLI and server.
 - Expanded database version coverage for integration tests.
 
-#### Improvements
+##### Improvements
 
 - Migrated Spark modules to Scala with Client SDK integration and Maven Central publishing.
 - Migrated server database access to ScalarDB SQL.
@@ -273,7 +277,7 @@ This release includes many enhancements, improvements, security issue fixes, and
 - Changed ScalarDB provider to take configuration as an embedded map instead of a file path.
 - Removed view feature.
 
-#### Bug fixes
+##### Bug fixes
 
 - Fixed data source deletion failing when namespaces are empty.
 - Fixed Oracle schema resolution rule for system users.


### PR DESCRIPTION
## Description

This PR updates both the English and Japanese release notes to include the "Enterprise Options" heading, with ScalarDB Analytics release notes nested within it.

## Related issues and/or PRs

- #2164 

## Changes made

* Grouped the `ScalarDB Analytics` section under a new parent section `Enterprise Options` across all relevant release notes files, both in English and Japanese, to better reflect product organization.
* Adjusted headings.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A