### PR TITLE
Add visual badge utility to flag new docs in sidebar nav and "Recent features" cards

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,9 @@
 
 > The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.
 
-- [ ] I have updated the side navigation as necessary.
+- [ ] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
+	- [ ] Relevant sidebar `label` entries in `sidebars.js` (latest).
+	- [ ] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
 - [ ] I have commented my code, particularly in hard-to-understand areas.
 - [ ] I have updated the documentation to reflect the changes.
 - [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).

--- a/.github/workflows/auto-create-pr-helm-charts.yml
+++ b/.github/workflows/auto-create-pr-helm-charts.yml
@@ -27,7 +27,9 @@ jobs:
                 '',
                 'Before merging this PR, confirm the following:',
                 '',
-                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary).',
+                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary). If this PR introduces a new page, I have added `[NEW]` to the:',
+                '  - [ ] Relevant sidebar `label` entries in `sidebars.js` (latest).',
+                '  - [ ] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).',
                 '- [ ] I have confirmed that this PR can be merged without waiting (if necessary).',
                 '  - An example of when a PR must wait to be merged is when the docs are part of a pending release of a new product version.'
               ].join('\n')

--- a/.github/workflows/auto-create-pr-scalar-kubernetes.yml
+++ b/.github/workflows/auto-create-pr-scalar-kubernetes.yml
@@ -27,7 +27,9 @@ jobs:
                 '',
                 'Before merging this PR, confirm the following:',
                 '',
-                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary).',
+                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary). If this PR introduces a new doc, I have added `[NEW]` to the:',
+                '  - [ ] Relevant sidebar `label` entries in `sidebars.js` (latest).',
+                '  - [ ] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).',
                 '- [ ] I have confirmed that this PR can be merged without waiting (if necessary).',
                 '  - An example of when a PR must wait to be merged is when the docs are part of a pending release of a new product version.'
               ].join('\n')

--- a/.github/workflows/auto-create-pr-scalar-manager.yml
+++ b/.github/workflows/auto-create-pr-scalar-manager.yml
@@ -27,7 +27,9 @@ jobs:
                 '',
                 'Before merging this PR, confirm the following:',
                 '',
-                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary).',
+                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary). If this PR introduces a new doc, I have added `[NEW]` to the:',
+                '  - [ ] Relevant sidebar `label` entries in `sidebars.js` (latest).',
+                '  - [ ] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).',
                 '- [ ] I have confirmed that this PR can be merged without waiting (if necessary).',
                 '  - An example of when a PR must wait to be merged is when the docs are part of a pending release of a new product version.'
               ].join('\n')

--- a/.github/workflows/auto-create-pr-scalardb.yml
+++ b/.github/workflows/auto-create-pr-scalardb.yml
@@ -27,7 +27,9 @@ jobs:
                 '',
                 'Before merging this PR, confirm the following:',
                 '',
-                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary).',
+                '- [ ] I have updated the side navigation to include new docs or remove deleted docs (if necessary). If this PR introduces a new doc, I have added `[NEW]` to the:',
+                '  - [ ] Relevant sidebar `label` entries in `sidebars.js` (latest).',
+                '  - [ ] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).',
                 '- [ ] I have confirmed that this PR can be merged without waiting (if necessary).',
                 '  - An example of when a PR must wait to be merged is when the docs are part of a pending release of a new product version.'
               ].join('\n')

--- a/sidebars.js
+++ b/sidebars.js
@@ -312,7 +312,7 @@ const sidebars = {
                 {
                   type: 'doc',
                   id: 'scalardb-cluster/control-access-via-oidc-based-jwt-tokens',
-                  label: 'Control User Access via OIDC-Based JWT Access Tokens',
+                  label: 'Control User Access via OIDC-Based JWT Access Tokens [NEW]',
                 },
                 {
                   type: 'doc',
@@ -647,7 +647,7 @@ const sidebars = {
                   type: 'doc',
                   key: 'develop-run-analytical-queries-advanced-configurations-and-operations-authentication-and-authorization-en-us-3.18',
                   id: 'scalardb-analytics/authentication-and-authorization',
-                  label: 'Authenticate and Authorize Users',
+                  label: 'Authenticate and Authorize Users [NEW]',
                 },
               ],
             },
