### PR TITLE
Fix incorrect URLs in `llms.txt` generated by `docusaurus-plugin-llms`

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -215,6 +215,9 @@ const config = {
         generateLLMsFullTxt: false, // Disabled. We're currently using gitingest to generate a more detailed llms-full.txt file. For details, see /scripts/README.md.
         docsDir: 'docs',
         version: 'latest',
+        pathTransformation: {
+          addPaths: ['latest'],
+        },
         title: 'ScalarDB Documentation',
         description: 'Universal hybrid transaction/analytical processing (HTAP) engine for diverse databases',
         // Content cleaning options


### PR DESCRIPTION
## Description

This PR adds a configuration to the `docusaurus-plugin-llms` plugin to fix incorrect URLs that are auto-generated in our `llms.txt` file. The main change is the addition of a `pathTransformation` option to the documentation configuration, which ensures that the `latest` path is always included in generated documentation URLs.

For some reason, the URLs are broken in the `llms.txt` file that gets generated by the `docusaurus-plugin-llms` plugin (an unofficial Docusaurus plugin since Docusaurus doesn't natively support generating `llms.txt` yet). By adding `pathTransformation.addPaths.latest` to the plugin configurations, we can get around this issue when using plugin version 0.1.5.

> [!IMPORTANT]
>
> Upgrading to the latest `docusaurus-plugin-llms` plugin version (0.4.0 at the time of this PR) breaks this fix. Therefore, please stay on 0.1.5 until future versions get released and are tested to work as expected.

## Related issues and/or PRs

N/A

## Changes made

* Added a `pathTransformation` object with an `addPaths` array containing `'latest'` to the Docusaurus configuration in `docusaurus.config.js`, ensuring documentation paths always include the `latest` version.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A