### PR TITLE
Add ScalarDB Analytics 3.19.0 release notes; add missing backward-incompatible release notes in Japanese to prior versions

### DIFF
--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -79,3 +79,29 @@ This release adds Consensus Commit recovery capabilities, including write-set lo
 ##### ScalarDB SQL
 
 - Fixed a statement cache regression where non-parameterized DML statements occupied cache slots intended for parameterized SQL. Cache eligibility is now correctly gated on the presence of bind markers in the parsed SQL.
+
+### Enterprise Options
+
+#### ScalarDB Analytics
+
+:::warning Backward-incompatible changes
+
+- Redesigned `user` / `internal-backend` / `role` / `permission` CLI commands: `user register` is replaced by `user create` + `user link` and `user unregister` by `user delete` + `user unlink` (+ `internal-backend create`), `--username` is split into `--user` / `--backend-user`, passwords are accepted only via `--password` / `--password-stdin`, and `data-source delete` is renamed to `data-source unregister`.
+
+:::
+
+##### Enhancements
+
+- Unified error code system (`DB-ANALYTICS-NNNNN`): server-side and SDK errors are reported as a single `AnalyticsException` carrying a machine-readable error code and structured metadata, propagated over gRPC as structured `AnalyticsError` details.
+- Filter push down, column pruning, and limit push down for the ScalarDB Spark data source, reducing data transfer for selective queries.
+- Configure authentication credentials via environment variables (`SCALAR_DB_ANALYTICS_CLIENT_AUTH_USERNAME` / `SCALAR_DB_ANALYTICS_CLIENT_AUTH_PASSWORD`) in the Spark connector.
+
+##### Improvements
+
+- Display clean error messages instead of raw stack traces for catalog errors in the spark-sql CLI.
+- Removed the internal `tenantId` field from Catalog JSON output in CLI commands.
+- Upgraded Spring Boot from 3.5.x to 4.0.4.
+
+##### Bug fixes
+
+- Fixed a `NullPointerException` in the metering server when reporting an execution that contains no jobs, or a job that contains no stages.

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -83,3 +83,29 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 ##### ScalarDB SQL
 
 - パラメーター化された SQL 用のキャッシュスロットを非パラメーター化 DML ステートメントが占有するステートメントキャッシュの不具合を修正しました。キャッシュ適格性は、解析された SQL 内のバインドマーカーの存在に基づいて正しく制御されるようになりました。
+
+### Enterprise Options
+
+#### ScalarDB Analytics
+
+:::warning 破壊的変更
+
+- `user` / `internal-backend` / `role` / `permission` CLI コマンドを再設計しました：`user register` は `user create` + `user link` に置き換わり、`user unregister` は `user delete` + `user unlink` (+ `internal-backend create`) に置き換わります。`--username` は `--user` / `--backend-user` に分割され、パスワードは `--password` / `--password-stdin` でのみ受け入れられるようになり、`data-source delete` は `data-source unregister` に名前変更されました。
+
+:::
+
+##### 機能強化
+
+- 統一されたエラーコードシステム (`DB-ANALYTICS-NNNNN`)：サーバー側と SDK エラーは、機械可読なエラーコードと構造化メタデータを含む単一の `AnalyticsException` として報告され、gRPC 上で構造化 `AnalyticsError` の詳細として伝播されます。
+- ScalarDB Spark データソースのフィルタプッシュダウン、列削除、リミットプッシュダウンにより、選択的クエリのデータ転送を削減します。
+- Spark コネクタで環境変数 (`SCALAR_DB_ANALYTICS_CLIENT_AUTH_USERNAME` / `SCALAR_DB_ANALYTICS_CLIENT_AUTH_PASSWORD`) を使用して認証認証情報を設定できるようになりました。
+
+##### 改善点
+
+- spark-sql CLI のカタログエラーについて、生のスタックトレースの代わりにクリーンなエラーメッセージを表示するようになりました。
+- CLI コマンドの Catalog JSON 出力から内部 `tenantId` フィールドを削除しました。
+- Spring Boot を 3.5.x から 4.0.4 にアップグレードしました。
+
+##### バグの修正
+
+- ジョブを含まない実行またはステージを含まないジョブを報告する際のメータリングサーバーの `NullPointerException` を修正しました。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.15/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.15/releases/release-notes.mdx
@@ -42,6 +42,12 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このリリースには、いくつかの改善点とバグ修正が含まれています。
 
