### PR TITLE
Revise DocVersionBanner with link to upgrade guide and translation improvements

### DIFF
--- a/i18n/versioned_docs/ja-jp/code.json
+++ b/i18n/versioned_docs/ja-jp/code.json
@@ -1,0 +1,289 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "エラーが発生しました",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "先頭へ戻る",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "アーカイブ",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "アーカイブ",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "ブログ記事一覧のナビゲーション",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "新しい記事",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "過去の記事",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "ブログ記事のナビゲーション",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "新しい記事",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "過去の記事",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.blog.post.plurals": {
+    "message": "{count}件",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "「{tagName}」タグの記事が{nPosts}件あります",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "全てのタグを見る",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "パンくずリストのナビゲーション",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "{count}項目",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "ダークモードを切り替える(現在は{mode})",
+    "description": "The ARIA label for the navbar color mode toggle"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "ダークモード",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "ライトモード",
+    "description": "The name for the light color mode"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "ドキュメントページ",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "前へ",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "次へ",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "{count}記事",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "「{tagName}」タグのついた{nDocsTagged}",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "バージョン: {versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "これはリリース前のバージョン{versionLabel}の{siteTitle}のドキュメントです。",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "これはバージョン{versionLabel}の{siteTitle}のドキュメントで現在はメンテナンスされていません",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "最新のドキュメントは{latestVersionLink} ({versionLabel}) を見てください",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "最新バージョン",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "このページを編集",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "{heading} への直接リンク",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": "{date}に",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": "{user}が",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "{atDate}{byUser}最終更新",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "他のバージョン",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.NotFound.title": {
+    "message": "ページが見つかりません",
+    "description": "The title of the 404 page"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "タグ:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "閉じる",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.admonition.caution": {
+    "message": "注意",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "危険",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "備考",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "注記",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "ヒント",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "警告",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "最近のブログ記事のナビゲーション",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "コピーしました",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "クリップボードにコードをコピー",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "コピー",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "折り返し",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "'{label}'の目次を開く",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "'{label}'の目次を隠す",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "他の言語",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "ナビゲーション",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.NotFound.p1": {
+    "message": "お探しのページが見つかりませんでした",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "このページにリンクしているサイトの所有者にリンクが壊れていることを伝えてください",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.blog.post.readMore": {
+    "message": "もっと見る",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "{title}についてもっと見る",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "このページの見出し",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "約{readingTime}分",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "ホームページ",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "サイドバーを隠す",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "サイドバーを隠す",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "ドキュメントのサイドバー",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "ナビゲーションバーを閉じる",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← メインメニューに戻る",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "ナビゲーションバーを開く",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "サイドバーを開く",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "サイドバーを開く",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "もう一度試してください",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "メインコンテンツまでスキップ",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "タグ",
+    "description": "The title of the tag list page"
+  },
+  "theme.unlistedContent.title": {
+    "message": "非公開のページ",
+    "description": "The unlisted content banner title"
+  },
+  "theme.unlistedContent.message": {
+    "message": "このページは非公開です。 検索対象外となり、このページのリンクに直接アクセスできるユーザーのみに公開されます。",
+    "description": "The unlisted content banner message"
+  }
+}

