### PR TITLE
Add backward incompatible change warnings to release notes

### DIFF
--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -18,7 +18,7 @@ This page includes a list of release notes for ScalarDB 3.18.
 
 This release includes a lot of enhancements, improvements, security issue fixes, and bug fixes.
 
-:::warning Backward incompatible changes
+:::warning Backward-incompatible changes
 
 - **JDBC connection pool migrated from Apache Commons DBCP2 to HikariCP:**
   - The following configuration properties are no longer supported. They are ignored, with a warning logged, if set:

--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -31,6 +31,7 @@ This release includes a lot of enhancements, improvements, security issue fixes,
   - Connection pool default behavior follows HikariCP rather than DBCP2, which may change runtime behavior even without configuration changes (for example, connection acquisition timeout and idle eviction).
 - **Existing tables require `repairTable()` to create the new before-image secondary index.** Index-based `Get`, `Scan`, and `ScanAll` in Consensus Commit now rely on a companion `before_<col>` index. Until you run `repairTable()` on each existing table, ScalarDB logs a warning at startup and index-based reads fall back to the previous behavior, which may miss records whose indexed column is being concurrently updated. The configuration `scalar.db.consensus_commit.index.eventually_consistent_read.enabled` is provided as an opt-out but is not recommended for new workloads.
 - **MySQL Connector/J replaced with MariaDB Connector/J.** SSL is no longer enabled by default. If you connect to MySQL 8.0 or later with `caching_sha2_password` authentication, add `sslMode=REQUIRED` or `allowPublicKeyRetrieval=true` to your JDBC URL. No action is required for `jdbc:mysql://` URLs because ScalarDB automatically appends `permitMysqlScheme` for compatibility.
+- **`BigIntColumn.MAX_VALUE` and `BigIntColumn.MIN_VALUE` constants have been removed.** Code that referenced them must use `Long.MAX_VALUE` and `Long.MIN_VALUE` instead.
 
 :::
 

--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -20,7 +20,7 @@ This release includes a lot of enhancements, improvements, security issue fixes,
 
 :::warning Backward incompatible changes
 
-- **JDBC connection pool migrated from Apache Commons DBCP2 to HikariCP**
+- **JDBC connection pool migrated from Apache Commons DBCP2 to HikariCP:**
   - The following configuration properties are no longer supported. They are ignored, with a warning logged, if set:
     - `scalar.db.jdbc.connection_pool.max_idle`
     - `scalar.db.jdbc.table_metadata.connection_pool.max_idle`

--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -18,6 +18,22 @@ This page includes a list of release notes for ScalarDB 3.18.
 
 This release includes a lot of enhancements, improvements, security issue fixes, and bug fixes.
 
+:::warning Backward incompatible changes
+
+- **JDBC connection pool migrated from Apache Commons DBCP2 to HikariCP**
+  - The following configuration properties are no longer supported. They are ignored, with a warning logged, if set:
+    - `scalar.db.jdbc.connection_pool.max_idle`
+    - `scalar.db.jdbc.table_metadata.connection_pool.max_idle`
+    - `scalar.db.jdbc.admin.connection_pool.max_idle`
+    - `scalar.db.jdbc.prepared_statements_pool.enabled`
+    - `scalar.db.jdbc.prepared_statements_pool.max_open`
+  - Prepared statement pooling is no longer available because HikariCP has no equivalent feature.
+  - Connection pool default behavior follows HikariCP rather than DBCP2, which may change runtime behavior even without configuration changes (for example, connection acquisition timeout and idle eviction).
+- **Existing tables require `repairTable()` to create the new before-image secondary index.** Index-based `Get`, `Scan`, and `ScanAll` in Consensus Commit now rely on a companion `before_<col>` index. Until you run `repairTable()` on each existing table, ScalarDB logs a warning at startup and index-based reads fall back to the previous behavior, which may miss records whose indexed column is being concurrently updated. The configuration `scalar.db.consensus_commit.index.eventually_consistent_read.enabled` is provided as an opt-out but is not recommended for new workloads.
+- **MySQL Connector/J replaced with MariaDB Connector/J.** SSL is no longer enabled by default. If you connect to MySQL 8.0 or later with `caching_sha2_password` authentication, add `sslMode=REQUIRED` or `allowPublicKeyRetrieval=true` to your JDBC URL. No action is required for `jdbc:mysql://` URLs because ScalarDB automatically appends `permitMysqlScheme` for compatibility.
+
+:::
+
 ### Community edition
 
 #### Enhancements
