### PR TITLE
Auto-open Ask AI modal when including parameter `?ask-ai` in URL

### DIFF
--- a/src/components/GoogleAIModeSearch/index.js
+++ b/src/components/GoogleAIModeSearch/index.js
@@ -1,5 +1,4 @@
-
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { useLocation } from '@docusaurus/router';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
@@ -176,6 +175,19 @@ export default function GoogleAIModeSearch() {
   const poweredBy = currentLanguage === 'ja-jp'
     ? '提供元: '
     : 'Powered by ';
+
+  // Auto-open modal if URL contains the ?ask-ai query parameter
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (params.has('ask-ai')) {
+      setIsModalOpen(true);
+      // Clean up the parameter from the URL without triggering a navigation
+      params.delete('ask-ai');
+      const newSearch = params.toString();
+      const newUrl = location.pathname + (newSearch ? `?${newSearch}` : '') + location.hash;
+      window.history.replaceState({}, '', newUrl);
+    }
+  }, [location.search, location.pathname, location.hash]);
 
   // Only render the button and modal if on latest docs version
   if (currentVersion !== 'latest') {

--- a/src/components/GoogleAIModeSearch/index.js
+++ b/src/components/GoogleAIModeSearch/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { useLocation } from '@docusaurus/router';
+import { useLocation, useHistory } from '@docusaurus/router';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 // Magic number constants
@@ -15,6 +15,7 @@ export default function GoogleAIModeSearch() {
   // Place hooks at the top
   const { siteConfig } = useDocusaurusContext();
   const location = useLocation();
+  const history = useHistory();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -96,12 +97,19 @@ export default function GoogleAIModeSearch() {
 
   const closeModal = useCallback(() => {
     setIsClosing(true);
+    // Strip ?ask-ai from the URL when the user closes the modal
+    const params = new URLSearchParams(location.search);
+    if (params.has('ask-ai')) {
+      params.delete('ask-ai');
+      const newSearch = params.toString();
+      history.replace(location.pathname + (newSearch ? `?${newSearch}` : '') + location.hash);
+    }
     setTimeout(() => {
       setIsModalOpen(false);
       setIsClosing(false);
       setSearchQuery('');
     }, MODAL_CLOSE_TIMEOUT_MS);
-  }, []);
+  }, [location.search, location.pathname, location.hash, history]);
 
   const handleSearch = useCallback((e) => {
     e.preventDefault();
@@ -176,18 +184,23 @@ export default function GoogleAIModeSearch() {
     ? '提供元: '
     : 'Powered by ';
 
-  // Auto-open modal if URL contains the ?ask-ai query parameter
+  // Auto-open modal if URL contains the ?ask-ai query parameter.
+  // The parameter stays in the URL while the modal is open and is removed when the user closes it.
+  // On non-latest versions, always strip the parameter since the modal can't be shown.
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     if (params.has('ask-ai')) {
-      setIsModalOpen(true);
-      // Clean up the parameter from the URL without triggering a navigation
-      params.delete('ask-ai');
-      const newSearch = params.toString();
-      const newUrl = location.pathname + (newSearch ? `?${newSearch}` : '') + location.hash;
-      window.history.replaceState({}, '', newUrl);
+      if (currentVersion === 'latest') {
+        setIsModalOpen(true);
+        // Leave the parameter in the URL — it will be removed when the modal is closed
+      } else {
+        // Strip the parameter on non-latest versions where the modal is unavailable
+        params.delete('ask-ai');
+        const newSearch = params.toString();
+        history.replace(location.pathname + (newSearch ? `?${newSearch}` : '') + location.hash);
+      }
     }
-  }, [location.search, location.pathname, location.hash]);
+  }, [currentVersion, location.search, location.pathname, location.hash, history]);
 
   // Only render the button and modal if on latest docs version
   if (currentVersion !== 'latest') {


### PR DESCRIPTION
## Description

This PR enhances the Ask AI component by adding support for automatically opening the AI modal when the `?ask-ai` query parameter is present in the URL. It also ensures the parameter is removed from the URL afterward, improving user experience for deep-linking and sharing.

> [!NOTE]
>
> Staging environment for testing:
>
> - https://6a02c81278cd57f778e47c9c--reliable-phoenix-b90994.netlify.app/docs/latest?ask-ai
>   - Link valid for 90 days from PR creation date.

## Related issues and/or PRs

N/A

## Changes made

* Added a `useEffect` hook to auto-open the AI modal if the URL contains the `ask-ai` query parameter, and then remove the parameter from the URL without navigation in `src/components/GoogleAIModeSearch/index.js`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A