--- a/i18n/versioned_docs/ja-jp/code.json
+++ b/i18n/versioned_docs/ja-jp/code.json
@@ -95,15 +95,15 @@
     "message": "バージョン: {versionLabel}"
   },
   "theme.docs.versions.unreleasedVersionLabel": {
-    "message": "これはリリース前のバージョン{versionLabel}の{siteTitle}のドキュメントです。",
+    "message": "これはリリース前のバージョン{versionLabel}の {siteTitle} のドキュメントです。",
     "description": "The label used to tell the user that he's browsing an unreleased doc version"
   },
   "theme.docs.versions.unmaintainedVersionLabel": {
-    "message": "これはバージョン{versionLabel}の{siteTitle}のドキュメントで現在はメンテナンスされていません",
+    "message": "これはバージョン{versionLabel}の {siteTitle} のドキュメントで現在はメンテナンスされていません。",
     "description": "The label used to tell the user that he's browsing an unmaintained doc version"
   },
   "theme.docs.versions.latestVersionSuggestionLabel": {
-    "message": "最新のドキュメントは{latestVersionLink} ({versionLabel}) を見てください",
+    "message": "最新のドキュメントは{latestVersionLink} ({versionLabel}) を見てください。",
     "description": "The label used to tell the user to check the latest version"
   },
   "theme.docs.versions.latestVersionLinkLabel": {

--- a/i18n/versioned_docs/ja-jp/code.json
+++ b/i18n/versioned_docs/ja-jp/code.json
@@ -99,12 +99,16 @@
     "description": "The label used to tell the user that he's browsing an unreleased doc version"
   },
   "theme.docs.versions.unmaintainedVersionLabel": {
-    "message": "これはバージョン{versionLabel}の {siteTitle} のドキュメントで現在はメンテナンスされていません。",
+    "message": "これは {siteTitle} {versionLabel} のドキュメントです。このソフトウェアバージョンは現在アクティブにメンテナンスされていません。",
     "description": "The label used to tell the user that he's browsing an unmaintained doc version"
   },
   "theme.docs.versions.latestVersionSuggestionLabel": {
-    "message": "最新のドキュメントは{latestVersionLink} ({versionLabel}) を見てください。",
+    "message": "ScalarDB {versionLabel} への{upgradeVersionLink}をご検討ください。",
     "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.upgradeVersionLinkLabel": {
+    "message": "アップグレード",
+    "description": "The label used for the latest version suggestion link label when the banner is 'unmaintained'"
   },
   "theme.docs.versions.latestVersionLinkLabel": {
     "message": "最新バージョン",

--- a/i18n/versioned_docs/ja-jp/code.json
+++ b/i18n/versioned_docs/ja-jp/code.json
@@ -95,12 +95,16 @@
     "message": "バージョン: {versionLabel}"
   },
   "theme.docs.versions.unreleasedVersionLabel": {
-    "message": "これはリリース前のバージョン{versionLabel}の {siteTitle} のドキュメントです。",
+    "message": "これはリリース前のバージョン{versionLabel}の ScalarDB のドキュメンテーションです。",
     "description": "The label used to tell the user that he's browsing an unreleased doc version"
   },
   "theme.docs.versions.unmaintainedVersionLabel": {
-    "message": "これは {siteTitle} {versionLabel} のドキュメントです。このソフトウェアバージョンは現在アクティブにメンテナンスされていません。",
+    "message": "これは ScalarDB {versionLabel} のドキュメンテーションです。このソフトウェアバージョンはすでに Maintenance Support の対象外です。詳細は{releaseSupportPolicyLink}を参照してください。",
     "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.releaseSupportPolicyLinkLabel": {
+    "message": "リリースサポートポリシー",
+    "description": "The label used for the release support policy link label when the banner is 'unmaintained'"
   },
   "theme.docs.versions.latestVersionSuggestionLabel": {
     "message": "ScalarDB {versionLabel} への{upgradeVersionLink}をご検討ください。",

--- a/i18n/versioned_docs/ja-jp/code.json
+++ b/i18n/versioned_docs/ja-jp/code.json
@@ -99,7 +99,7 @@
     "description": "The label used to tell the user that he's browsing an unreleased doc version"
   },
   "theme.docs.versions.unmaintainedVersionLabel": {
-    "message": "これは ScalarDB {versionLabel} のドキュメンテーションです。このソフトウェアバージョンはすでに Maintenance Support の対象外です。詳細は{releaseSupportPolicyLink}を参照してください。",
+    "message": "これは ScalarDB {versionLabel} のドキュメンテーションです。このバージョンはすでに Maintenance Support の対象外です。詳細は{releaseSupportPolicyLink}を参照してください。",
     "description": "The label used to tell the user that he's browsing an unmaintained doc version"
   },
   "theme.docs.versions.releaseSupportPolicyLinkLabel": {

--- a/src/theme/DocVersionBanner/index.tsx
+++ b/src/theme/DocVersionBanner/index.tsx
@@ -1,0 +1,169 @@
+import React, {type ComponentType, type ReactNode} from 'react';
+import clsx from 'clsx';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Link from '@docusaurus/Link';
+import Translate from '@docusaurus/Translate';
+import {
+  useActivePlugin,
+  useDocVersionSuggestions,
+  type GlobalVersion,
+} from '@docusaurus/plugin-content-docs/client';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {
+  useDocsPreferredVersion,
+  useDocsVersion,
+} from '@docusaurus/plugin-content-docs/client';
+import type {Props} from '@theme/DocVersionBanner';
+import type {
+  VersionBanner,
+  PropVersionMetadata,
+} from '@docusaurus/plugin-content-docs';
+
+type BannerLabelComponentProps = {
+  siteTitle: string;
+  versionMetadata: PropVersionMetadata;
+};
+
+function UnreleasedVersionLabel({
+  siteTitle,
+  versionMetadata,
+}: BannerLabelComponentProps) {
+  return (
+    <Translate
+      id="theme.docs.versions.unreleasedVersionLabel"
+      description="The label used to tell the user that he's browsing an unreleased doc version"
+      values={{
+        siteTitle,
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}>
+      {
+        'This is unreleased documentation for {siteTitle} {versionLabel} version.'
+      }
+    </Translate>
+  );
+}
+
+function UnmaintainedVersionLabel({
+  siteTitle,
+  versionMetadata,
+}: BannerLabelComponentProps) {
+  return (
+    <Translate
+      id="theme.docs.versions.unmaintainedVersionLabel"
+      description="The label used to tell the user that he's browsing an unmaintained doc version"
+      values={{
+        siteTitle,
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}>
+      {
+        'This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.'
+      }
+    </Translate>
+  );
+}
+
+const BannerLabelComponents: {
+  [banner in VersionBanner]: ComponentType<BannerLabelComponentProps>;
+} = {
+  unreleased: UnreleasedVersionLabel,
+  unmaintained: UnmaintainedVersionLabel,
+};
+
+function BannerLabel(props: BannerLabelComponentProps) {
+  const BannerLabelComponent =
+    BannerLabelComponents[props.versionMetadata.banner!];
+  return <BannerLabelComponent {...props} />;
+}
+
+function LatestVersionSuggestionLabel({
+  versionLabel,
+  to,
+  onClick,
+}: {
+  to: string;
+  onClick: () => void;
+  versionLabel: string;
+}) {
+  return (
+    <Translate
+      id="theme.docs.versions.latestVersionSuggestionLabel"
+      description="The label used to tell the user to check the latest version"
+      values={{
+        versionLabel,
+        latestVersionLink: (
+          <b>
+            <Link to={to} onClick={onClick}>
+              <Translate
+                id="theme.docs.versions.latestVersionLinkLabel"
+                description="The label used for the latest version suggestion link label">
+                latest version
+              </Translate>
+            </Link>
+          </b>
+        ),
+      }}>
+      {
+        'For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).'
+      }
+    </Translate>
+  );
+}
+
+function DocVersionBannerEnabled({
+  className,
+  versionMetadata,
+}: Props & {
+  versionMetadata: PropVersionMetadata;
+}): ReactNode {
+  const {
+    siteConfig: {title: siteTitle},
+  } = useDocusaurusContext();
+  const {pluginId} = useActivePlugin({failfast: true})!;
+
+  const getVersionMainDoc = (version: GlobalVersion) =>
+    version.docs.find((doc) => doc.id === version.mainDocId)!;
+
+  const {savePreferredVersionName} = useDocsPreferredVersion(pluginId);
+
+  const {latestDocSuggestion, latestVersionSuggestion} =
+    useDocVersionSuggestions(pluginId);
+
+  // Try to link to same doc in latest version (not always possible), falling
+  // back to main doc of latest version
+  const latestVersionSuggestedDoc =
+    latestDocSuggestion ?? getVersionMainDoc(latestVersionSuggestion);
+
+  return (
+    <div
+      className={clsx(
+        className,
+        ThemeClassNames.docs.docVersionBanner,
+        'alert alert--warning margin-bottom--md',
+      )}
+      role="alert">
+      <div>
+        <BannerLabel siteTitle={siteTitle} versionMetadata={versionMetadata} />
+      </div>
+      <div className="margin-top--md">
+        <LatestVersionSuggestionLabel
+          versionLabel={latestVersionSuggestion.label}
+          to={latestVersionSuggestedDoc.path}
+          onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function DocVersionBanner({className}: Props): ReactNode {
+  const versionMetadata = useDocsVersion();
+  if (versionMetadata.banner) {
+    return (
+      <DocVersionBannerEnabled
+        className={className}
+        versionMetadata={versionMetadata}
+      />
+    );
+  }
+  return null;
+}

--- a/src/theme/DocVersionBanner/index.tsx
+++ b/src/theme/DocVersionBanner/index.tsx
@@ -5,6 +5,7 @@ import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
 import {
   useActivePlugin,
+  useActiveVersion,
   useDocVersionSuggestions,
   type GlobalVersion,
 } from '@docusaurus/plugin-content-docs/client';
@@ -79,17 +80,21 @@ function LatestVersionSuggestionLabel({
   versionLabel,
   to,
   onClick,
+  upgradeDocPath,
 }: {
   to: string;
   onClick: () => void;
   versionLabel: string;
+  upgradeDocPath: string;
 }) {
   return (
     <Translate
       id="theme.docs.versions.latestVersionSuggestionLabel"
       description="The label used to tell the user to check the latest version"
       values={{
-        versionLabel,
+        versionLabel: (
+          <b>{versionLabel}</b>
+        ),
         latestVersionLink: (
           <b>
             <Link to={to} onClick={onClick}>
@@ -101,9 +106,20 @@ function LatestVersionSuggestionLabel({
             </Link>
           </b>
         ),
+        upgradeVersionLink: (
+          <b>
+            <Link to={upgradeDocPath} onClick={onClick}>
+              <Translate
+                id="theme.docs.versions.upgradeVersionLinkLabel"
+                description="The label used for the latest version suggestion link label when the banner is 'unmaintained'">
+                upgrading
+              </Translate>
+            </Link>
+          </b>
+        ),
       }}>
       {
-        'For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).'
+        'Please consider {upgradeVersionLink} to {versionLabel}.'
       }
     </Translate>
   );
@@ -119,6 +135,7 @@ function DocVersionBannerEnabled({
     siteConfig: {title: siteTitle},
   } = useDocusaurusContext();
   const {pluginId} = useActivePlugin({failfast: true})!;
+  const activeVersion = useActiveVersion(pluginId);
 
   const getVersionMainDoc = (version: GlobalVersion) =>
     version.docs.find((doc) => doc.id === version.mainDocId)!;
@@ -132,6 +149,18 @@ function DocVersionBannerEnabled({
   // back to main doc of latest version
   const latestVersionSuggestedDoc =
     latestDocSuggestion ?? getVersionMainDoc(latestVersionSuggestion);
+
+  // Find the upgrade doc in the current version
+  const getUpgradeDocPath = (): string => {
+    const upgradeDoc = activeVersion?.docs.find(
+      (doc) => doc.id.includes('HowToUpgradeScalarDB')
+    );
+    if (upgradeDoc) {
+      return upgradeDoc.path;
+    }
+    // Fallback to latest suggested doc if upgrade doc is not available
+    return latestVersionSuggestedDoc.path;
+  };
 
   return (
     <div
@@ -149,6 +178,7 @@ function DocVersionBannerEnabled({
           versionLabel={latestVersionSuggestion.label}
           to={latestVersionSuggestedDoc.path}
           onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
+          upgradeDocPath={getUpgradeDocPath()}
         />
       </div>
     </div>

--- a/src/theme/DocVersionBanner/index.tsx
+++ b/src/theme/DocVersionBanner/index.tsx
@@ -23,11 +23,13 @@ import type {
 type BannerLabelComponentProps = {
   siteTitle: string;
   versionMetadata: PropVersionMetadata;
+  releaseSupportPolicyDocPath: string;
 };
 
 function UnreleasedVersionLabel({
   siteTitle,
   versionMetadata,
+  releaseSupportPolicyDocPath,
 }: BannerLabelComponentProps) {
   return (
     <Translate
@@ -38,7 +40,7 @@ function UnreleasedVersionLabel({
         versionLabel: <b>{versionMetadata.label}</b>,
       }}>
       {
-        'This is unreleased documentation for {siteTitle} {versionLabel} version.'
+        'This is unreleased documentation for ScalarDB {versionLabel}.'
       }
     </Translate>
   );
@@ -47,6 +49,7 @@ function UnreleasedVersionLabel({
 function UnmaintainedVersionLabel({
   siteTitle,
   versionMetadata,
+  releaseSupportPolicyDocPath,
 }: BannerLabelComponentProps) {
   return (
     <Translate
@@ -55,9 +58,20 @@ function UnmaintainedVersionLabel({
       values={{
         siteTitle,
         versionLabel: <b>{versionMetadata.label}</b>,
+        releaseSupportPolicyLink: (
+          <b>
+            <Link to={releaseSupportPolicyDocPath}>
+              <Translate
+                id="theme.docs.versions.releaseSupportPolicyLinkLabel"
+                description="The label used for the release support policy link label when the banner is 'unmaintained'">
+                Release Support Policy
+              </Translate>
+            </Link>
+          </b>
+        ),
       }}>
       {
-        'This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.'
+        'This is documentation for ScalarDB {versionLabel}, which is no longer under Maintenance Support. For details, see the {releaseSupportPolicyLink}.'
       }
     </Translate>
   );
@@ -119,7 +133,7 @@ function LatestVersionSuggestionLabel({
         ),
       }}>
       {
-        'Please consider {upgradeVersionLink} to {versionLabel}.'
+        'Please consider {upgradeVersionLink} to ScalarDB {versionLabel}.'
       }
     </Translate>
   );
@@ -150,16 +164,12 @@ function DocVersionBannerEnabled({
   const latestVersionSuggestedDoc =
     latestDocSuggestion ?? getVersionMainDoc(latestVersionSuggestion);
 
-  // Find the upgrade doc in the current version
-  const getUpgradeDocPath = (): string => {
-    const upgradeDoc = activeVersion?.docs.find(
-      (doc) => doc.id.includes('HowToUpgradeScalarDB')
-    );
-    if (upgradeDoc) {
-      return upgradeDoc.path;
-    }
-    // Fallback to latest suggested doc if upgrade doc is not available
-    return latestVersionSuggestedDoc.path;
+  const getDocPathInCurrentVersion = (
+    docIdPart: string,
+    fallbackPath: string
+  ): string => {
+    const doc = activeVersion?.docs.find((item) => item.id.includes(docIdPart));
+    return doc?.path ?? fallbackPath;
   };
 
   return (
@@ -171,14 +181,24 @@ function DocVersionBannerEnabled({
       )}
       role="alert">
       <div>
-        <BannerLabel siteTitle={siteTitle} versionMetadata={versionMetadata} />
+        <BannerLabel
+          siteTitle="ScalarDB"
+          versionMetadata={versionMetadata}
+          releaseSupportPolicyDocPath={getDocPathInCurrentVersion(
+            'releases/release-support-policy',
+            latestVersionSuggestedDoc.path
+          )}
+        />
       </div>
       <div className="margin-top--md">
         <LatestVersionSuggestionLabel
           versionLabel={latestVersionSuggestion.label}
           to={latestVersionSuggestedDoc.path}
           onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
-          upgradeDocPath={getUpgradeDocPath()}
+          upgradeDocPath={getDocPathInCurrentVersion(
+            'HowToUpgradeScalarDB',
+            latestVersionSuggestedDoc.path
+          )}
         />
       </div>
     </div>


### PR DESCRIPTION
## Description

This PR refactors the banner for unmaintained versions of docs to guide users to the doc for how to upgrade their version of ScalarDB. Previously, the banner directed users to the latest version of ScalarDB docs (this is the default behavior in Docusaurus), but doing so doesn't recommend or guide users on how to upgrade ScalarDB.

You can see how the banner looks in the following staging environment: https://resilient-torrone-db-unmaintained.netlify.app/docs/3.14/

## Related issues and/or PRs

A similar PR has been made for the ScalarDL docs site:

- https://github.com/scalar-labs/docs-scalardl/pull/1375

## Changes made

**Component refactor and UX enhancements**

* Refactored `DocVersionBanner` into a modular React component, introducing distinct subcomponents for unreleased and unmaintained banners, and for the version suggestion label. (`src/theme/DocVersionBanner/index.tsx`)
* The banner now explicitly suggests upgrading to the latest version and, when possible, links directly to the upgrade guide (`HowToUpgradeScalarDB`). If the upgrade guide isn't found, it falls back to the main doc of the latest version. (`src/theme/DocVersionBanner/index.tsx`)
* Improved accessibility and visual clarity by restructuring the banner layout and using semantic HTML and CSS classes. (`src/theme/DocVersionBanner/index.tsx`)

**Japanese language improvements**
* Updated Japanese translation strings for unmaintained version labels and latest version suggestions to provide clearer messaging and actionable upgrade prompts. Added a new label for the upgrade link. (`i18n/versioned_docs/ja-jp/code.json`)

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A