@@ -79,7 +95,7 @@ This release includes a lot of enhancements, improvements, security issue fixes,
 - Added `Metadata.getRole(roleName)`
 - Added support for Spring Boot 4 in Spring Data JDBC for ScalarDB.
 - Added support for extending `AbstractJdbcConfiguration` for custom bean configuration in Spring Data JDBC for ScalarDB.
-- Changed the `PreparedStatement` API to use `bind()` methods that return a `BoundStatement` for parameter binding, instead of directly setting values on `PreparedStatement`. Note that this is a breaking change, and users may need to update their source code accordingly.
+- Changed the `PreparedStatement` API to use `bind()` methods that return a `BoundStatement` for parameter binding, instead of directly setting values on `PreparedStatement`.
 - Added `executeBatch` API to execute multiple statements in a single call, with support in the core SQL API, direct-mode, and JDBC driver.
 - Added support for BLOB literals using X'hex' syntax in SQL statements.
 - Added support for AuthenticationMethod in `CREATE/ALTER USER` and `SHOW USERS`

--- a/versioned_docs/version-3.15/releases/release-notes.mdx
+++ b/versioned_docs/version-3.15/releases/release-notes.mdx
@@ -18,7 +18,7 @@ This page includes a list of release notes for ScalarDB 3.15.
 
 This release includes improvements and bug fixes.
 
-:::warning Backward incompatible changes
+:::warning Backward-incompatible changes
 
 - **MySQL Connector/J replaced with MariaDB Connector/J.** SSL is no longer enabled by default. If you connect to MySQL 8.0 or later with `caching_sha2_password` authentication, add `sslMode=REQUIRED` or `allowPublicKeyRetrieval=true` to your JDBC URL. No action is required for `jdbc:mysql://` URLs because ScalarDB automatically appends `permitMysqlScheme` for compatibility.
 

--- a/versioned_docs/version-3.15/releases/release-notes.mdx
+++ b/versioned_docs/version-3.15/releases/release-notes.mdx
@@ -18,6 +18,12 @@ This page includes a list of release notes for ScalarDB 3.15.
 
 This release includes improvements and bug fixes.
 
+:::warning Backward incompatible changes
+
+- **MySQL Connector/J replaced with MariaDB Connector/J.** SSL is no longer enabled by default. If you connect to MySQL 8.0 or later with `caching_sha2_password` authentication, add `sslMode=REQUIRED` or `allowPublicKeyRetrieval=true` to your JDBC URL. No action is required for `jdbc:mysql://` URLs because ScalarDB automatically appends `permitMysqlScheme` for compatibility.
+
+:::
+
 ### Community edition
 
 #### Improvements

--- a/versioned_docs/version-3.16/releases/release-notes.mdx
+++ b/versioned_docs/version-3.16/releases/release-notes.mdx
@@ -18,6 +18,13 @@ This page includes a list of release notes for ScalarDB 3.16.
 
 This release includes improvements and bug fixes.
 
+:::warning Backward incompatible changes
+
+- **Existing tables require `repairTable()` to create the new before-image secondary index.** Index-based `Get`, `Scan`, and `ScanAll` in Consensus Commit now rely on a companion `before_<col>` index. Until you run `repairTable()` on each existing table, ScalarDB logs a warning at startup and index-based reads fall back to the previous behavior, which may miss records whose indexed column is being concurrently updated. The configuration `scalar.db.consensus_commit.index.eventually_consistent_read.enabled` is provided as an opt-out but is not recommended for new workloads.
+- **MySQL Connector/J replaced with MariaDB Connector/J.** SSL is no longer enabled by default. If you connect to MySQL 8.0 or later with `caching_sha2_password` authentication, add `sslMode=REQUIRED` or `allowPublicKeyRetrieval=true` to your JDBC URL. No action is required for `jdbc:mysql://` URLs because ScalarDB automatically appends `permitMysqlScheme` for compatibility.
+
+:::
+
 ### Community edition
 
 #### Improvements
@@ -122,6 +129,12 @@ This release mainly consists of several minor bug fixes and small improvements.
 ### Summary
 
 This release includes several bug fixes and vulnerability fixes.
+
+:::warning Backward incompatible changes
+
+- **`Get` and `Scan` operations using a secondary index under the SERIALIZABLE isolation level now throw `IllegalArgumentException`** because such operations cannot guarantee the strict consistency that SERIALIZABLE requires. To restore SERIALIZABLE support for index-based reads, upgrade to 3.16.5 or later, which adds it back via a companion before-image secondary index. Otherwise, switch to a non-SERIALIZABLE isolation level (reads become eventually consistent and may return slightly stale data) or rewrite the operation to use the primary key.
+
+:::
 
 ### Community edition
 

