### PR TITLE
Optimize workflow timing for refreshing Context7 source

### DIFF
--- a/.github/workflows/refresh-context7-sources.yml
+++ b/.github/workflows/refresh-context7-sources.yml
@@ -2,7 +2,7 @@ name: Refresh Context7 library (llms-full.txt)
 
 on:
   schedule:
-    - cron: "0 23 * * 0" # Run every Sunday at 23:00 UTC (Monday at 8:00 AM JST).
+    - cron: "0 20 * * 0" # Run every Sunday at 20:00 UTC (Monday at 5:00 AM JST).
   workflow_dispatch:
     inputs:
       library_name:


### PR DESCRIPTION
## Description

This PR updates the schedule for the `refresh-context7-sources.yml` GitHub Actions workflow. This is needed because the workflow often runs long (2.5+ hours), which causes the [Context7 workflow for the ScalarDL docs site content](https://github.com/scalar-labs/docs-scalardl/blob/eecc7f890d648a2f4ff33d60e5a96d57a1aa74d4/.github/workflows/refresh-context7-sources.yml) to fail. The reason for the failed Context7 source update on the ScalarDL docs site content is because only one library can be processed at a time in Context7.

The workflow will now run three hours earlier each Monday morning, which should give Context7 ample time to finish processing the ScalarDB docs site content before the ScalarDL docs site content is schedule to run.

## Related issues and/or PRs

N/A

## Changes made

* Updated the cron schedule in `.github/workflows/refresh-context7-sources.yml` to run every Sunday at 20:00 UTC (Monday at 5:00 AM JST) instead of 23:00 UTC (Monday at 8:00 AM JST).

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
	- [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
	- [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A