@@ -1450,7 +1450,7 @@ const sidebars = {
                 {
                   type: 'doc',
                   id: 'scalardb-cluster/control-access-via-oidc-based-jwt-tokens',
-                  label: 'OIDC ベースの JWT アクセストークンを用いてユーザーアクセスを制御',
+                  label: 'OIDC ベースの JWT アクセストークンを用いてユーザーアクセスを制御 [NEW]',
                 },
                 {
                   type: 'doc',
@@ -1783,7 +1783,7 @@ const sidebars = {
                   type: 'doc',
                   key: 'develop-run-analytical-queries-advanced-configurations-and-operations-authentication-and-authorization-ja-jp-3.18',
                   id: 'scalardb-analytics/authentication-and-authorization',
-                  label: 'ユーザーの認証と認可',
+                  label: 'ユーザーの認証と認可 [NEW]',
                 },
               ],
             },

--- a/src/components/Cards/3.15.tsx
+++ b/src/components/Cards/3.15.tsx
@@ -15,6 +15,7 @@ import LiteYouTubeEmbed from 'react-lite-youtube-embed';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBook } from '@fortawesome/free-solid-svg-icons';
+import { parseBadgeLabel } from './utils';
 
 const recentFeatures = [
   {
@@ -26,12 +27,12 @@ const recentFeatures = [
       {
         cell: 0, // First cell
         links: ['scalardb-cluster/getting-started-with-vector-search'],
-        labels: ['Getting Started with ScalarDB Cluster for Vector Search']
+        labels: ['Getting Started with ScalarDB Cluster for Vector Search [NEW]']
       },
       {
         cell: 1, // Second cell
         links: ['scalardb-cluster/authorize-with-abac'],
-        labels: ['Control User Access in a Fine-Grained Manner']
+        labels: ['Control User Access in a Fine-Grained Manner [NEW]']
       },
       {
         cell: 2, // Third cell
@@ -209,15 +210,15 @@ const CategoryGrid = () => {
               {doc.name}
             </div>
             {doc.categoryLinks.map((categoryLinkCell, j) => (
-              <div key={j} className="category-cell-multiple-links">
+              <div key={j} className="category-cell-multiple-links recent-features-cell-bg">
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="recent-features-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}
@@ -235,11 +236,11 @@ const CategoryGrid = () => {
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="category-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}

--- a/src/components/Cards/3.16.tsx
+++ b/src/components/Cards/3.16.tsx
@@ -15,6 +15,7 @@ import LiteYouTubeEmbed from 'react-lite-youtube-embed';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBook } from '@fortawesome/free-solid-svg-icons';
+import { parseBadgeLabel } from './utils';
 
 const recentFeatures = [
   {
@@ -26,12 +27,12 @@ const recentFeatures = [
       {
         cell: 0, // First cell
         links: ['scalardb-cluster/remote-replication'],
-        labels: ['Replicate Data for High Availability']
+        labels: ['Replicate Data for High Availability [NEW]']
       },
       {
         cell: 1, // Second cell
         links: ['scalardb-mcp-server/getting-started-with-scalardb-mcp-server'],
-        labels: ['Getting Started with ScalarDB MCP Server']
+        labels: ['Getting Started with ScalarDB MCP Server [NEW]']
       },
       {
         cell: 2, // Third cell
@@ -209,15 +210,15 @@ const CategoryGrid = () => {
               {doc.name}
             </div>
             {doc.categoryLinks.map((categoryLinkCell, j) => (
-              <div key={j} className="category-cell-multiple-links">
+              <div key={j} className="category-cell-multiple-links recent-features-cell-bg">
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="recent-features-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}
@@ -235,11 +236,11 @@ const CategoryGrid = () => {
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="category-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}

--- a/src/components/Cards/3.17.tsx
+++ b/src/components/Cards/3.17.tsx
@@ -15,6 +15,7 @@ import LiteYouTubeEmbed from 'react-lite-youtube-embed';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBook } from '@fortawesome/free-solid-svg-icons';
+import { parseBadgeLabel } from './utils';
 
 const recentFeatures = [
   {
@@ -26,7 +27,7 @@ const recentFeatures = [
       {
         cell: 0, // First cell
         links: ['consensus-commit#transaction-metadata-decoupling'],
-        labels: ['Transaction Metadata Decoupling']
+        labels: ['Transaction Metadata Decoupling [NEW]']
       },
       {
         cell: 1, // Second cell
@@ -209,15 +210,15 @@ const CategoryGrid = () => {
               {doc.name}
             </div>
             {doc.categoryLinks.map((categoryLinkCell, j) => (
-              <div key={j} className="category-cell-multiple-links">
+              <div key={j} className="category-cell-multiple-links recent-features-cell-bg">
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="recent-features-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}
@@ -235,11 +236,11 @@ const CategoryGrid = () => {
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="category-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}

--- a/src/components/Cards/3.18.tsx
+++ b/src/components/Cards/3.18.tsx
@@ -15,6 +15,7 @@ import LiteYouTubeEmbed from 'react-lite-youtube-embed';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBook } from '@fortawesome/free-solid-svg-icons';
+import { parseBadgeLabel } from './utils';
 
 const recentFeatures = [
   {
@@ -26,12 +27,12 @@ const recentFeatures = [
       {
         cell: 0, // First cell
         links: ['scalardb-cluster/control-access-via-oidc-based-jwt-tokens'],
-        labels: ['Control User Access via OIDC-Based JWT Access Tokens']
+        labels: ['Control User Access via OIDC-Based JWT Access Tokens [NEW]']
       },
       {
         cell: 1, // Second cell
         links: ['scalardb-analytics/authentication-and-authorization'],
-        labels: ['Authenticate and Authorize Users in ScalarDB Analytics']
+        labels: ['Authenticate and Authorize Users in ScalarDB Analytics [NEW]']
       },
       {
         cell: 2, // Third cell
@@ -209,15 +210,15 @@ const CategoryGrid = () => {
               {doc.name}
             </div>
             {doc.categoryLinks.map((categoryLinkCell, j) => (
-              <div key={j} className="category-cell-multiple-links">
+              <div key={j} className="category-cell-multiple-links recent-features-cell-bg">
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="recent-features-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}
@@ -235,11 +236,11 @@ const CategoryGrid = () => {
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="category-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}

--- a/src/components/Cards/ja-jp/3.15.tsx
+++ b/src/components/Cards/ja-jp/3.15.tsx
@@ -15,6 +15,7 @@ import LiteYouTubeEmbed from 'react-lite-youtube-embed';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBook } from '@fortawesome/free-solid-svg-icons';
+import { parseBadgeLabel } from '../utils';
 
 const recentFeatures = [
   {
@@ -26,12 +27,12 @@ const recentFeatures = [
       {
         cell: 0, // First cell
         links: ['scalardb-cluster/getting-started-with-vector-search'],
-        labels: ['ScalarDB Cluster でベクトル検索をはじめよう']
+        labels: ['ScalarDB Cluster でベクトル検索をはじめよう [NEW]']
       },
       {
         cell: 1, // Second cell
         links: ['scalardb-cluster/authorize-with-abac'],
-        labels: ['ユーザーアクセスをきめ細かく制御する']
+        labels: ['ユーザーアクセスをきめ細かく制御する [NEW]']
       },
       {
         cell: 2, // Third cell
@@ -209,15 +210,15 @@ const CategoryGrid = () => {
               {doc.name}
             </div>
             {doc.categoryLinks.map((categoryLinkCell, j) => (
-              <div key={j} className="category-cell-multiple-links">
+              <div key={j} className="category-cell-multiple-links recent-features-cell-bg">
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="recent-features-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}
@@ -235,11 +236,11 @@ const CategoryGrid = () => {
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="category-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}

--- a/src/components/Cards/ja-jp/3.16.tsx
+++ b/src/components/Cards/ja-jp/3.16.tsx
@@ -15,6 +15,7 @@ import LiteYouTubeEmbed from 'react-lite-youtube-embed';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBook } from '@fortawesome/free-solid-svg-icons';
+import { parseBadgeLabel } from '../utils';
 
 const recentFeatures = [
   {
@@ -26,12 +27,12 @@ const recentFeatures = [
       {
         cell: 0, // First cell
         links: ['scalardb-cluster/remote-replication'],
-        labels: ['高可用性のためのデータレプリケーション']
+        labels: ['高可用性のためのデータレプリケーション [NEW]']
       },
       {
         cell: 1, // Second cell
         links: ['scalardb-mcp-server/getting-started-with-scalardb-mcp-server'],
-        labels: ['ScalarDB MCP Server をはじめよう']
+        labels: ['ScalarDB MCP Server をはじめよう [NEW]']
       },
       {
         cell: 2, // Third cell
@@ -209,15 +210,15 @@ const CategoryGrid = () => {
               {doc.name}
             </div>
             {doc.categoryLinks.map((categoryLinkCell, j) => (
-              <div key={j} className="category-cell-multiple-links">
+              <div key={j} className="category-cell-multiple-links recent-features-cell-bg">
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="recent-features-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}
@@ -235,11 +236,11 @@ const CategoryGrid = () => {
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="category-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}

--- a/src/components/Cards/ja-jp/3.17.tsx
+++ b/src/components/Cards/ja-jp/3.17.tsx
@@ -15,6 +15,7 @@ import LiteYouTubeEmbed from 'react-lite-youtube-embed';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBook } from '@fortawesome/free-solid-svg-icons';
+import { parseBadgeLabel } from '../utils';
 
 const recentFeatures = [
   {
@@ -26,7 +27,7 @@ const recentFeatures = [
       {
         cell: 0, // First cell
         links: ['consensus-commit#%E3%83%88%E3%83%A9%E3%83%B3%E3%82%B6%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3%E3%83%A1%E3%82%BF%E3%83%87%E3%83%BC%E3%82%BF%E5%88%86%E9%9B%A2'],
-        labels: ['トランザクションメタデータ分離']
+        labels: ['トランザクションメタデータ分離 [NEW]']
       },
       {
         cell: 1, // Second cell
@@ -209,15 +210,15 @@ const CategoryGrid = () => {
               {doc.name}
             </div>
             {doc.categoryLinks.map((categoryLinkCell, j) => (
-              <div key={j} className="category-cell-multiple-links">
+              <div key={j} className="category-cell-multiple-links recent-features-cell-bg">
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="recent-features-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}
@@ -235,11 +236,11 @@ const CategoryGrid = () => {
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="category-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}

--- a/src/components/Cards/ja-jp/3.18.tsx
+++ b/src/components/Cards/ja-jp/3.18.tsx
@@ -15,6 +15,7 @@ import LiteYouTubeEmbed from 'react-lite-youtube-embed';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBook } from '@fortawesome/free-solid-svg-icons';
+import { parseBadgeLabel } from '../utils';
 
 const recentFeatures = [
   {
@@ -26,12 +27,12 @@ const recentFeatures = [
       {
         cell: 0, // First cell
         links: ['scalardb-cluster/control-access-via-oidc-based-jwt-tokens'],
-        labels: ['OIDC ベースの JWT アクセストークンを用いてユーザーアクセスを制御']
+        labels: ['OIDC ベースの JWT アクセストークンを用いてユーザーアクセスを制御 [NEW]']
       },
       {
         cell: 1, // Second cell
         links: ['scalardb-analytics/authentication-and-authorization'],
-        labels: ['ScalarDB Analytics でユーザーを認証と認可']
+        labels: ['ScalarDB Analytics でユーザーを認証と認可 [NEW]']
       },
       {
         cell: 2, // Second cell
@@ -209,15 +210,15 @@ const CategoryGrid = () => {
               {doc.name}
             </div>
             {doc.categoryLinks.map((categoryLinkCell, j) => (
-              <div key={j} className="category-cell-multiple-links">
+              <div key={j} className="category-cell-multiple-links recent-features-cell-bg">
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="recent-features-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}
@@ -235,11 +236,11 @@ const CategoryGrid = () => {
                 {categoryLinkCell.links.map((cellLink, k) => (
                   cellLink ? (
                     <Link key={`${j}-${k}`} className="category-cell-link" to={cellLink}>
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </Link>
                   ) : (
                     <span key={`${j}-${k}`} className="category-cell">
-                      {categoryLinkCell.labels[k]}
+                      <span className="category-cell-link-text">{parseBadgeLabel(categoryLinkCell.labels[k])}</span>
                     </span>
                   )
                 ))}

--- a/src/components/Cards/utils.tsx
+++ b/src/components/Cards/utils.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export function parseBadgeLabel(label: React.ReactNode): React.ReactNode {
+  if (typeof label !== 'string') return label;
+  const match = label.match(/^(.*?)\s*\[([A-Z]+)\]$/);
+  if (!match) return label;
+  return (
+    <>
+      {match[1]}
+      <span className={`badge--${match[2].toLowerCase()}`}>{match[2]}</span>
+    </>
+  );
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -473,7 +473,7 @@ html[data-theme="dark"] a[class^='tag_'] {
   } */
 }
 
-/* NEW badge next to H1 title on pages with new: true in frontmatter */
+/* NEW badge next to H1 title for docs marked new (sidebar label ending in [NEW]). */
 .doc-new .markdown h1:first-of-type::after {
   background-color: var(--scalar-green);
   border-radius: 3px;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,6 +15,9 @@
   --ifm-color-primary-lightest: #2673BB;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --scalar-green: #78C740;
+  --scalar-green-alpha-low: rgba(120, 199, 64, 0.08);
+  --scalar-green-alpha-medium: rgba(120, 199, 64, 0.13);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -225,7 +228,11 @@ table, pre, code, img, iframe { /* Fix for common elements that might cause over
 
   &:hover {
     color: var(--ifm-color-primary);
-    text-decoration: underline;
+    text-decoration: none;
+
+    .category-cell-link-text {
+      text-decoration: underline;
+    }
   }
 }
 
@@ -299,7 +306,7 @@ table, pre, code, img, iframe { /* Fix for common elements that might cause over
 }
 
 .recent-features-icon {
-  color: #78C740;
+  color: var(--scalar-green);
   /* Fix for FontAwesome icon FOUC. */
   width: 1em !important;
   height: 1em !important;
@@ -322,6 +329,50 @@ html[data-theme="dark"] .category-cell-multiple-links {
     border-top: 0;
     border-bottom: 0;
   }
+}
+
+/* NEW badge for items in the recent column and sidebar navigation */
+.badge--new {
+  background-color: var(--scalar-green);
+  border-radius: 3px;
+  color: #fff;
+  display: inline-block;
+  font-size: 0.65em;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  margin-left: 4px;
+  padding: 2px 5px;
+  text-decoration: none;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+
+a:hover .badge--new {
+  text-decoration: none;
+}
+
+/* Recent Features row background */
+.recent-features-cell-bg {
+  background-color: var(--scalar-green-alpha-low);
+  border-top: 1px solid var(--scalar-green);
+  border-bottom: 1px solid var(--scalar-green);
+  box-shadow: 0 1px 4px 0 rgba(60, 60, 60, 0.04);
+}
+
+/* First recent features cell: left border */
+.category-label + .recent-features-cell-bg {
+  border-left: 1px solid var(--scalar-green);
+}
+
+/* Last recent features cell: right border */
+.recent-features-cell-bg:nth-child(4n) {
+  border-right: 1px solid var(--scalar-green);
+}
+
+html[data-theme="dark"] .recent-features-cell-bg {
+  background-color: var(--scalar-green-alpha-medium);
+  box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.10);
 }
 
 /* Target first cell in each row that follows a category-label. */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -473,6 +473,23 @@ html[data-theme="dark"] a[class^='tag_'] {
   } */
 }
 
+/* NEW badge next to H1 title on pages with new: true in frontmatter */
+.doc-new .markdown h1:first-of-type::after {
+  background-color: var(--scalar-green);
+  border-radius: 3px;
+  color: #fff;
+  content: "NEW";
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  margin-left: 10px;
+  padding: 3px 6px;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+
 /* The following Font Awesome-related styles are for the question mark next to the Editions tags. These styles are currently not being used but might be useful later. */
 a[class^='fa-solid fa-circle-question'] {
   color: #6B7280;
@@ -1243,4 +1260,18 @@ html[data-theme="dark"] .googleAiModeModalSubmitIcon:hover:not(:disabled) {
 
 .DocSearch-Button-Key {
   padding: 0;
+}
+
+/* Screen-reader-only utility: visually hidden but announced by assistive technology. */
+.sr-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }

--- a/src/theme/DocBreadcrumbs/index.js
+++ b/src/theme/DocBreadcrumbs/index.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Swizzled (ejected) to strip [BADGE] markers (e.g. [NEW]) from breadcrumb labels.
+// The markers are used in sidebars.js labels and rendered as badges in the sidebar,
+// but should not appear as plain text in breadcrumbs.
+
+import React from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {useSidebarBreadcrumbs} from '@docusaurus/plugin-content-docs/client';
+import {useHomePageRoute} from '@docusaurus/theme-common/internal';
+import Link from '@docusaurus/Link';
+import {translate} from '@docusaurus/Translate';
+import HomeBreadcrumbItem from '@theme/DocBreadcrumbs/Items/Home';
+import DocBreadcrumbsStructuredData from '@theme/DocBreadcrumbs/StructuredData';
+
+const BADGE_PATTERN = /\s*\[[A-Z]+\]$/;
+
+function stripBadgeMarker(label) {
+  if (typeof label === 'string') {
+    return label.replace(BADGE_PATTERN, '');
+  }
+  return label;
+}
+
+function BreadcrumbsItemLink({children, href, isLast}) {
+  const className = 'breadcrumbs__link';
+  if (isLast) {
+    return <span className={className}>{children}</span>;
+  }
+  return href ? (
+    <Link className={className} href={href}>
+      <span>{children}</span>
+    </Link>
+  ) : (
+    <span className={className}>{children}</span>
+  );
+}
+
+function BreadcrumbsItem({children, active}) {
+  return (
+    <li
+      className={clsx('breadcrumbs__item', {
+        'breadcrumbs__item--active': active,
+      })}>
+      {children}
+    </li>
+  );
+}
+
+export default function DocBreadcrumbs() {
+  const breadcrumbs = useSidebarBreadcrumbs();
+  const homePageRoute = useHomePageRoute();
+  if (!breadcrumbs) {
+    return null;
+  }
+
+  return (
+    <>
+      <DocBreadcrumbsStructuredData breadcrumbs={breadcrumbs} />
+      <nav
+        className={clsx(
+          ThemeClassNames.docs.docBreadcrumbs,
+          'breadcrumbsContainer',
+        )}
+        aria-label={translate({
+          id: 'theme.docs.breadcrumbs.navAriaLabel',
+          message: 'Breadcrumbs',
+          description: 'The ARIA label for the breadcrumbs',
+        })}>
+        <ul className="breadcrumbs">
+          {homePageRoute && <HomeBreadcrumbItem />}
+          {breadcrumbs.map((item, idx) => {
+            const isLast = idx === breadcrumbs.length - 1;
+            const href =
+              item.type === 'category' && item.linkUnlisted
+                ? undefined
+                : item.href;
+            return (
+              <BreadcrumbsItem key={idx} active={isLast}>
+                <BreadcrumbsItemLink href={href} isLast={isLast}>
+                  {stripBadgeMarker(item.label)}
+                </BreadcrumbsItemLink>
+              </BreadcrumbsItem>
+            );
+          })}
+        </ul>
+      </nav>
+    </>
+  );
+}

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import clsx from 'clsx';
 import { useWindowSize } from '@docusaurus/theme-common';
-import { useDoc } from '@docusaurus/plugin-content-docs/client';
+import { useDoc, useDocsSidebar } from '@docusaurus/plugin-content-docs/client';
 import DocItemPaginator from '@theme/DocItem/Paginator';
 import DocVersionBanner from '@theme/DocVersionBanner';
 import DocVersionBadge from '@theme/DocVersionBadge';
@@ -13,6 +13,28 @@ import DocBreadcrumbs from '@theme/DocBreadcrumbs';
 import ContentVisibility from '@theme/ContentVisibility';
 
 import styles from './styles.module.css';
+
+const BADGE_PATTERN = /\[[A-Z]+\]$/;
+
+type SidebarItem = {
+  type: string;
+  href?: string;
+  label?: string;
+  items?: SidebarItem[];
+};
+
+// Recursively search sidebar items for a link matching permalink that has a badge marker.
+function sidebarItemHasBadge(items: SidebarItem[], permalink: string): boolean {
+  for (const item of items) {
+    if (item.type === 'link' && item.href === permalink && BADGE_PATTERN.test(item.label ?? '')) {
+      return true;
+    }
+    if (item.type === 'category' && Array.isArray(item.items)) {
+      if (sidebarItemHasBadge(item.items, permalink)) return true;
+    }
+  }
+  return false;
+}
 
 // Define the type for the useDocTOC return value.
 interface DocTOC {
@@ -44,8 +66,10 @@ function useDocTOC(): DocTOC {
 const DocItemLayout: React.FC<DocItemLayoutProps> = ({ children }) => {
   const docTOC = useDocTOC();
   const { metadata, frontMatter } = useDoc();
+  const sidebar = useDocsSidebar();
   const hideTOC = frontMatter.hide_table_of_contents;
   const windowSize = useWindowSize();
+  const isNew = frontMatter['new'] || (sidebar != null && sidebarItemHasBadge(sidebar.items, metadata.permalink));
 
   return (
     <div className="row">
@@ -53,9 +77,10 @@ const DocItemLayout: React.FC<DocItemLayoutProps> = ({ children }) => {
         <ContentVisibility metadata={metadata} />
         <DocVersionBanner />
         <div className={styles.docItemContainer}>
-          <article>
+          <article className={clsx(isNew && 'doc-new')}>
             <DocBreadcrumbs />
             <DocVersionBadge />
+            {isNew && <span className="sr-only">New</span>}
             {docTOC.mobile}
             <DocItemContent>{children}</DocItemContent>
             <DocItemFooter />

--- a/src/theme/DocSidebarItem/Link/index.js
+++ b/src/theme/DocSidebarItem/Link/index.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {isActiveSidebarItem} from '@docusaurus/plugin-content-docs/client';
+import Link from '@docusaurus/Link';
+import isInternalUrl from '@docusaurus/isInternalUrl';
+import IconExternalLink from '@theme/Icon/ExternalLink';
+
+const BADGE_PATTERN = /^(.*?)\s*\[([A-Z]+)\]$/;
+
+function LinkLabel({label}) {
+  const match = typeof label === 'string' ? label.match(BADGE_PATTERN) : null;
+  if (match) {
+    return (
+      <span title={match[1]} className="linkLabel">
+        {match[1]}
+        <span className="badge--new">{match[2]}</span>
+      </span>
+    );
+  }
+  return (
+    <span title={label} className="linkLabel">
+      {label}
+    </span>
+  );
+}
+
+export default function DocSidebarItemLink({
+  item,
+  onItemClick,
+  activePath,
+  level,
+  index,
+  ...props
+}) {
+  const {href, label, className, autoAddBaseUrl} = item;
+  const isActive = isActiveSidebarItem(item, activePath);
+  const isInternalLink = isInternalUrl(href);
+  return (
+    <li
+      className={clsx(
+        ThemeClassNames.docs.docSidebarItemLink,
+        ThemeClassNames.docs.docSidebarItemLinkLevel(level),
+        'menu__list-item',
+        className,
+      )}
+      key={label}>
+      <Link
+        className={clsx(
+          'menu__link',
+          !isInternalLink && 'menuExternalLink',
+          {
+            'menu__link--active': isActive,
+          },
+        )}
+        autoAddBaseUrl={autoAddBaseUrl}
+        aria-current={isActive ? 'page' : undefined}
+        to={href}
+        {...(isInternalLink && {
+          onClick: onItemClick ? () => onItemClick(item) : undefined,
+        })}
+        {...props}>
+        <LinkLabel label={label} />
+        {!isInternalLink && <IconExternalLink />}
+      </Link>
+    </li>
+  );
+}

--- a/versioned_sidebars/version-3.15-sidebars.json
+++ b/versioned_sidebars/version-3.15-sidebars.json
@@ -169,7 +169,7 @@
         {
           "type": "doc",
           "id": "scalardb-cluster/getting-started-with-vector-search",
-          "label": "Try Running Vector Search Through ScalarDB Cluster"
+          "label": "Try Running Vector Search Through ScalarDB Cluster [NEW]"
         }
       ]
     },
@@ -277,7 +277,7 @@
                 {
                   "type": "doc",
                   "id": "scalardb-cluster/authorize-with-abac",
-                  "label": "Control User Access in a Fine-Grained Manner"
+                  "label": "Control User Access in a Fine-Grained Manner [NEW]"
                 },
                 {
                   "type": "doc",
@@ -951,7 +951,7 @@
             {
               "type": "doc",
               "id": "scalardb-cluster/scalardb-abac-status-codes",
-              "label": "Attributed-Based Access Control"
+              "label": "Attributed-Based Access Control [NEW]"
             },
             {
               "type": "doc",
@@ -1193,7 +1193,7 @@
         {
           "type": "doc",
           "id": "scalardb-cluster/getting-started-with-vector-search",
-          "label": "ScalarDB Cluster を使用してベクトル検索を実行"
+          "label": "ScalarDB Cluster を使用してベクトル検索を実行 [NEW]"
         }
       ]
     },
@@ -1301,7 +1301,7 @@
                 {
                   "type": "doc",
                   "id": "scalardb-cluster/authorize-with-abac",
-                  "label": "ユーザーアクセスを細かく制御"
+                  "label": "ユーザーアクセスを細かく制御 [NEW]"
                 },
                 {
                   "type": "doc",
@@ -1975,7 +1975,7 @@
             {
               "type": "doc",
               "id": "scalardb-cluster/scalardb-abac-status-codes",
-              "label": "属性ベースのアクセス制御"
+              "label": "属性ベースのアクセス制御 [NEW]"
             },
             {
               "type": "doc",

--- a/versioned_sidebars/version-3.16-sidebars.json
+++ b/versioned_sidebars/version-3.16-sidebars.json
@@ -563,12 +563,12 @@
                     {
                       "type": "doc",
                       "id": "scalardb-mcp-server/getting-started-with-scalardb-mcp-server",
-                      "label": "Use ScalarDB MCP Server"
+                      "label": "Use ScalarDB MCP Server [NEW]"
                     },
                     {
                       "type": "doc",
                       "id": "scalardb-mcp-server/tools-reference",
-                      "label": "ScalarDB MCP Server Tools Reference"
+                      "label": "ScalarDB MCP Server Tools Reference [NEW]"
                     }
                   ]
                 }
@@ -872,7 +872,7 @@
             {
               "type": "doc",
               "id": "scalardb-cluster/remote-replication",
-              "label": "Replicate Data for High Availability"
+              "label": "Replicate Data for High Availability [NEW]"
             }
           ]
         },
@@ -1027,7 +1027,7 @@
             {
               "type": "doc",
               "id": "scalardb-cluster/scalardb-remote-replication-status-codes",
-              "label": "Remote Replication"
+              "label": "Remote Replication [NEW]"
             }
           ]
         }
@@ -1653,12 +1653,12 @@
                     {
                       "type": "doc",
                       "id": "scalardb-mcp-server/getting-started-with-scalardb-mcp-server",
-                      "label": "ScalarDB MCP Server を使用"
+                      "label": "ScalarDB MCP Server を使用 [NEW]"
                     },
                     {
                       "type": "doc",
                       "id": "scalardb-mcp-server/tools-reference",
-                      "label": "ScalarDB MCP Server ツールリファレンス"
+                      "label": "ScalarDB MCP Server ツールリファレンス [NEW]"
                     }
                   ]
                 }
@@ -1957,7 +1957,7 @@
             {
               "type": "doc",
               "id": "scalardb-cluster/remote-replication",
-              "label": "高可用性のためのデータレプリケーション"
+              "label": "高可用性のためのデータレプリケーション [NEW]"
             }
           ]
         },
@@ -2112,7 +2112,7 @@
             {
               "type": "doc",
               "id": "scalardb-cluster/scalardb-remote-replication-status-codes",
-              "label": "リモートレプリケーション"
+              "label": "リモートレプリケーション [NEW]"
             }
           ]
         }


### PR DESCRIPTION
## Description

This PR introduces a visual badge utility that lets editors flag new docs directly in the sidebar navigation and on the home page's **Recent features** cards. Readers get an at-a-glance signal when docs are new without any change to the doc files themselves—badges are driven entirely by a plain-text marker appended to label strings in the sidebar config or cards component.

To see this in action, see the following staging site: https://gleeful-jalebi-97307e.netlify.app/

> [!NOTE]
>
> The current primary use case for this visual badge utility is `[NEW]`. It can be extended in the future to use other badges (uppercase words in square brackets, like `[UPDATED]`, `[DEPRECATED]`, etc.), but we should assign other badges specific colors different from the green color that `[NEW]` uses.

## Related issues and/or PRs

A similar PR has been made for the ScalarDL docs site:

- https://github.com/scalar-labs/docs-scalardl/pull/1363

## Changes made

**New badge infrastructure:**

- **`src/theme/DocSidebarItem/Link/index.js`:** Custom Docusaurus theme component that strips trailing `[MARKER]` tokens from sidebar labels and renders them as a green badge.
- **`src/components/Cards/utils.tsx`:** Shared `parseBadgeLabel` helper used by all "Recent features" card files to split a label into text + optional badge.
- **`src/css/custom.css`:** CSS variables (`--badge-new-bg`, `--badge-new-text`) and badge styles, including a visually hidden `sr-only` span for screen readers.

**Badge applied to existing content:**

- **`src/components/Cards/3.15.tsx`, `3.16.tsx`, `3.17.tsx`, `3.18.tsx` (and matching `ja-jp/` variants):** updated to use `parseBadgeLabel` and `[NEW]` markers on newly added entries.
- **`sidebars.js`, `versioned_sidebars/version-3.15-sidebars.json`, `version-3.16-sidebars.json`, `version-3.17-sidebars.json`:** `[NEW]` markers added to newly surfaced docs.

**Contributor guidance:**

- **`.github/pull_request_template.md` and all four `.github/workflows/auto-create-pr-*.yml`:** Updated workflows with a checklist item prompting contributors to add `[NEW]` when introducing new pages.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
  - [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
  - [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A