--- a/versioned_docs/version-3.16/releases/release-notes.mdx
+++ b/versioned_docs/version-3.16/releases/release-notes.mdx
@@ -18,7 +18,7 @@ This page includes a list of release notes for ScalarDB 3.16.
 
 This release includes improvements and bug fixes.
 
-:::warning Backward incompatible changes
+:::warning Backward-incompatible changes
 
 - **Existing tables require `repairTable()` to create the new before-image secondary index.** Index-based `Get`, `Scan`, and `ScanAll` in Consensus Commit now rely on a companion `before_<col>` index. Until you run `repairTable()` on each existing table, ScalarDB logs a warning at startup and index-based reads fall back to the previous behavior, which may miss records whose indexed column is being concurrently updated. The configuration `scalar.db.consensus_commit.index.eventually_consistent_read.enabled` is provided as an opt-out but is not recommended for new workloads.
 - **MySQL Connector/J replaced with MariaDB Connector/J.** SSL is no longer enabled by default. If you connect to MySQL 8.0 or later with `caching_sha2_password` authentication, add `sslMode=REQUIRED` or `allowPublicKeyRetrieval=true` to your JDBC URL. No action is required for `jdbc:mysql://` URLs because ScalarDB automatically appends `permitMysqlScheme` for compatibility.
@@ -130,7 +130,7 @@ This release mainly consists of several minor bug fixes and small improvements.
 
 This release includes several bug fixes and vulnerability fixes.
 
-:::warning Backward incompatible changes
+:::warning Backward-incompatible changes
 
 - **`Get` and `Scan` operations using a secondary index under the SERIALIZABLE isolation level now throw `IllegalArgumentException`** because such operations cannot guarantee the strict consistency that SERIALIZABLE requires. To restore SERIALIZABLE support for index-based reads, upgrade to 3.16.5 or later, which adds it back via a companion before-image secondary index. Otherwise, switch to a non-SERIALIZABLE isolation level (reads become eventually consistent and may return slightly stale data) or rewrite the operation to use the primary key.
 

--- a/versioned_docs/version-3.17/releases/release-notes.mdx
+++ b/versioned_docs/version-3.17/releases/release-notes.mdx
@@ -18,6 +18,13 @@ This page includes a list of release notes for ScalarDB 3.17.
 
 This release includes several improvements and bug fixes.
 
+:::warning Backward incompatible changes
+
+- **Existing tables require `repairTable()` to create the new before-image secondary index.** Index-based `Get`, `Scan`, and `ScanAll` in Consensus Commit now rely on a companion `before_<col>` index. Until you run `repairTable()` on each existing table, ScalarDB logs a warning at startup and index-based reads fall back to the previous behavior, which may miss records whose indexed column is being concurrently updated. The configuration `scalar.db.consensus_commit.index.eventually_consistent_read.enabled` is provided as an opt-out but is not recommended for new workloads.
+- **MySQL Connector/J replaced with MariaDB Connector/J.** SSL is no longer enabled by default. If you connect to MySQL 8.0 or later with `caching_sha2_password` authentication, add `sslMode=REQUIRED` or `allowPublicKeyRetrieval=true` to your JDBC URL. No action is required for `jdbc:mysql://` URLs because ScalarDB automatically appends `permitMysqlScheme` for compatibility.
+
+:::
+
 ### Community edition
 
 #### Improvements
@@ -149,6 +156,12 @@ This release mainly consists of several minor bug fixes and small improvements.
 ### Summary
 
 This release includes many enhancements, improvements, security issue fixes, and bug fixes.
+
+:::warning Backward incompatible changes
+
+- **`Get` and `Scan` operations using a secondary index under the SERIALIZABLE isolation level now throw `IllegalArgumentException`** because such operations cannot guarantee the strict consistency that SERIALIZABLE requires. To restore SERIALIZABLE support for index-based reads, upgrade to 3.17.3 or later, which adds it back via a companion before-image secondary index. Otherwise, switch to a non-SERIALIZABLE isolation level (reads become eventually consistent and may return slightly stale data) or rewrite the operation to use the primary key.
+
+:::
 
 ### Community edition
 

--- a/versioned_docs/version-3.17/releases/release-notes.mdx
+++ b/versioned_docs/version-3.17/releases/release-notes.mdx
@@ -18,7 +18,7 @@ This page includes a list of release notes for ScalarDB 3.17.
 
 This release includes several improvements and bug fixes.
 