+:::warning 破壊的変更
+
+- **MySQL Connector/J が MariaDB Connector/J に置き換わりました。** SSL はデフォルトで有効になりません。MySQL 8.0 以降に `caching_sha2_password` 認証で接続する場合は、JDBC URL に `sslMode=REQUIRED` または `allowPublicKeyRetrieval=true` を追加してください。`jdbc:mysql://` URL の場合、ScalarDB が互換性のために自動的に `permitMysqlScheme` を付加するため、アクションは不要です。
+
+:::
+
 ### Community edition
 
 #### 改善点

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.16/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.16/releases/release-notes.mdx
@@ -67,6 +67,13 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このリリースには、いくつかの改善点とバグ修正が含まれています。
 
+:::warning 破壊的変更
+
+- **既存のテーブルは新しい before-image セカンダリインデックスを作成するために `repairTable()` が必要です。** Consensus Commit でのインデックスベースの `Get`、`Scan`、および `ScanAll` は、コンパニオン `before_<col>` インデックスに依存するようになりました。既存のテーブルそれぞれで `repairTable()` を実行するまで、ScalarDB はスタートアップ時に警告をログに記録し、インデックスベースの読み取りは前の動作にフォールバックします。これにより、インデックス付き列が同時に更新されているレコードを見逃す可能性があります。設定 `scalar.db.consensus_commit.index.eventually_consistent_read.enabled` はオプトアウトとして提供されていますが、新しいワークロードには推奨されません。
+- **MySQL Connector/J が MariaDB Connector/J に置き換わりました。** SSL はデフォルトで有効になりません。MySQL 8.0 以降に `caching_sha2_password` 認証で接続する場合は、JDBC URL に `sslMode=REQUIRED` または `allowPublicKeyRetrieval=true` を追加してください。`jdbc:mysql://` URL の場合、ScalarDB が互換性のために自動的に `permitMysqlScheme` を付加するため、アクションは不要です。
+
+:::
+
 ### Community edition
 
 #### 改善点
@@ -170,6 +177,12 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 ### まとめ
 
 このリリースには、いくつかのバグ修正および脆弱性修正が含まれています。
+
+:::warning 破壊的変更
+
+- **SERIALIZABLE 分離レベルでセカンダリインデックスを使用した `Get` および `Scan` 操作は、 `IllegalArgumentException` をスロー**するようになりました。これらの操作は SERIALIZABLE が要求する厳密な一貫性を保証できないためです。インデックスベースの読み取りの SERIALIZABLE サポートを復元するには、3.16.5以降にアップグレードしてください。このバージョンでは、コンパニオンの before-image セカンダリインデックスを介して機能が復元されます。または、非 SERIALIZABLE な分離レベルに切り替え (読み取りは結果整合性になり、わずかに古いデータを返す可能性があります) るか、プライマリキーを使用する操作に書き直してください。
+
+:::
 
 ### Community edition
 

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.17/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.17/releases/release-notes.mdx
@@ -67,6 +67,13 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このリリースには、いくつかの改善点とバグ修正が含まれています。
 
+:::warning 破壊的変更
+
+- **既存のテーブルは、新しい before-image セカンダリインデックスを作成するために `repairTable()` が必要です。** Consensus Commit のインデックスベースの `Get`、`Scan`、`ScanAll` 操作は、コンパニオンの `before_<col>` インデックスに依存するようになりました。既存のテーブルそれぞれで `repairTable()` を実行するまで、ScalarDB はスタートアップ時に警告をログに出力し、インデックスベースの読み取りは以前の動作にフォールバックします。これにより、インデックス列が同時に更新されているレコードを見落とす可能性があります。設定 `scalar.db.consensus_commit.index.eventually_consistent_read.enabled` はオプトアウト用に提供されていますが、新しいワークロードにはお勧めしません。
+- **MySQL Connector/J が MariaDB Connector/J に置き換わりました。** SSL はデフォルトで有効になりません。MySQL 8.0 以降に `caching_sha2_password` 認証で接続する場合は、JDBC URL に `sslMode=REQUIRED` または `allowPublicKeyRetrieval=true` を追加してください。`jdbc:mysql://` URL の場合、ScalarDB が互換性のために自動的に `permitMysqlScheme` を追加するため、操作は不要です。
+
+:::
+
 ### Community edition
 
 #### 改善点
