### PR TITLE
Add 3.18 blog post link to announcement banner and notification messages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -509,6 +509,7 @@ const config = {
         content:
           'Announcing the release of ScalarDB 3.18!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a>.',
           // 'Announcing the release of ScalarDB X.X!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a>',
+          'Announcing the release of ScalarDB 3.18!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a> and <a target="_self" href="XXX?utm_source=docs-site&utm_medium=announcementbar">blog post</a>.',
         backgroundColor: '#2673BB',
         textColor: '#FFFFFF',
         isCloseable: false,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -507,9 +507,7 @@ const config = {
       announcementBar: {
         id: 'new_version',
         content:
-          'Announcing the release of ScalarDB 3.18!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a>.',
-          // 'Announcing the release of ScalarDB X.X!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a>',
-          'Announcing the release of ScalarDB 3.18!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a> and <a target="_self" href="XXX?utm_source=docs-site&utm_medium=announcementbar">blog post</a>.',
+          'Announcing the release of ScalarDB 3.18!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a> and <a target="_blank" href="https://medium.com/scalar-engineering/scalardb-3-18-has-been-released-e85b7f536cc7?utm_source=docs-site&utm_medium=announcementbar">blog post</a>.',
         backgroundColor: '#2673BB',
         textColor: '#FFFFFF',
         isCloseable: false,

--- a/src/data/notifications.js
+++ b/src/data/notifications.js
@@ -25,6 +25,17 @@ const notificationsList = [
   // },
   {
     message: {
+      en: 'Blog post: ScalarDB 3.18 has been released!',
+      ja: 'ブログ記事: ScalarDB 3.18 をリリースしました！'
+    },
+    url: {
+      en: 'https://medium.com/scalar-engineering/scalardb-3-18-has-been-released-e85b7f536cc7?utm_source=docs-site&utm_medium=notifications',
+      ja: 'https://medium.com/scalar-engineering-ja/scalardb-3-18-%E3%82%92%E3%83%AA%E3%83%AA%E3%83%BC%E3%82%B9%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F-3bd653f87137?utm_source=docs-site&utm_medium=notifications'
+    },
+    unread: true
+  },
+  {
+    message: {
       en: 'Learn about transaction metadata decoupling in ScalarDB 3.17',
       ja: 'ScalarDB 3.17 でトランザクションメタデータ分離について学ぶ'
     },


### PR DESCRIPTION
## Description

This PR updates the announcement banner and notification message to highlight the release of ScalarDB 3.18.

## Related issues and/or PRs

N/A

## Changes made

* Added a link to the ScalarDB 3.18 release blog post in addition to the release notes in the announcement bar in `docusaurus.config.js`.
* Added a new notification about the ScalarDB 3.18 blog post, with messages and links in both English and Japanese, to `src/data/notifications.js`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A