### PR TITLE
Add workflow to auto-refresh Context7 library source (`llms-full.txt`) weekly

### DIFF
--- a/.github/workflows/refresh-context7-sources.yml
+++ b/.github/workflows/refresh-context7-sources.yml
@@ -1,0 +1,113 @@
+name: Refresh Context7 library (llms-full.txt)
+
+# Behavior:
+# - Scheduled to run every Sunday at 23:00 UTC (Monday at 8:00 AM JST).
+# - workflow_dispatch can run immediately and optionally override the library ID via input.
+
+on:
+  schedule:
+    - cron: "0 23 * * 0" # Run every Sunday at 23:00 UTC (Monday at 8:00 AM JST).
+  workflow_dispatch:
+    inputs:
+      library_name:
+        description: "Optional override for Context7 library ID (for example /llmstxt/example_com)"
+        required: false
+        type: string
+
+jobs:
+  refresh:
+    name: Trigger Context7 refresh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger refresh through Context7 API
+        env:
+          CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
+          CONTEXT7_LIBRARY_NAME: ${{ vars.CONTEXT7_LIBRARY_NAME }}
+          INPUT_LIBRARY_NAME: ${{ inputs.library_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${CONTEXT7_API_KEY:-}" ]]; then
+            echo "CONTEXT7_API_KEY secret is not set."
+            exit 1
+          fi
+
+          # Optional one-off override for manual runs.
+          if [[ -n "$INPUT_LIBRARY_NAME" ]]; then
+            export CONTEXT7_LIBRARY_NAME="$INPUT_LIBRARY_NAME"
+          fi
+
+          if [[ -z "${CONTEXT7_LIBRARY_NAME:-}" ]]; then
+            echo "CONTEXT7_LIBRARY_NAME is not set."
+            exit 1
+          fi
+
+          max_attempts=5
+          base_retry_seconds=2
+          curl_exit_code=0
+
+          # Remove temp files on any unexpected early exit.
+          trap 'rm -f "${headers_file:-}" "${body_file:-}"' EXIT
+
+          for attempt in $(seq 1 "$max_attempts"); do
+            headers_file=$(mktemp)
+            body_file=$(mktemp)
+
+            # Run curl without set -e interference, then inspect exit code explicitly.
+            curl -sS \
+              -X POST "https://context7.com/api/v1/refresh" \
+              --connect-timeout 10 \
+              --max-time 30 \
+              -H "Authorization: Bearer $CONTEXT7_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d "{\"libraryName\":\"$CONTEXT7_LIBRARY_NAME\"}" \
+              -D "$headers_file" \
+              -o "$body_file" \
+              -w "%{http_code}" > "${body_file}.status" \
+              && curl_exit_code=0 || curl_exit_code=$?
+            status_code=$(cat "${body_file}.status" 2>/dev/null || echo "")
+            rm -f "${body_file}.status"
+
+            if [[ "$curl_exit_code" -ne 0 ]]; then
+              retry_after=$((base_retry_seconds * 2 ** (attempt - 1)))
+              echo "Context7 refresh request failed at network layer (curl exit $curl_exit_code). Retrying in ${retry_after}s (attempt $attempt/$max_attempts)."
+              rm -f "$headers_file" "$body_file"
+
+              if [[ "$attempt" -eq "$max_attempts" ]]; then
+                echo "Max retry attempts reached after transport errors."
+                exit 1
+              fi
+
+              sleep "$retry_after"
+              continue
+            fi
+
+            if [[ "$status_code" == "200" ]]; then
+              echo "Context7 refresh requested for $CONTEXT7_LIBRARY_NAME"
+              cat "$body_file"
+              rm -f "$headers_file" "$body_file"
+              exit 0
+            fi
+
+            if [[ "$status_code" != "429" && "$status_code" != "500" && "$status_code" != "503" && "$status_code" != "504" ]]; then
+              echo "Context7 refresh failed with status $status_code"
+              cat "$body_file"
+              rm -f "$headers_file" "$body_file"
+              exit 1
+            fi
+
+            retry_after=$(awk 'tolower($1) == "retry-after:" {print $2}' "$headers_file" | tr -d '\r' | tail -n 1)
+            if [[ -z "$retry_after" ]]; then
+              retry_after=$((base_retry_seconds * 2 ** (attempt - 1)))
+            fi
+
+            echo "Context7 refresh returned $status_code. Retrying in ${retry_after}s (attempt $attempt/$max_attempts)."
+            rm -f "$headers_file" "$body_file"
+
+            if [[ "$attempt" -eq "$max_attempts" ]]; then
+              echo "Max retry attempts reached."
+              exit 1
+            fi
+
+            sleep "$retry_after"
+          done


### PR DESCRIPTION
## Description

This PR introduces a new GitHub Actions workflow to automate the refreshing of the Context7 library source (`llms-full.txt`) for the ScalarDB docs site. The workflow is designed to run weekly on a schedule and can also be triggered manually, with robust error handling and retry logic for reliability.

> [!NOTE]
>
> - Successful action run in forked repository: https://github.com/josh-wong/docs-scalardb/actions/runs/27399480467.
>   - Confirmed in the Context7 dashboard that the `llms-full.txt` file for the ScalarDB docs site was triggered. 
> - The ScalarDB docs site is set to run at 8:00 AM Japan Standard Time, and the workflow for the ScalarDL docs site is set to run at 9:00 AM Japan Standard Time. The reason for this gap is because Context7 allows only one source to be updated at once.

## Related issues and/or PRs

Similar workflow added to the ScalarDL docs site repository:

- https://github.com/scalar-labs/docs-scalardl/pull/1365

## Changes made

* Added `.github/workflows/refresh-context7-sources.yml` to schedule a weekly refresh of the Context7 library source (`llms-full.txt`) for this docs site and allow manual triggering with an optional library name override.
* Set `CONTEXT7_API_KEY` as a repository secret and `CONTEXT7_LIBRARY_NAME` as a repository variable.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A