### PR TITLE
Swap placement of "Manage" and "Migrate" categories in version home pages

### DIFF
--- a/src/components/Cards/3.15.tsx
+++ b/src/components/Cards/3.15.tsx
@@ -104,8 +104,8 @@ const categories = [
       },
       {
         cell: 2, // Third cell
-        links: ['develop-run-non-transactional-operations-overview'],
-        labels: ['Run Non-Transactional Storage Operations']
+        links: ['develop-run-analytical-queries-overview'],
+        labels: ['Run Analytical Queries']
       }
     ]
   },

--- a/src/components/Cards/3.15.tsx
+++ b/src/components/Cards/3.15.tsx
@@ -132,28 +132,6 @@ const categories = [
     ]
   },
   {
-    name: 'Migrate',
-    categoryLinks: [
-      // To add a link, use the format ['link1', 'link2']
-      // To add a label, use the format ['label1', 'label2']
-      {
-        cell: 0, // First cell
-        links: ['migrate-overview'],
-        labels: ['Migrate Overview']
-      },
-      {
-        cell: 1, // Second cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['Import Tables by Using Schema Loader']
-      },
-      {
-        cell: 2, // Third cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['Migrate Applications and Databases']
-      }
-    ]
-  },
-  {
     name: 'Manage',
     categoryLinks: [
       // To add a link, use the format ['link1', 'link2']
@@ -172,6 +150,28 @@ const categories = [
         cell: 2, // Third cell
         links: ['scalar-kubernetes/HowToUpgradeScalarDB'],
         labels: ['Upgrade ScalarDB']
+      }
+    ]
+  },
+  {
+    name: 'Migrate',
+    categoryLinks: [
+      // To add a link, use the format ['link1', 'link2']
+      // To add a label, use the format ['label1', 'label2']
+      {
+        cell: 0, // First cell
+        links: ['migrate-overview'],
+        labels: ['Migrate Overview']
+      },
+      {
+        cell: 1, // Second cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['Import Tables by Using Schema Loader']
+      },
+      {
+        cell: 2, // Third cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['Migrate Applications and Databases']
       }
     ]
   }

--- a/src/components/Cards/3.16.tsx
+++ b/src/components/Cards/3.16.tsx
@@ -104,8 +104,8 @@ const categories = [
       },
       {
         cell: 2, // Third cell
-        links: ['develop-run-non-transactional-operations-overview'],
-        labels: ['Run Non-Transactional Storage Operations']
+        links: ['develop-run-analytical-queries-overview'],
+        labels: ['Run Analytical Queries']
       }
     ]
   },

--- a/src/components/Cards/3.16.tsx
+++ b/src/components/Cards/3.16.tsx
@@ -132,28 +132,6 @@ const categories = [
     ]
   },
   {
-    name: 'Migrate',
-    categoryLinks: [
-      // To add a link, use the format ['link1', 'link2']
-      // To add a label, use the format ['label1', 'label2']
-      {
-        cell: 0, // First cell
-        links: ['migrate-overview'],
-        labels: ['Migrate Overview']
-      },
-      {
-        cell: 1, // Second cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['Import Tables by Using Schema Loader']
-      },
-      {
-        cell: 2, // Third cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['Migrate Applications and Databases']
-      }
-    ]
-  },
-  {
     name: 'Manage',
     categoryLinks: [
       // To add a link, use the format ['link1', 'link2']
@@ -172,6 +150,28 @@ const categories = [
         cell: 2, // Third cell
         links: ['scalar-kubernetes/HowToUpgradeScalarDB'],
         labels: ['Upgrade ScalarDB']
+      }
+    ]
+  },
+  {
+    name: 'Migrate',
+    categoryLinks: [
+      // To add a link, use the format ['link1', 'link2']
+      // To add a label, use the format ['label1', 'label2']
+      {
+        cell: 0, // First cell
+        links: ['migrate-overview'],
+        labels: ['Migrate Overview']
+      },
+      {
+        cell: 1, // Second cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['Import Tables by Using Schema Loader']
+      },
+      {
+        cell: 2, // Third cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['Migrate Applications and Databases']
       }
     ]
   }

