### PR TITLE
Add patch version release notes for 3.18.1, 3.17.4, 3.16.6, and 3.15.9

### DIFF
--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -10,6 +10,61 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.18.
 
+## v3.18.1
+
+**Release date:** August 2, 2026
+
+### Summary
+
+This release improves `repairTable` to avoid unnecessary metadata and indexing-policy updates, adds support for `jdbc:spanner` connection strings, fixes multiple Consensus Commit transaction handling issues, improves ScalarDB Cluster metadata repair and ScalarDB SQL SELECT execution, resolves Cluster rollback/pause and SQL statement cache bugs, and upgrades several dependencies to address security vulnerabilities.
+
+### Community edition
+
+#### Improvements
+
+- Improved `repairTable` to skip rewriting a table's metadata when it is already up to date (and, for Cosmos DB, to skip updating the container indexing policy when it already matches), avoiding unnecessary writes. ([#3613](https://github.com/scalar-labs/scalardb/pull/3613))
+
+#### Bug fixes
+
+- Accepts connection string starting with `jdbc:spanner` to connect to Spanner (emulator, omni, and cloud instance) in addition to the already supported `jdbc:cloudspanner` pattern. ([#3559](https://github.com/scalar-labs/scalardb/pull/3559))
+- Fixed an issue in Consensus Commit where a `Get` operation using a secondary index could fail with an `IllegalArgumentException` when another record with the same indexed value was concurrently being deleted and inserted. ([#3607](https://github.com/scalar-labs/scalardb/pull/3607))
+- Fixed an issue in Consensus Commit where a read-only transaction could fail when coordinator write omission on read-only was disabled and coordinator group commit was enabled. ([#3614](https://github.com/scalar-labs/scalardb/pull/3614))
+- Fixed a bug where aborting an in-flight, group-committed transaction by ID via `DistributedTransactionManager.rollback(String)` / `abort(String)` could be lost when the Coordinator group commit feature was enabled. ([#3619](https://github.com/scalar-labs/scalardb/pull/3619))
+- Fixed an issue in the Consensus Commit transaction manager where a read could return a stale (pre-commit) value for a record whose writing transaction committed concurrently during lazy recovery. ([#3621](https://github.com/scalar-labs/scalardb/pull/3621))
+- Upgraded the Jackson, Netty, Azure Cosmos DB, and Azure Blob Storage libraries to fix security issues: [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9) ([#3754](https://github.com/scalar-labs/scalardb/pull/3754))
+- Upgraded the PostgreSQL JDBC driver to fix security issues: [CVE-2026-42198](https://github.com/advisories/GHSA-98qh-xjc8-98pq) and [CVE-2026-54291](https://github.com/advisories/GHSA-j92g-9f8w-j867) ([#3758](https://github.com/scalar-labs/scalardb/pull/3758))
+
+### Enterprise edition
+
+#### Enhancements
+
+##### ScalarDB SQL
+
+- Added `@AutoConfigureBefore` to `ScalarDbJdbcConfiguration` to explicitly declare auto-configuration ordering relative to Spring Boot's auto-configs.
+
+#### Improvements
+
+##### ScalarDB Cluster
+
+- ScalarDB Cluster now repairs its authentication and ABAC system metadata tables at node startup to create the companion before-image secondary indexes required after upgrading, so deployments upgraded from an earlier version gain them automatically without a manual `repairTable()`.
+
+##### ScalarDB SQL
+
+- Enabled the read-only optimization for one-shot SELECT statements and SELECT-only batches.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Fixed a bug where a `rollback` that exceeded the cluster's request-forwarding hop limit was silently reported as successful instead of surfacing the failure, which could leave records prepared until lazy recovery.
+- Fixed a race condition where pausing a cluster node or the Transaction Coordinator could report success while the node remained unpaused. This could happen when an unpause or another pause request was issued concurrently, and also when a pause that waits for outstanding requests timed out after an earlier pause had already succeeded.
+- Upgraded the Jackson, Netty, and LangChain4j libraries to fix security issues: [CVE-2026-40682](https://github.com/advisories/GHSA-4v8g-86x5-3vrc), [CVE-2026-42027](https://github.com/advisories/GHSA-cx4m-2p55-rw7j), [CVE-2026-42440](https://github.com/advisories/GHSA-659w-93r5-9j6m), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55405](https://github.com/advisories/GHSA-2mfg-cc43-9pcj), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9)
+- Upgraded the Bouncy Castle library and the grpc_health_probe binary to fix security issues: [CVE-2025-14813](https://github.com/advisories/GHSA-574f-3g2m-x479), [CVE-2026-5598](https://github.com/advisories/GHSA-p93r-85wp-75v3), [CVE-2026-25681](https://github.com/advisories/GHSA-w9p8-pvxh-rxpj), [CVE-2026-27136](https://github.com/advisories/GHSA-m9x8-m34x-fj9q), [CVE-2026-27145](https://github.com/advisories/GHSA-4279-q6mj-392r), [CVE-2026-33811](https://github.com/advisories/GHSA-497x-jcxf-m478), CVE-2026-33814, [CVE-2026-39820](https://github.com/advisories/GHSA-p9h5-jm8x-mjm5), [CVE-2026-39821](https://github.com/advisories/GHSA-w2q5-6q6x-x959), [CVE-2026-39822](https://github.com/advisories/GHSA-xcgv-8mv7-v8c7), [CVE-2026-39836](https://github.com/advisories/GHSA-8g2r-hhvj-mv99), [CVE-2026-42499](https://github.com/advisories/GHSA-xq5j-9r39-c3vf), and [CVE-2026-42504](https://github.com/advisories/GHSA-h524-452v-82p9)
+
+##### ScalarDB SQL
+
+- Fixed a statement cache regression where non-parameterized DML statements occupied cache slots intended for parameterized SQL. Cache eligibility is now correctly gated on the presence of bind markers in the parsed SQL.
+
 ## v3.18.0
 
 **Release date:** May 1, 2026

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,25 +78,25 @@ const config = {
                 label: '3.18',
                 path: 'latest', // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 banner: 'none',
-                className: '3.18.0',
+                className: '3.18.1',
               },
               "3.17": {
                 label: '3.17',
                 path: '3.17',
                 banner: 'none',
-                className: '3.17.3',
+                className: '3.17.4',
               },
               "3.16": {
                 label: '3.16',
                 path: '3.16',
                 banner: 'none',
-                className: '3.16.5',
+                className: '3.16.6',
               },
               "3.15": {
                 label: '3.15',
                 path: '3.15',
                 banner: 'unmaintained',
-                className: '3.15.8',
+                className: '3.15.9',
               },
               "3.14": {
                 label: '3.14',

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -14,6 +14,61 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.18 のリリースノートのリストが含まれています。
 
+## v3.18.1
+
+**発売日:** 2026年8月2日
+
+### まとめ
+
+このリリースでは、不要なメタデータおよびインデックスポリシーの更新を回避するために `repairTable` を改善し、`jdbc:spanner` 接続文字列のサポートを追加し、複数の Consensus Commit トランザクション処理の問題を修正し、ScalarDB Cluster のメタデータ修復と ScalarDB SQL の SELECT 実行を改善し、クラスターのロールバック/一時停止と SQL ステートメントキャッシュのバグを解決し、セキュリティの脆弱性に対処するためにいくつかの依存関係をアップグレードしました。
+
+### Community edition
+
+#### 改善点
+
+- メタデータが既に最新の状態の場合にテーブルのメタデータの再書き込みをスキップする (Cosmos DB の場合は、コンテナーのインデックスポリシーが既に一致する場合にその更新もスキップする) ように `repairTable` を改善し、不要な書き込みを回避するようにしました。 ([#3613](https://github.com/scalar-labs/scalardb/pull/3613))
+
+#### バグの修正
+
+- Spanner (エミュレーター、omni、クラウドインスタンス) に接続するために、既にサポートされている `jdbc:cloudspanner` パターンに加えて、`jdbc:spanner` で始まる接続文字列を受け入れるようになりました。 ([#3559](https://github.com/scalar-labs/scalardb/pull/3559))
+- 同じインデックス値を持つ別のレコードが同時に削除および挿入されている場合に、セカンダリインデックスを使用した `Get` 操作が `IllegalArgumentException` で失敗する可能性がある Consensus Commit の問題を修正しました。 ([#3607](https://github.com/scalar-labs/scalardb/pull/3607))
+- 読み取り専用でのコーディネーター書き込み省略が無効で、コーディネーターのグループコミットが有効な場合に、読み取り専用トランザクションが失敗する可能性がある Consensus Commit の問題を修正しました。 ([#3614](https://github.com/scalar-labs/scalardb/pull/3614))
+- コーディネーターのグループコミット機能が有効になっている場合に、`DistributedTransactionManager.rollback(String)` / `abort(String)` を使用して ID でインフライトのグループコミットされたトランザクションをアボートすると、その操作が失われる可能性があるバグを修正しました。 ([#3619](https://github.com/scalar-labs/scalardb/pull/3619))
+- lazy recovery 中に書き込みトランザクションが同時にコミットされたレコードの読み取りが、古い (コミット前の) 値を返す可能性がある Consensus Commit トランザクションマネージャーの問題を修正しました。 ([#3621](https://github.com/scalar-labs/scalardb/pull/3621))
+- Jackson、Netty、Azure Cosmos DB、および Azure Blob Storage ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9) ([#3754](https://github.com/scalar-labs/scalardb/pull/3754))
+- PostgreSQL JDBC ドライバーをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-42198](https://github.com/advisories/GHSA-98qh-xjc8-98pq) and [CVE-2026-54291](https://github.com/advisories/GHSA-j92g-9f8w-j867) ([#3758](https://github.com/scalar-labs/scalardb/pull/3758))
+
+### Enterprise edition
+
+#### 機能強化
+
+##### ScalarDB SQL
+
+- Spring Boot の自動設定に対する自動設定の順序を明示的に宣言するために、`ScalarDbJdbcConfiguration` に `@AutoConfigureBefore` を追加しました。
+
+#### 改善点
+
+##### ScalarDB Cluster
+
+- ScalarDB Cluster は、アップグレード後に必要なコンパニオン before-image セカンダリインデックスを作成するために、ノード起動時に認証および ABAC システムメタデータテーブルを修復するようになりました。これにより、以前のバージョンからアップグレードされたデプロイメントは、手動で `repairTable()` を実行することなく、自動的にこれらのインデックスを取得できます。
+
+##### ScalarDB SQL
+
+- ワンショット SELECT ステートメントおよび SELECT のみのバッチに対する読み取り専用最適化を有効にしました。
+
+#### バグの修正
+
+##### ScalarDB Cluster
+
+- クラスターのリクエスト転送ホップ制限を超えた `rollback` が失敗を表面化する代わりにサイレントに成功として報告されるバグを修正しました。これにより、lazy recovery までレコードが prepared 状態のままになる可能性がありました。
+- クラスターノードまたはトランザクションコーディネーターの一時停止がノードが一時停止されていないにもかかわらず成功と報告されるレースコンディションを修正しました。これは、一時停止解除または別の一時停止リクエストが同時に発行された場合、および以前の一時停止がすでに成功した後に未処理リクエストを待機する一時停止がタイムアウトした場合に発生する可能性がありました。
+- Jackson、Netty、および LangChain4j ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-40682](https://github.com/advisories/GHSA-4v8g-86x5-3vrc), [CVE-2026-42027](https://github.com/advisories/GHSA-cx4m-2p55-rw7j), [CVE-2026-42440](https://github.com/advisories/GHSA-659w-93r5-9j6m), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55405](https://github.com/advisories/GHSA-2mfg-cc43-9pcj), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9)
+- Bouncy Castle ライブラリおよび grpc_health_probe バイナリをアップグレードしてセキュリティ問題を修正しました: [CVE-2025-14813](https://github.com/advisories/GHSA-574f-3g2m-x479), [CVE-2026-5598](https://github.com/advisories/GHSA-p93r-85wp-75v3), [CVE-2026-25681](https://github.com/advisories/GHSA-w9p8-pvxh-rxpj), [CVE-2026-27136](https://github.com/advisories/GHSA-m9x8-m34x-fj9q), [CVE-2026-27145](https://github.com/advisories/GHSA-4279-q6mj-392r), [CVE-2026-33811](https://github.com/advisories/GHSA-497x-jcxf-m478), CVE-2026-33814, [CVE-2026-39820](https://github.com/advisories/GHSA-p9h5-jm8x-mjm5), [CVE-2026-39821](https://github.com/advisories/GHSA-w2q5-6q6x-x959), [CVE-2026-39822](https://github.com/advisories/GHSA-xcgv-8mv7-v8c7), [CVE-2026-39836](https://github.com/advisories/GHSA-8g2r-hhvj-mv99), [CVE-2026-42499](https://github.com/advisories/GHSA-xq5j-9r39-c3vf), and [CVE-2026-42504](https://github.com/advisories/GHSA-h524-452v-82p9)
+
+##### ScalarDB SQL
+
+- パラメーター化された SQL 用のキャッシュスロットを非パラメーター化 DML ステートメントが占有するステートメントキャッシュの不具合を修正しました。キャッシュ適格性は、解析された SQL 内のバインドマーカーの存在に基づいて正しく制御されるようになりました。
+
 ## v3.18.0
 
 **発売日:** 2026年05月01日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.15/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.15/releases/release-notes.mdx
@@ -14,6 +14,26 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.15 のリリースノートのリストが含まれています。
 
+## v3.15.9
+
+**発売日:** 2026年8月2日
+
+### まとめ
+
+このリリースでは、Community エディションと Enterprise エディションの両方の非推奨ポリシーを更新し、トランザクションのアボート、ロールバック、一時停止、およびメタデータキャッシュの無効化に関する問題を修正し、セキュリティの脆弱性に対処するためにいくつかの依存関係をアップグレードしました。
+
+### Community edition
+
+#### 改善点
+
+- 非推奨ポリシーを変更し、API と設定に非推奨のマーク付けされたものは 5.0.0 ではなく 4.0.0 で削除されるようになりました。 ([#3520](https://github.com/scalar-labs/scalardb/pull/3520))
+
+#### バグの修正
+
+- コーディネーターのグループコミット機能が有効になっている場合に、`DistributedTransactionManager.rollback(String)` / `abort(String)` を使用して ID でインフライトのグループコミットされたトランザクションをアボートすると、その操作が失われる可能性があるバグを修正しました。 ([#3619](https://github.com/scalar-labs/scalardb/pull/3619))
+- Jackson、Netty、Azure Cosmos DB、および Azure Blob Storage ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9) ([#3754](https://github.com/scalar-labs/scalardb/pull/3754))
+- PostgreSQL JDBC ドライバーおよび Netty ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-42198](https://github.com/advisories/GHSA-98qh-xjc8-98pq), [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), and [CVE-2026-54291](https://github.com/advisories/GHSA-j92g-9f8w-j867) ([#3761](https://github.com/scalar-labs/scalardb/pull/3761))
+
 ## v3.15.8
 
 **発売日:** 2026年4月15日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.16/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.16/releases/release-notes.mdx
@@ -14,6 +14,51 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.16 のリリースノートのリストが含まれています。
 
+## v3.16.6
+
+**リリース日:** 2026年8月2日
+
+### まとめ
+
+このリリースでは、非推奨ポリシーを更新し、`repairTable` の動作を改善し、Consensus Commit、クラスターのロールバック/一時停止、SQL メタデータキャッシュの問題を修正し、Community エディションと Enterprise エディション全体でセキュリティの脆弱性に対処するためにいくつかの依存関係をアップグレードしました。
+
+### Community edition
+
+#### 改善点
+
+- 非推奨ポリシーを変更し、API と設定に非推奨のマーク付けされたものは 5.0.0 ではなく 4.0.0 で削除されるようになりました。 ([#3520](https://github.com/scalar-labs/scalardb/pull/3520))
+- メタデータが既に最新の状態の場合にテーブルのメタデータの再書き込みをスキップする (Cosmos DB の場合は、コンテナーのインデックスポリシーが既に一致する場合にその更新もスキップする) ように `repairTable` を改善し、不要な書き込みを回避するようにしました。 ([#3613](https://github.com/scalar-labs/scalardb/pull/3613))
+
+#### バグの修正
+
+- 同じインデックス値を持つ別のレコードが同時に削除および挿入されている場合に、セカンダリインデックスを使用した `Get` 操作が `IllegalArgumentException` で失敗する可能性がある Consensus Commit の問題を修正しました。 ([#3607](https://github.com/scalar-labs/scalardb/pull/3607))
+- 読み取り専用でのコーディネーター書き込み省略が無効で、コーディネーターのグループコミットが有効な場合に、読み取り専用トランザクションが失敗する可能性がある Consensus Commit の問題を修正しました。 ([#3614](https://github.com/scalar-labs/scalardb/pull/3614))
+- コーディネーターのグループコミット機能が有効になっている場合に、`DistributedTransactionManager.rollback(String)` / `abort(String)` を使用して ID でインフライトのグループコミットされたトランザクションをアボートすると、その操作が失われる可能性があるバグを修正しました。 ([#3619](https://github.com/scalar-labs/scalardb/pull/3619))
+- lazy recovery 中に書き込みトランザクションが同時にコミットされたレコードの読み取りが、古い (コミット前の) 値を返す可能性がある Consensus Commit トランザクションマネージャーの問題を修正しました。 ([#3621](https://github.com/scalar-labs/scalardb/pull/3621))
+- Jackson、Netty、Azure Cosmos DB、および Azure Blob Storage ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9) ([#3754](https://github.com/scalar-labs/scalardb/pull/3754))
+- PostgreSQL JDBC ドライバーおよび Netty ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-42198](https://github.com/advisories/GHSA-98qh-xjc8-98pq), [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), and [CVE-2026-54291](https://github.com/advisories/GHSA-j92g-9f8w-j867) ([#3760](https://github.com/scalar-labs/scalardb/pull/3760))
+
+### Enterprise edition
+
+#### 改善点
+
+##### ScalarDB Cluster
+
+- 非推奨ポリシーを変更し、非推奨とマーク付けされた API は 5.0.0 ではなく 4.0.0 で削除されるようになりました。
+
+#### バグの修正
+
+##### ScalarDB Cluster
+
+- クラスターのリクエスト転送ホップ制限を超えた `rollback` が失敗を表面化する代わりにサイレントに成功として報告されるバグを修正しました。これにより、lazy recovery までレコードが prepared 状態のままになる可能性がありました。
+- クラスターノードまたはトランザクションコーディネーターの一時停止がノードが一時停止されていないにもかかわらず成功と報告されるレースコンディションを修正しました。これは、一時停止解除または別の一時停止リクエストが同時に発行された場合、および以前の一時停止がすでに成功した後に未処理リクエストを待機する一時停止がタイムアウトした場合に発生する可能性がありました。
+- Jackson および Netty ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9)
+- Bouncy Castle ライブラリおよび grpc_health_probe バイナリをアップグレードしてセキュリティ問題を修正しました: [CVE-2025-14813](https://github.com/advisories/GHSA-574f-3g2m-x479), [CVE-2026-5598](https://github.com/advisories/GHSA-p93r-85wp-75v3), [CVE-2026-25681](https://github.com/advisories/GHSA-w9p8-pvxh-rxpj), [CVE-2026-27136](https://github.com/advisories/GHSA-m9x8-m34x-fj9q), [CVE-2026-27145](https://github.com/advisories/GHSA-4279-q6mj-392r), [CVE-2026-33811](https://github.com/advisories/GHSA-497x-jcxf-m478), CVE-2026-33814, [CVE-2026-39820](https://github.com/advisories/GHSA-p9h5-jm8x-mjm5), [CVE-2026-39821](https://github.com/advisories/GHSA-w2q5-6q6x-x959), [CVE-2026-39822](https://github.com/advisories/GHSA-xcgv-8mv7-v8c7), [CVE-2026-39836](https://github.com/advisories/GHSA-8g2r-hhvj-mv99), [CVE-2026-42499](https://github.com/advisories/GHSA-xq5j-9r39-c3vf), and [CVE-2026-42504](https://github.com/advisories/GHSA-h524-452v-82p9)
+
+##### ScalarDB SQL
+
+- `CachedMetadata#invalidateNamespaceNamesCache()` が実際に名前空間のキャッシュリストを無効にしなかった問題を修正しました。これにより `SHOW NAMESPACES` および関連操作がキャッシュ TTL が期限切れになるまで古い結果を返す可能性がありました。
+
 ## v3.16.5
 
 **リリース日:** 2026年4月15日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.17/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.17/releases/release-notes.mdx
@@ -14,6 +14,51 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDB 3.17 のリリースノートのリストが含まれています。
 
+## v3.17.4
+
+**発売日:** 2026年8月2日
+
+### まとめ
+
+このリリースでは、非推奨ポリシーを更新し、`repairTable` の動作を改善し、Consensus Commit、クラスターのロールバック/一時停止、SQL メタデータキャッシュに関するいくつかの問題を修正し、Community エディションと Enterprise エディション全体でセキュリティの脆弱性に対処するために複数の依存関係をアップグレードしました。
+
+### Community edition
+
+#### 改善点
+
+- 非推奨ポリシーを変更し、API と設定に非推奨のマーク付けされたものは 5.0.0 ではなく 4.0.0 で削除されるようになりました。 ([#3520](https://github.com/scalar-labs/scalardb/pull/3520))
+- メタデータが既に最新の状態の場合にテーブルのメタデータの再書き込みをスキップする (Cosmos DB の場合は、コンテナーのインデックスポリシーが既に一致する場合にその更新もスキップする) ように `repairTable` を改善し、不要な書き込みを回避するようにしました。 ([#3613](https://github.com/scalar-labs/scalardb/pull/3613))
+
+#### バグの修正
+
+- 同じインデックス値を持つ別のレコードが同時に削除および挿入されている場合に、セカンダリインデックスを使用した `Get` 操作が `IllegalArgumentException` で失敗する可能性がある Consensus Commit の問題を修正しました。 ([#3607](https://github.com/scalar-labs/scalardb/pull/3607))
+- 読み取り専用でのコーディネーター書き込み省略が無効で、コーディネーターのグループコミットが有効な場合に、読み取り専用トランザクションが失敗する可能性がある Consensus Commit の問題を修正しました。 ([#3614](https://github.com/scalar-labs/scalardb/pull/3614))
+- コーディネーターのグループコミット機能が有効になっている場合に、`DistributedTransactionManager.rollback(String)` / `abort(String)` を使用して ID でインフライトのグループコミットされたトランザクションをアボートすると、その操作が失われる可能性があるバグを修正しました。 ([#3619](https://github.com/scalar-labs/scalardb/pull/3619))
+- lazy recovery 中に書き込みトランザクションが同時にコミットされたレコードの読み取りが、古い (コミット前の) 値を返す可能性がある Consensus Commit トランザクションマネージャーの問題を修正しました。 ([#3621](https://github.com/scalar-labs/scalardb/pull/3621))
+- Jackson、Netty、Azure Cosmos DB、および Azure Blob Storage ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9) ([#3754](https://github.com/scalar-labs/scalardb/pull/3754))
+- PostgreSQL JDBC ドライバーをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-42198](https://github.com/advisories/GHSA-98qh-xjc8-98pq) and [CVE-2026-54291](https://github.com/advisories/GHSA-j92g-9f8w-j867) ([#3759](https://github.com/scalar-labs/scalardb/pull/3759))
+
+### Enterprise edition
+
+#### 改善点
+
+##### ScalarDB Cluster
+
+- 非推奨ポリシーを変更し、非推奨とマーク付けされた API は 5.0.0 ではなく 4.0.0 で削除されるようになりました。
+
+#### バグの修正
+
+##### ScalarDB Cluster
+
+- クラスターのリクエスト転送ホップ制限を超えた `rollback` が失敗を表面化する代わりにサイレントに成功として報告されるバグを修正しました。これにより、lazy recovery までレコードが prepared 状態のままになる可能性がありました。
+- クラスターノードまたはトランザクションコーディネーターの一時停止がノードが一時停止されていないにもかかわらず成功と報告されるレースコンディションを修正しました。これは、一時停止解除または別の一時停止リクエストが同時に発行された場合、および以前の一時停止がすでに成功した後に未処理リクエストを待機する一時停止がタイムアウトした場合に発生する可能性がありました。
+- Jackson、Netty、および LangChain4j ライブラリをアップグレードしてセキュリティ問題を修正しました: [CVE-2026-40682](https://github.com/advisories/GHSA-4v8g-86x5-3vrc), [CVE-2026-42027](https://github.com/advisories/GHSA-cx4m-2p55-rw7j), [CVE-2026-42440](https://github.com/advisories/GHSA-659w-93r5-9j6m), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55405](https://github.com/advisories/GHSA-2mfg-cc43-9pcj), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9)
+- Bouncy Castle ライブラリおよび grpc_health_probe バイナリをアップグレードしてセキュリティ問題を修正しました: [CVE-2025-14813](https://github.com/advisories/GHSA-574f-3g2m-x479), [CVE-2026-5598](https://github.com/advisories/GHSA-p93r-85wp-75v3), [CVE-2026-25681](https://github.com/advisories/GHSA-w9p8-pvxh-rxpj), [CVE-2026-27136](https://github.com/advisories/GHSA-m9x8-m34x-fj9q), [CVE-2026-27145](https://github.com/advisories/GHSA-4279-q6mj-392r), [CVE-2026-33811](https://github.com/advisories/GHSA-497x-jcxf-m478), CVE-2026-33814, [CVE-2026-39820](https://github.com/advisories/GHSA-p9h5-jm8x-mjm5), [CVE-2026-39821](https://github.com/advisories/GHSA-w2q5-6q6x-x959), [CVE-2026-39822](https://github.com/advisories/GHSA-xcgv-8mv7-v8c7), [CVE-2026-39836](https://github.com/advisories/GHSA-8g2r-hhvj-mv99), [CVE-2026-42499](https://github.com/advisories/GHSA-xq5j-9r39-c3vf), and [CVE-2026-42504](https://github.com/advisories/GHSA-h524-452v-82p9)
+
+##### ScalarDB SQL
+
+- `CachedMetadata#invalidateNamespaceNamesCache()` が実際に名前空間のキャッシュリストを無効にしなかった問題を修正しました。これにより `SHOW NAMESPACES` および関連操作がキャッシュ TTL が期限切れになるまで古い結果を返す可能性がありました。
+
 ## v3.17.3
 
 **発売日:** 2026年4月15日

--- a/versioned_docs/version-3.15/releases/release-notes.mdx
+++ b/versioned_docs/version-3.15/releases/release-notes.mdx
@@ -10,6 +10,47 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.15.
 
+## v3.15.9
+
+**Release date:** August 2, 2026
+
+### Summary
+
+This release updates the deprecation policy for both Community and Enterprise editions, fixes transaction abort, rollback, pause, and metadata cache invalidation issues, and upgrades several dependencies to address security vulnerabilities.
+
+### Community edition
+
+#### Improvements
+
+- Changed the deprecation policy so that APIs and configurations marked as deprecated will now be removed in 4.0.0 instead of 5.0.0. ([#3520](https://github.com/scalar-labs/scalardb/pull/3520))
+
+#### Bug fixes
+
+- Fixed a bug where aborting an in-flight, group-committed transaction by ID via `DistributedTransactionManager.rollback(String)` / `abort(String)` could be lost when the Coordinator group commit feature was enabled. ([#3619](https://github.com/scalar-labs/scalardb/pull/3619))
+- Upgraded the Jackson, Netty, Azure Cosmos DB, and Azure Blob Storage libraries to fix security issues: [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9) ([#3754](https://github.com/scalar-labs/scalardb/pull/3754))
+- Upgraded the PostgreSQL JDBC driver and the Netty library to fix security issues: [CVE-2026-42198](https://github.com/advisories/GHSA-98qh-xjc8-98pq), [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), and [CVE-2026-54291](https://github.com/advisories/GHSA-j92g-9f8w-j867) ([#3761](https://github.com/scalar-labs/scalardb/pull/3761))
+
+### Enterprise edition
+
+#### Improvements
+
+##### ScalarDB Cluster
+
+- Changed the deprecation policy so that APIs marked as deprecated will now be removed in 4.0.0 instead of 5.0.0.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Fixed a bug where a `rollback` that exceeded the cluster's request-forwarding hop limit was silently reported as successful instead of surfacing the failure, which could leave records prepared until lazy recovery.
+- Fixed a race condition where pausing a cluster node or the Transaction Coordinator could report success while the node remained unpaused. This could happen when an unpause or another pause request was issued concurrently, and also when a pause that waits for outstanding requests timed out after an earlier pause had already succeeded.
+- Upgraded the Jackson and Netty libraries to fix security issues: [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9)
+- Upgraded the Bouncy Castle library and the grpc_health_probe binary to fix security issues: [CVE-2025-14813](https://github.com/advisories/GHSA-574f-3g2m-x479), [CVE-2026-5598](https://github.com/advisories/GHSA-p93r-85wp-75v3), [CVE-2026-25681](https://github.com/advisories/GHSA-w9p8-pvxh-rxpj), [CVE-2026-27136](https://github.com/advisories/GHSA-m9x8-m34x-fj9q), [CVE-2026-27145](https://github.com/advisories/GHSA-4279-q6mj-392r), [CVE-2026-33811](https://github.com/advisories/GHSA-497x-jcxf-m478), CVE-2026-33814, [CVE-2026-39820](https://github.com/advisories/GHSA-p9h5-jm8x-mjm5), [CVE-2026-39821](https://github.com/advisories/GHSA-w2q5-6q6x-x959), [CVE-2026-39822](https://github.com/advisories/GHSA-xcgv-8mv7-v8c7), [CVE-2026-39836](https://github.com/advisories/GHSA-8g2r-hhvj-mv99), [CVE-2026-42499](https://github.com/advisories/GHSA-xq5j-9r39-c3vf), and [CVE-2026-42504](https://github.com/advisories/GHSA-h524-452v-82p9)
+
+##### ScalarDB SQL
+
+- Fixed an issue where `CachedMetadata#invalidateNamespaceNamesCache()` did not actually invalidate the cached list of namespaces, causing `SHOW NAMESPACES` and related operations to potentially return stale results until the cache TTL expired.
+
 ## v3.15.8
 
 **Release date:** April 15, 2026

--- a/versioned_docs/version-3.16/releases/release-notes.mdx
+++ b/versioned_docs/version-3.16/releases/release-notes.mdx
@@ -10,6 +10,51 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.16.
 
+## v3.16.6
+
+**Release date:** August 2, 2026
+
+### Summary
+
+This release updates the deprecation policy, improves `repairTable` behavior, fixes Consensus Commit, Cluster rollback/pause, and SQL metadata cache issues, and upgrades several dependencies to address security vulnerabilities across the Community and Enterprise editions.
+
+### Community edition
+
+#### Improvements
+
+- Changed the deprecation policy so that APIs and configurations marked as deprecated will now be removed in 4.0.0 instead of 5.0.0. ([#3520](https://github.com/scalar-labs/scalardb/pull/3520))
+- Improved `repairTable` to skip rewriting a table's metadata when it is already up to date (and, for Cosmos DB, to skip updating the container indexing policy when it already matches), avoiding unnecessary writes. ([#3613](https://github.com/scalar-labs/scalardb/pull/3613))
+
+#### Bug fixes
+
+- Fixed an issue in Consensus Commit where a `Get` operation using a secondary index could fail with an `IllegalArgumentException` when another record with the same indexed value was concurrently being deleted and inserted. ([#3607](https://github.com/scalar-labs/scalardb/pull/3607))
+- Fixed an issue in Consensus Commit where a read-only transaction could fail when coordinator write omission on read-only was disabled and coordinator group commit was enabled. ([#3614](https://github.com/scalar-labs/scalardb/pull/3614))
+- Fixed a bug where aborting an in-flight, group-committed transaction by ID via `DistributedTransactionManager.rollback(String)` / `abort(String)` could be lost when the Coordinator group commit feature was enabled. ([#3619](https://github.com/scalar-labs/scalardb/pull/3619))
+- Fixed an issue in the Consensus Commit transaction manager where a read could return a stale (pre-commit) value for a record whose writing transaction committed concurrently during lazy recovery. ([#3621](https://github.com/scalar-labs/scalardb/pull/3621))
+- Upgraded the Jackson, Netty, Azure Cosmos DB, and Azure Blob Storage libraries to fix security issues: [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9) ([#3754](https://github.com/scalar-labs/scalardb/pull/3754))
+- Upgraded the PostgreSQL JDBC driver and the Netty library to fix security issues: [CVE-2026-42198](https://github.com/advisories/GHSA-98qh-xjc8-98pq), [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), and [CVE-2026-54291](https://github.com/advisories/GHSA-j92g-9f8w-j867) ([#3760](https://github.com/scalar-labs/scalardb/pull/3760))
+
+### Enterprise edition
+
+#### Improvements
+
+##### ScalarDB Cluster
+
+- Changed the deprecation policy so that APIs marked as deprecated will now be removed in 4.0.0 instead of 5.0.0.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Fixed a bug where a `rollback` that exceeded the cluster's request-forwarding hop limit was silently reported as successful instead of surfacing the failure, which could leave records prepared until lazy recovery.
+- Fixed a race condition where pausing a cluster node or the Transaction Coordinator could report success while the node remained unpaused. This could happen when an unpause or another pause request was issued concurrently, and also when a pause that waits for outstanding requests timed out after an earlier pause had already succeeded.
+- Upgraded the Jackson and Netty libraries to fix security issues: [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9)
+- Upgraded the Bouncy Castle library and the grpc_health_probe binary to fix security issues: [CVE-2025-14813](https://github.com/advisories/GHSA-574f-3g2m-x479), [CVE-2026-5598](https://github.com/advisories/GHSA-p93r-85wp-75v3), [CVE-2026-25681](https://github.com/advisories/GHSA-w9p8-pvxh-rxpj), [CVE-2026-27136](https://github.com/advisories/GHSA-m9x8-m34x-fj9q), [CVE-2026-27145](https://github.com/advisories/GHSA-4279-q6mj-392r), [CVE-2026-33811](https://github.com/advisories/GHSA-497x-jcxf-m478), CVE-2026-33814, [CVE-2026-39820](https://github.com/advisories/GHSA-p9h5-jm8x-mjm5), [CVE-2026-39821](https://github.com/advisories/GHSA-w2q5-6q6x-x959), [CVE-2026-39822](https://github.com/advisories/GHSA-xcgv-8mv7-v8c7), [CVE-2026-39836](https://github.com/advisories/GHSA-8g2r-hhvj-mv99), [CVE-2026-42499](https://github.com/advisories/GHSA-xq5j-9r39-c3vf), and [CVE-2026-42504](https://github.com/advisories/GHSA-h524-452v-82p9)
+
+##### ScalarDB SQL
+
+- Fixed an issue where `CachedMetadata#invalidateNamespaceNamesCache()` did not actually invalidate the cached list of namespaces, causing `SHOW NAMESPACES` and related operations to potentially return stale results until the cache TTL expired.
+
 ## v3.16.5
 
 **Release date:** April 15, 2026

--- a/versioned_docs/version-3.17/releases/release-notes.mdx
+++ b/versioned_docs/version-3.17/releases/release-notes.mdx
@@ -10,6 +10,51 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDB 3.17.
 
+## v3.17.4
+
+**Release date:** August 2, 2026
+
+### Summary
+
+This release updates the deprecation policy, improves `repairTable` behavior, fixes several Consensus Commit, Cluster rollback/pause, and SQL metadata cache issues, and upgrades multiple dependencies to address security vulnerabilities across the Community and Enterprise editions.
+
+### Community edition
+
+#### Improvements
+
+- Changed the deprecation policy so that APIs and configurations marked as deprecated will now be removed in 4.0.0 instead of 5.0.0. ([#3520](https://github.com/scalar-labs/scalardb/pull/3520))
+- Improved `repairTable` to skip rewriting a table's metadata when it is already up to date (and, for Cosmos DB, to skip updating the container indexing policy when it already matches), avoiding unnecessary writes. ([#3613](https://github.com/scalar-labs/scalardb/pull/3613))
+
+#### Bug fixes
+
+- Fixed an issue in Consensus Commit where a `Get` operation using a secondary index could fail with an `IllegalArgumentException` when another record with the same indexed value was concurrently being deleted and inserted. ([#3607](https://github.com/scalar-labs/scalardb/pull/3607))
+- Fixed an issue in Consensus Commit where a read-only transaction could fail when coordinator write omission on read-only was disabled and coordinator group commit was enabled. ([#3614](https://github.com/scalar-labs/scalardb/pull/3614))
+- Fixed a bug where aborting an in-flight, group-committed transaction by ID via `DistributedTransactionManager.rollback(String)` / `abort(String)` could be lost when the Coordinator group commit feature was enabled. ([#3619](https://github.com/scalar-labs/scalardb/pull/3619))
+- Fixed an issue in the Consensus Commit transaction manager where a read could return a stale (pre-commit) value for a record whose writing transaction committed concurrently during lazy recovery. ([#3621](https://github.com/scalar-labs/scalardb/pull/3621))
+- Upgraded the Jackson, Netty, Azure Cosmos DB, and Azure Blob Storage libraries to fix security issues: [CVE-2026-42579](https://github.com/advisories/GHSA-cm33-6792-r9fm), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-45674](https://github.com/advisories/GHSA-676x-f7gg-47vc), [CVE-2026-47691](https://github.com/advisories/GHSA-5pvg-856g-cp85), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9) ([#3754](https://github.com/scalar-labs/scalardb/pull/3754))
+- Upgraded the PostgreSQL JDBC driver to fix security issues: [CVE-2026-42198](https://github.com/advisories/GHSA-98qh-xjc8-98pq) and [CVE-2026-54291](https://github.com/advisories/GHSA-j92g-9f8w-j867) ([#3759](https://github.com/scalar-labs/scalardb/pull/3759))
+
+### Enterprise edition
+
+#### Improvements
+
+##### ScalarDB Cluster
+
+- Changed the deprecation policy so that APIs marked as deprecated will now be removed in 4.0.0 instead of 5.0.0.
+
+#### Bug fixes
+
+##### ScalarDB Cluster
+
+- Fixed a bug where a `rollback` that exceeded the cluster's request-forwarding hop limit was silently reported as successful instead of surfacing the failure, which could leave records prepared until lazy recovery.
+- Fixed a race condition where pausing a cluster node or the Transaction Coordinator could report success while the node remained unpaused. This could happen when an unpause or another pause request was issued concurrently, and also when a pause that waits for outstanding requests timed out after an earlier pause had already succeeded.
+- Upgraded the Jackson, Netty, and LangChain4j libraries to fix security issues: [CVE-2026-40682](https://github.com/advisories/GHSA-4v8g-86x5-3vrc), [CVE-2026-42027](https://github.com/advisories/GHSA-cx4m-2p55-rw7j), [CVE-2026-42440](https://github.com/advisories/GHSA-659w-93r5-9j6m), [CVE-2026-42583](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6), [CVE-2026-42584](https://github.com/advisories/GHSA-57rv-r2g8-2cj3), [CVE-2026-42587](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv), [CVE-2026-44249](https://github.com/advisories/GHSA-3qp7-7mw8-wx86), [CVE-2026-45416](https://github.com/advisories/GHSA-x4gw-5cx5-pgmh), [CVE-2026-50010](https://github.com/advisories/GHSA-c653-97m9-rcg9), [CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://github.com/advisories/GHSA-rmj7-2vxq-3g9f), [CVE-2026-55405](https://github.com/advisories/GHSA-2mfg-cc43-9pcj), [CVE-2026-55831](https://github.com/advisories/GHSA-6jqx-86gh-f27w), [CVE-2026-55833](https://github.com/advisories/GHSA-mvh2-crg5-v77c), [CVE-2026-56745](https://github.com/advisories/GHSA-jppx-w49h-x2qq), [CVE-2026-59901](https://github.com/advisories/GHSA-558v-64gr-wgg4), and [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9)
+- Upgraded the Bouncy Castle library and the grpc_health_probe binary to fix security issues: [CVE-2025-14813](https://github.com/advisories/GHSA-574f-3g2m-x479), [CVE-2026-5598](https://github.com/advisories/GHSA-p93r-85wp-75v3), [CVE-2026-25681](https://github.com/advisories/GHSA-w9p8-pvxh-rxpj), [CVE-2026-27136](https://github.com/advisories/GHSA-m9x8-m34x-fj9q), [CVE-2026-27145](https://github.com/advisories/GHSA-4279-q6mj-392r), [CVE-2026-33811](https://github.com/advisories/GHSA-497x-jcxf-m478), CVE-2026-33814, [CVE-2026-39820](https://github.com/advisories/GHSA-p9h5-jm8x-mjm5), [CVE-2026-39821](https://github.com/advisories/GHSA-w2q5-6q6x-x959), [CVE-2026-39822](https://github.com/advisories/GHSA-xcgv-8mv7-v8c7), [CVE-2026-39836](https://github.com/advisories/GHSA-8g2r-hhvj-mv99), [CVE-2026-42499](https://github.com/advisories/GHSA-xq5j-9r39-c3vf), and [CVE-2026-42504](https://github.com/advisories/GHSA-h524-452v-82p9)
+
+##### ScalarDB SQL
+
+- Fixed an issue where `CachedMetadata#invalidateNamespaceNamesCache()` did not actually invalidate the cached list of namespaces, causing `SHOW NAMESPACES` and related operations to potentially return stale results until the cache TTL expired.
+
 ## v3.17.3
 
 **Release date:** April 15, 2026


### PR DESCRIPTION
## Description

This PR adds patch version release notes for ScalarDB 3.18, 3.17, 3.16, and 3.15.

## Related issues and/or PRs

N/A

## Changes made

- Added patch version release notes for the following versions:
  - 3.17.3
  - 3.16.5
  - 3.15.8
- Updated patch versions for the `className` configurations in the Docusaurus configuration file.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
	- [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
	- [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A