### PR TITLE
Mark ScalarDB 3.14 and 3.15 as out of Maintenance Support

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -95,13 +95,13 @@ const config = {
               "3.15": {
                 label: '3.15',
                 path: '3.15',
-                banner: 'none',
+                banner: 'unmaintained',
                 className: '3.15.8',
               },
               "3.14": {
                 label: '3.14',
                 path: '3.14',
-                banner: 'none',
+                banner: 'unmaintained',
                 className: '3.14.6',
               },
             },


### PR DESCRIPTION
## Description

This PR marks ScalarDB 3.14 and 3.15 as no longer under Maintenance Support. Maintenance Support for 3.14 ended on February 20, 2026, and for 3.15 on June 23, 2026 (according to the [Release Support Policy](https://scalardb.scalar-labs.com/docs/latest/releases/release-support-policy)).

## Related issues and/or PRs

N/A

## Changes made

- Set `banner` in **docusaurus.config.js** for 3.14 and 3.15 docs to `unmaintained` to indicate that the versions are no longer actively maintained.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
	- [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
	- [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

I will merge this PR after two reviewers have approved it.