--- a/src/components/Cards/3.17.tsx
+++ b/src/components/Cards/3.17.tsx
@@ -104,8 +104,8 @@ const categories = [
       },
       {
         cell: 2, // Third cell
-        links: ['develop-run-non-transactional-operations-overview'],
-        labels: ['Run Non-Transactional Storage Operations']
+        links: ['develop-run-analytical-queries-overview'],
+        labels: ['Run Analytical Queries']
       }
     ]
   },

--- a/src/components/Cards/3.17.tsx
+++ b/src/components/Cards/3.17.tsx
@@ -132,28 +132,6 @@ const categories = [
     ]
   },
   {
-    name: 'Migrate',
-    categoryLinks: [
-      // To add a link, use the format ['link1', 'link2']
-      // To add a label, use the format ['label1', 'label2']
-      {
-        cell: 0, // First cell
-        links: ['migrate-overview'],
-        labels: ['Migrate Overview']
-      },
-      {
-        cell: 1, // Second cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['Import Tables by Using Schema Loader']
-      },
-      {
-        cell: 2, // Third cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['Migrate Applications and Databases']
-      }
-    ]
-  },
-  {
     name: 'Manage',
     categoryLinks: [
       // To add a link, use the format ['link1', 'link2']
@@ -172,6 +150,28 @@ const categories = [
         cell: 2, // Third cell
         links: ['scalar-kubernetes/HowToUpgradeScalarDB'],
         labels: ['Upgrade ScalarDB']
+      }
+    ]
+  },
+  {
+    name: 'Migrate',
+    categoryLinks: [
+      // To add a link, use the format ['link1', 'link2']
+      // To add a label, use the format ['label1', 'label2']
+      {
+        cell: 0, // First cell
+        links: ['migrate-overview'],
+        labels: ['Migrate Overview']
+      },
+      {
+        cell: 1, // Second cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['Import Tables by Using Schema Loader']
+      },
+      {
+        cell: 2, // Third cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['Migrate Applications and Databases']
       }
     ]
   }

--- a/src/components/Cards/3.18.tsx
+++ b/src/components/Cards/3.18.tsx
@@ -104,8 +104,8 @@ const categories = [
       },
       {
         cell: 2, // Third cell
-        links: ['develop-run-non-transactional-operations-overview'],
-        labels: ['Run Non-Transactional Storage Operations']
+        links: ['develop-run-analytical-queries-overview'],
+        labels: ['Run Analytical Queries']
       }
     ]
   },

--- a/src/components/Cards/3.18.tsx
+++ b/src/components/Cards/3.18.tsx
@@ -132,28 +132,6 @@ const categories = [
     ]
   },
   {
-    name: 'Migrate',
-    categoryLinks: [
-      // To add a link, use the format ['link1', 'link2']
-      // To add a label, use the format ['label1', 'label2']
-      {
-        cell: 0, // First cell
-        links: ['migrate-overview'],
-        labels: ['Migrate Overview']
-      },
-      {
-        cell: 1, // Second cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['Import Tables by Using Schema Loader']
-      },
-      {
-        cell: 2, // Third cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['Migrate Applications and Databases']
-      }
-    ]
-  },
-  {
     name: 'Manage',
     categoryLinks: [
       // To add a link, use the format ['link1', 'link2']
@@ -172,6 +150,28 @@ const categories = [
         cell: 2, // Third cell
         links: ['scalar-kubernetes/HowToUpgradeScalarDB'],
         labels: ['Upgrade ScalarDB']
+      }
+    ]
+  },
+  {
+    name: 'Migrate',
+    categoryLinks: [
+      // To add a link, use the format ['link1', 'link2']
+      // To add a label, use the format ['label1', 'label2']
+      {
+        cell: 0, // First cell
+        links: ['migrate-overview'],
+        labels: ['Migrate Overview']
+      },
+      {
+        cell: 1, // Second cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['Import Tables by Using Schema Loader']
+      },
+      {
+        cell: 2, // Third cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['Migrate Applications and Databases']
       }
     ]
   }

