### PR TITLE
Remove ScalarDB 3.18 blog post links in announcement bar and notifications

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -510,7 +510,8 @@ const config = {
       announcementBar: {
         id: 'new_version',
         content:
-          'Announcing the release of ScalarDB 3.19!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a> and <a target="_blank" href="https://medium.com/scalar-engineering/scalardb-3-18-has-been-released-e85b7f536cc7?utm_source=docs-site&utm_medium=announcementbar">blog post</a>.',
+          'Announcing the release of ScalarDB 3.19!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a>.',
+          // and <a target="_blank" href="XXX?utm_source=docs-site&utm_medium=announcementbar">blog post</a>.',
         backgroundColor: '#2673BB',
         textColor: '#FFFFFF',
         isCloseable: false,

--- a/src/data/notifications.js
+++ b/src/data/notifications.js
@@ -12,17 +12,17 @@ const notificationsList = [
   //   },
   //   unread: true
   // },
-  {
-    message: {
-      en: 'Blog post: ScalarDB 3.18 has been released!',
-      ja: 'ブログ記事: ScalarDB 3.18 をリリースしました！'
-    },
-    url: {
-      en: 'https://medium.com/scalar-engineering/scalardb-3-18-has-been-released-e85b7f536cc7?utm_source=docs-site&utm_medium=notifications',
-      ja: 'https://medium.com/scalar-engineering-ja/scalardb-3-18-%E3%82%92%E3%83%AA%E3%83%AA%E3%83%BC%E3%82%B9%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F-3bd653f87137?utm_source=docs-site&utm_medium=notifications'
-    },
-    unread: true
-  },
+  // {
+  //   message: {
+  //     en: 'Blog post: ScalarDB 3.19 has been released!',
+  //     ja: 'ブログ記事: ScalarDB 3.19 をリリースしました！'
+  //   },
+  //   url: {
+  //     en: 'XXX?utm_source=docs-site&utm_medium=notifications',
+  //     ja: 'XXX?utm_source=docs-site&utm_medium=notifications'
+  //   },
+  //   unread: true
+  // },
   {
     message: {
       en: 'Control user access via OIDC-based JWT access tokens',


### PR DESCRIPTION
## Description

This PR removes the link to the ScalarDB 3.18 blog post since ScalarDB 3.19 has been released.

## Related issues and/or PRs

Forgot to remove these mentions when adding 3.19 docs in #2435.

## Changes made

- Commented out the text in the announcement bar and in the notifications dropdown about the new release blog post since we don't have one yet for ScalarDB 3.19.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
  - [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
  - [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A