-:::warning Backward incompatible changes
+:::warning Backward-incompatible changes
 
 - **Existing tables require `repairTable()` to create the new before-image secondary index.** Index-based `Get`, `Scan`, and `ScanAll` in Consensus Commit now rely on a companion `before_<col>` index. Until you run `repairTable()` on each existing table, ScalarDB logs a warning at startup and index-based reads fall back to the previous behavior, which may miss records whose indexed column is being concurrently updated. The configuration `scalar.db.consensus_commit.index.eventually_consistent_read.enabled` is provided as an opt-out but is not recommended for new workloads.
 - **MySQL Connector/J replaced with MariaDB Connector/J.** SSL is no longer enabled by default. If you connect to MySQL 8.0 or later with `caching_sha2_password` authentication, add `sslMode=REQUIRED` or `allowPublicKeyRetrieval=true` to your JDBC URL. No action is required for `jdbc:mysql://` URLs because ScalarDB automatically appends `permitMysqlScheme` for compatibility.
@@ -157,7 +157,7 @@ This release mainly consists of several minor bug fixes and small improvements.
 
 This release includes many enhancements, improvements, security issue fixes, and bug fixes.
 
-:::warning Backward incompatible changes
+:::warning Backward-incompatible changes
 
 - **`Get` and `Scan` operations using a secondary index under the SERIALIZABLE isolation level now throw `IllegalArgumentException`** because such operations cannot guarantee the strict consistency that SERIALIZABLE requires. To restore SERIALIZABLE support for index-based reads, upgrade to 3.17.3 or later, which adds it back via a companion before-image secondary index. Otherwise, switch to a non-SERIALIZABLE isolation level (reads become eventually consistent and may return slightly stale data) or rewrite the operation to use the primary key.
 


### PR DESCRIPTION
## Description

Surfaces backward incompatible changes that previously shipped buried inside the Improvements / Bug fixes lists, so users upgrading don't miss upgrade-blocking items. Each affected version now carries a `:::warning Backward incompatible changes:::` admonition placed right after `### Summary`, listing the breakage and the action users need to take.

This change is documentation-only and only updates the English release notes. The existing Improvements / Bug fixes entries (with their PR links) are left untouched; the warning blocks intentionally avoid duplicating PR links and focus on what stops working that previously worked.

## Related issues and/or PRs

- scalar-labs/scalardb#3305 — JDBC connection pool migrated to HikariCP (3.18.0)
- scalar-labs/scalardb#3133 — `Get` / `Scan` on a secondary index under SERIALIZABLE rejected (3.16.2, 3.17.0)
- scalar-labs/scalardb#3419 — Before-image secondary index required for index-based reads (3.16.5, 3.17.3, 3.18.0)
- scalar-labs/scalardb#3428 — MySQL Connector/J replaced with MariaDB Connector/J (3.15.8, 3.16.5, 3.17.3, 3.18.0)
- scalar-labs/scalardb#3490 — `BigIntColumn.MAX_VALUE` / `MIN_VALUE` constants removed (3.18.0)

## Changes made

Added a `:::warning Backward incompatible changes:::` admonition after `### Summary` in the following release-notes pages:

- `versioned_docs/version-3.15/releases/release-notes.mdx` — 3.15.8: MariaDB Connector/J SSL default
- `versioned_docs/version-3.16/releases/release-notes.mdx`
  - 3.16.2: SERIALIZABLE secondary index rejection (with pointer to 3.16.5+ where SERIALIZABLE was restored via the before-image index)
  - 3.16.5: before-image index `repairTable()` requirement, MariaDB Connector/J SSL default
- `versioned_docs/version-3.17/releases/release-notes.mdx`
  - 3.17.0: SERIALIZABLE secondary index rejection (with pointer to 3.17.3+)
  - 3.17.3: before-image index `repairTable()` requirement, MariaDB Connector/J SSL default
- `docs/releases/release-notes.mdx` — 3.18.0: HikariCP migration (removed JDBC pool config properties and prepared statement pooling), before-image index `repairTable()` requirement, MariaDB Connector/J SSL default, removal of `BigIntColumn.MAX_VALUE` / `MIN_VALUE` constants

For the MariaDB Connector/J entry, the warning also notes that `jdbc:mysql://` URLs continue to work because ScalarDB automatically appends `permitMysqlScheme`.

## Checklist

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The Japanese release notes are not updated in this PR (per request). Backporting these warnings to ja-jp can be a follow-up.