--- a/src/components/Cards/ja-jp/3.15.tsx
+++ b/src/components/Cards/ja-jp/3.15.tsx
@@ -132,28 +132,6 @@ const categories = [
     ]
   },
   {
-    name: '移行',
-    categoryLinks: [
-      // To add a link, use the format ['link1', 'link2']
-      // To add a label, use the format ['label1', 'label2']
-      {
-        cell: 0, // First cell
-        links: ['migrate-overview'],
-        labels: ['移行の概要']
-      },
-      {
-        cell: 1, // Second cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
-      },
-      {
-        cell: 2, // Third cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
-      }
-    ]
-  },
-  {
     name: '管理',
     categoryLinks: [
       // To add a link, use the format ['link1', 'link2']
@@ -172,6 +150,28 @@ const categories = [
         cell: 2, // Third cell
         links: ['scalar-kubernetes/HowToUpgradeScalarDB'],
         labels: ['ScalarDB のアップグレード方法']
+      }
+    ]
+  },
+  {
+    name: '移行',
+    categoryLinks: [
+      // To add a link, use the format ['link1', 'link2']
+      // To add a label, use the format ['label1', 'label2']
+      {
+        cell: 0, // First cell
+        links: ['migrate-overview'],
+        labels: ['移行の概要']
+      },
+      {
+        cell: 1, // Second cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
+      },
+      {
+        cell: 2, // Third cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
       }
     ]
   }

--- a/src/components/Cards/ja-jp/3.15.tsx
+++ b/src/components/Cards/ja-jp/3.15.tsx
@@ -104,8 +104,8 @@ const categories = [
       },
       {
         cell: 2, // Third cell
-        links: ['develop-run-non-transactional-operations-overview'],
-        labels: ['非トランザクションストレージ操作を実行']
+        links: ['develop-run-analytical-queries-overview'],
+        labels: ['分析クエリの実行']
       }
     ]
   },

--- a/src/components/Cards/ja-jp/3.16.tsx
+++ b/src/components/Cards/ja-jp/3.16.tsx
@@ -132,28 +132,6 @@ const categories = [
     ]
   },
   {
-    name: '移行',
-    categoryLinks: [
-      // To add a link, use the format ['link1', 'link2']
-      // To add a label, use the format ['label1', 'label2']
-      {
-        cell: 0, // First cell
-        links: ['migrate-overview'],
-        labels: ['移行の概要']
-      },
-      {
-        cell: 1, // Second cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
-      },
-      {
-        cell: 2, // Third cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
-      }
-    ]
-  },
-  {
     name: '管理',
     categoryLinks: [
       // To add a link, use the format ['link1', 'link2']
@@ -172,6 +150,28 @@ const categories = [
         cell: 2, // Third cell
         links: ['scalar-kubernetes/HowToUpgradeScalarDB'],
         labels: ['ScalarDB のアップグレード方法']
+      }
+    ]
+  },
+  {
+    name: '移行',
+    categoryLinks: [
+      // To add a link, use the format ['link1', 'link2']
+      // To add a label, use the format ['label1', 'label2']
+      {
+        cell: 0, // First cell
+        links: ['migrate-overview'],
+        labels: ['移行の概要']
+      },
+      {
+        cell: 1, // Second cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
+      },
+      {
+        cell: 2, // Third cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
       }
     ]
   }

--- a/src/components/Cards/ja-jp/3.16.tsx
+++ b/src/components/Cards/ja-jp/3.16.tsx
@@ -104,8 +104,8 @@ const categories = [
       },
       {
         cell: 2, // Third cell
-        links: ['develop-run-non-transactional-operations-overview'],
-        labels: ['非トランザクションストレージ操作を実行']
+        links: ['develop-run-analytical-queries-overview'],
+        labels: ['分析クエリの実行']
       }
     ]
   },

