### PR TITLE
Adjust FAB z-index to prevent overlap with site update banner

### DIFF
--- a/src/components/Support/SupportDropdownMenu.tsx
+++ b/src/components/Support/SupportDropdownMenu.tsx
@@ -171,7 +171,9 @@ const SupportDropdownMenu: React.FC = () => {
         bottom: showBackToTop ? '80px' : '20px', // Move up when back-to-top is visible
         right: '20px',
         transition: 'bottom 0.3s ease',
-        zIndex: 1000
+        // Stay below the PWA "New version available" popup (z-index 999) and the
+        // cookie consent banner (z-index 1011), but above normal page content.
+        zIndex: 500
       }}
     >
       <button className="supportDropBtn" onClick={toggleDropdown}>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1280,7 +1280,9 @@ html[data-theme="dark"] .googleAiModeModalSubmitIcon:hover:not(:disabled) {
   gap: 0.5rem;
   position: fixed;
   right: calc(20px + 3rem + 0.625rem);
-  z-index: 1010;
+  /* Stay below the PWA "New version available" popup (z-index 999) and the
+     cookie consent banner (z-index 1011), but above normal page content. */
+  z-index: 500;
 }
 
 /* FAB trigger button */


### PR DESCRIPTION
## Description

This PR adjusts the stacking order (z-index) of the support dropdown and "Chat with Page" floating action buttons (FABs) to make them appear behind the "New version available" banner when the docs site has been updated. Prior to this change, the FABs appeared on top of the "New version available" banner, which blocked users from pressing the "Refresh" button in the banner.

## Related issues and/or PRs

Similar change made in the ScalarDL docs site repository:

- https://github.com/scalar-labs/docs-scalardl/pull/1404

## Changes made

* In `src/components/Support/SupportDropdownMenu.tsx`, set the `zIndex` of the support dropdown menu to `500`, ensuring it stays below the PWA "New version available" popup (`z-index: 999`) and the cookie consent banner (`z-index: 1011`), but above normal page content.
* In `src/css/custom.css`, updated the FAB trigger button's `z-index` to `500` with a comment explaining its position relative to other UI layers.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
	- [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
	- [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

I tried testing this by implementing the fix, running the site, and then making changes to a doc, and rebuilding the site both locally and in our Netlify staging environment, but I couldn't get the "New version available" banner to appear. I'll confirm whether this works or not in a comment after this PR has been merged.