@@ -206,6 +213,12 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 ### まとめ
 
 このリリースには、多くの機能強化、改善、セキュリティ問題の修正、およびバグ修正が含まれています。
+
+:::warning 破壊的変更
+
+- **SERIALIZABLE 分離レベルでセカンダリインデックスを使用した `Get` および `Scan` 操作は、`IllegalArgumentException` をスロー**するようになりました。これらの操作は SERIALIZABLE が要求する厳密な一貫性を保証できないためです。インデックスベースの読み取りの SERIALIZABLE サポートを復元するには、3.17.3以降にアップグレードしてください。このバージョンでは、コンパニオンの before-image セカンダリインデックスを介して機能が復元されます。または、非 SERIALIZABLE な分離レベルに切り替え (読み取りは結果整合性になり、わずかに古いデータを返す可能性があります) るか、プライマリキーを使用する操作に書き直してください。
+
+:::
 
 ### Community edition
 

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.18/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.18/releases/release-notes.mdx
@@ -77,6 +77,23 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このリリースには、多くの改善点、セキュリティ問題の修正、およびバグ修正が含まれています。
 
+:::warning 破壊的変更
+
+- **JDBC コネクションプールが Apache Commons DBCP2 から HikariCP に移行しました:**
+  - 次の設定プロパティはサポートされなくなりました。設定されている場合は警告がログに記録されて無視されます:
+    - `scalar.db.jdbc.connection_pool.max_idle`
+    - `scalar.db.jdbc.table_metadata.connection_pool.max_idle`
+    - `scalar.db.jdbc.admin.connection_pool.max_idle`
+    - `scalar.db.jdbc.prepared_statements_pool.enabled`
+    - `scalar.db.jdbc.prepared_statements_pool.max_open`
+  - プリペアドステートメントプーリングは HikariCP には同等の機能がないため、利用できなくなりました。
+  - コネクションプールのデフォルト動作は DBCP2 ではなく HikariCP に従います。これにより、設定変更がなくても実行時の動作が変わる可能性があります (例: コネクション取得タイムアウトとアイドルエビクション)。
+- **既存のテーブルは、新しい before-image セカンダリインデックスを作成するために `repairTable()` が必要です。** Consensus Commit のインデックスベースの `Get`、`Scan`、`ScanAll` 操作は、コンパニオンの `before_<col>` インデックスに依存するようになりました。既存のテーブルそれぞれで `repairTable()` を実行するまで、ScalarDB はスタートアップ時に警告をログに出力し、インデックスベースの読み取りは以前の動作にフォールバックします。これにより、インデックス列が同時に更新されているレコードを見落とす可能性があります。設定 `scalar.db.consensus_commit.index.eventually_consistent_read.enabled` はオプトアウト用に提供されていますが、新しいワークロードにはお勧めしません。
+- **MySQL Connector/J が MariaDB Connector/J に置き換わりました。** SSL はデフォルトで有効になりません。MySQL 8.0 以降に `caching_sha2_password` 認証で接続する場合は、JDBC URL に `sslMode=REQUIRED` または `allowPublicKeyRetrieval=true` を追加してください。`jdbc:mysql://` URL の場合、ScalarDB が互換性のために自動的に `permitMysqlScheme` を追加するため、操作は不要です。
+- **`BigIntColumn.MAX_VALUE` および `BigIntColumn.MIN_VALUE` 定数が削除されました。** これらを参照していたコードは、代わりに `Long.MAX_VALUE` および `Long.MIN_VALUE` を使用する必要があります。
+
+:::
+
 ### Community edition
 
 #### 機能強化


### PR DESCRIPTION
## Description

This PR adds ScalarDB Analytics 3.19 release notes and missing ScalarDB backward-incompatible changes in both English and Japanese.

## Related issues and/or PRs

N/A

## Changes made

- Added ScalarDB Analytics 3.19 release notes in both English and Japanese.
- Added missing ScalarDB backward-incompatible changes to the 3.18, 3.17, 3.16, and 3.15 release notes in Japanese.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
  - [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
  - [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A