--- a/src/components/Cards/ja-jp/3.17.tsx
+++ b/src/components/Cards/ja-jp/3.17.tsx
@@ -132,28 +132,6 @@ const categories = [
     ]
   },
   {
-    name: '移行',
-    categoryLinks: [
-      // To add a link, use the format ['link1', 'link2']
-      // To add a label, use the format ['label1', 'label2']
-      {
-        cell: 0, // First cell
-        links: ['migrate-overview'],
-        labels: ['移行の概要']
-      },
-      {
-        cell: 1, // Second cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
-      },
-      {
-        cell: 2, // Third cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
-      }
-    ]
-  },
-  {
     name: '管理',
     categoryLinks: [
       // To add a link, use the format ['link1', 'link2']
@@ -172,6 +150,28 @@ const categories = [
         cell: 2, // Third cell
         links: ['scalar-kubernetes/HowToUpgradeScalarDB'],
         labels: ['ScalarDB のアップグレード方法']
+      }
+    ]
+  },
+  {
+    name: '移行',
+    categoryLinks: [
+      // To add a link, use the format ['link1', 'link2']
+      // To add a label, use the format ['label1', 'label2']
+      {
+        cell: 0, // First cell
+        links: ['migrate-overview'],
+        labels: ['移行の概要']
+      },
+      {
+        cell: 1, // Second cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
+      },
+      {
+        cell: 2, // Third cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
       }
     ]
   }

--- a/src/components/Cards/ja-jp/3.17.tsx
+++ b/src/components/Cards/ja-jp/3.17.tsx
@@ -104,8 +104,8 @@ const categories = [
       },
       {
         cell: 2, // Third cell
-        links: ['develop-run-non-transactional-operations-overview'],
-        labels: ['非トランザクションストレージ操作を実行']
+        links: ['develop-run-analytical-queries-overview'],
+        labels: ['分析クエリの実行']
       }
     ]
   },

--- a/src/components/Cards/ja-jp/3.18.tsx
+++ b/src/components/Cards/ja-jp/3.18.tsx
@@ -132,28 +132,6 @@ const categories = [
     ]
   },
   {
-    name: '移行',
-    categoryLinks: [
-      // To add a link, use the format ['link1', 'link2']
-      // To add a label, use the format ['label1', 'label2']
-      {
-        cell: 0, // First cell
-        links: ['migrate-overview'],
-        labels: ['移行の概要']
-      },
-      {
-        cell: 1, // Second cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
-      },
-      {
-        cell: 2, // Third cell
-        links: ['scalardb-sql/migration-guide'],
-        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
-      }
-    ]
-  },
-  {
     name: '管理',
     categoryLinks: [
       // To add a link, use the format ['link1', 'link2']
@@ -172,6 +150,28 @@ const categories = [
         cell: 2, // Third cell
         links: ['scalar-kubernetes/HowToUpgradeScalarDB'],
         labels: ['ScalarDB のアップグレード方法']
+      }
+    ]
+  },
+  {
+    name: '移行',
+    categoryLinks: [
+      // To add a link, use the format ['link1', 'link2']
+      // To add a label, use the format ['label1', 'label2']
+      {
+        cell: 0, // First cell
+        links: ['migrate-overview'],
+        labels: ['移行の概要']
+      },
+      {
+        cell: 1, // Second cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
+      },
+      {
+        cell: 2, // Third cell
+        links: ['scalardb-sql/migration-guide'],
+        labels: ['アプリケーションとデータベースを ScalarDB ベースの環境に移行する方法']
       }
     ]
   }

--- a/src/components/Cards/ja-jp/3.18.tsx
+++ b/src/components/Cards/ja-jp/3.18.tsx
@@ -104,8 +104,8 @@ const categories = [
       },
       {
         cell: 2, // Third cell
-        links: ['develop-run-non-transactional-operations-overview'],
-        labels: ['非トランザクションストレージ操作を実行']
+        links: ['develop-run-analytical-queries-overview'],
+        labels: ['分析クエリの実行']
       }
     ]
   },


### PR DESCRIPTION
## Description

This PR swaps the placement of the "Manage" and "Migrate" categories in the version home pages for 3.15 to 3.18 across both English and Japanese documentation. In addition, the links in the "Develop" section were updated to better reflect the sub-category overviews in that category.

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-scalardb/pull/2232
- https://github.com/scalar-labs/docs-scalardb/pull/2259

## Changes made

**Category reordering and relabeling**

* Swapped the "Migrate" and "Manage" categories in the `categories` array for `3.15.tsx`, `3.16.tsx`, `3.17.tsx`, and `3.18.tsx`, so "Manage" now appears before "Migrate" in both English and Japanese documentation. Category names and their corresponding links/labels were updated to match the new order.

**Link updates**

* Changed the link to the overview for non-transactional storage operations to the overview for analytical operations since that's more aligned with the sidebar navigation

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A